### PR TITLE
Add MAX78 family to build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,3 +18,4 @@
 
 
 add_subdirectory_ifdef(CONFIG_SOC_FAMILY_MAX32 MAX)
+add_subdirectory_ifdef(CONFIG_SOC_FAMILY_MAX78 MAX)


### PR DESCRIPTION
Include MAX file as a sub directory for MAX78 SoC family.