### PR TITLE
fix(CMSIS): Manually add .svd that were excluded in error

### DIFF
--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32520/Include/max32520.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32520/Include/max32520.svd
@@ -1,0 +1,9650 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max32520</name>
+ <series>ARMCM4</series>
+ <version>1.0</version>
+ <description>MAX32520 32-bit ARM Cortex-M4 microcontroller, 1024KB of flash, 760KB of system RAM, 128KB of Boot ROM.</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>AESKEYS</name>
+   <description>AES Keys.</description>
+   <baseAddress>0x40005000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SRAM_KEY</name>
+     <description>AES SRAM KEY</description>
+     <addressOffset>0x000</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CODE_KEY</name>
+     <description>AES CODE Key </description>
+     <addressOffset>0x080</addressOffset>
+    </register>
+    <register>
+     <name>DATA_KEY</name>
+     <description>AES DATA KEY</description>
+     <addressOffset>0x100</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--AESKEYS AES Keys.-->
+  <peripheral>
+   <name>CTB</name>
+   <description>The Cryptographic Toolbox is a combination of cryptographic engines and a secure cryptographic accelerator (SCA) used to provide advanced cryptographic security.</description>
+   <baseAddress>0x40001000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Crypto_Engine</name>
+    <description>Crypto Engine interrupt.</description>
+    <value>27</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CRYPTO_CTRL</name>
+     <description>Crypto Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0xC0000000</resetValue>
+     <fields>
+      <field>
+       <name>RST</name>
+       <description>Reset. This bit is used to reset the crypto accelerator.  All crypto internal states and related registers are reset to their default reset values. Control register such as CRYPTO_CTRL, CIPHER_CTRL, HASH_CTRL, CRC_CTRL, MAA_CTRL (with the exception of the STC bit), HASH_MSG_SZ_[3:0] and MAA_MAWS will retain their values. This bit will automatically clear itself after one cycle.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INT</name>
+       <description>Interrupt Enable. Generates an interrupt when done or error set.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRC</name>
+       <description>Source Select.  This bit selects the hash function and CRC generator input source.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inputFIFO</name>
+         <description>Input FIFO</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputFIFO</name>
+         <description>Output FIFO</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BSO</name>
+       <description>Byte Swap Output. Note. No byte swap will occur if there is not a full word.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BSI</name>
+       <description>Byte Swap Input. Note. No byte swap will occur if there is not a full word.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WAIT_EN</name>
+       <description>Wait Pin Enable. This can be used to hold off the crypto DMA until an external memory is ready. This is useful for transferring pages from NAND flash which may take several microseconds to become ready.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WAIT_POL</name>
+       <description>Wait Pin Polarity. When the wait pin is enabled, this bit selects its active state.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRSRC</name>
+       <description>Write FIFO Source Select. This field determines where data written to the write FIFO comes from. When data is written to the write FIFO, it is always written out the DMA. To decrypt or encrypt data, the write FIFO source should be set to the cipher output. To implement memcpy() or memset() functions, or to fill memory with random data, the write FIFO source should be set to the read FIFO. When calculating a HASH or CMAC, the write FIFO should be disabled.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>none</name>
+         <description>None.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cipherOutput</name>
+         <description>Cipher Output.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>readFIFO</name>
+         <description>Read FIFO.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDSRC</name>
+       <description>Read FIFO Source Select. This field selects the source of the read FIFO. Typically, it is set to use the DMA. To implement a memset() function, the read FIFO DMA should be disabled. To fill memory with random data or to hash random numbers, the read FIFO source should be set to the random number generator.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dmaDisabled</name>
+         <description>DMA Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dmaOrApb</name>
+         <description>DMA Or APB.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rng</name>
+         <description>RNG.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLAG_MODE</name>
+       <description>Done Flag Mode. This bit configures the access behavior of the individual CRYPTO_CTRL Done flags (CRYPTO_CTRL[27:24]). This bit is cleared only on reset to limit upkeep, i.e. once set, it will remain set until a reset occurs.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unres_wr</name>
+         <description>Unrestricted write (0 or 1) of CRYPTO_CTRL[27:24] flags.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>res_wr</name>
+         <description>Access to CRYPTO_CTRL[27:24] are write 1 to clear/write 0 no effect.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMADNEMSK</name>
+       <description>DMA Done Flag Mask. This bit masks the DMA_DONE flag from being used to generate the CRYPTO_CTRL.DONE flag, and this disables a DMA_DONE condition from generating and interrupt. The DMA_DONE flag itself is unaffected and still may be monitored. This allows more optimal interrupt-driven crypto operations using DMA.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_used</name>
+         <description>DMA_DONE not used in setting CRYPTO_CTRL.DONE bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>used</name>
+         <description>DMA_DONE used in setting CRYPTO_CTRL.DONE bit.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMA_DONE</name>
+       <description>DMA Done. DMA write/read operation is complete. This bit must be cleared before starting a DMA operation.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notDone</name>
+         <description>Not Done.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>done</name>
+         <description>Done.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>GLS_DONE</name>
+       <description>Galois Done. FIFO is full and CRC or Hamming Code Generator is enabled. This bit must be cleared before starting a CRC operation Note that DMA_DONE must be polled instead of this bit to determine the end of DMA operation during the utilization of Hamming Code Generator.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>HSH_DONE</name>
+       <description>Hash Done. SHA operation is complete. This bit must be cleared before starting a HASH operation.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>CPH_DONE</name>
+       <description>Cipher Done. Either AES or DES encryption/decryption operation is complete. This bit must be cleared before starting a cipher operation.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERR</name>
+       <description>AHB Bus Error. This bit is set when the DMA encounters a bus error during a read or write operation. Once this bit is set, the DMA will stop. This bit can only be cleared by resetting the crypto block.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Ready. Crypto block ready for more data.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>DONE</name>
+       <description>Done. One or more cryptographic calculations complete (logical OR of done flags).</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CIPHER_CTRL</name>
+     <description>Cipher Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ENC</name>
+       <description>Encrypt. Select encryption or decryption of input data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>encrypt</name>
+         <description>Encrypt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>decrypt</name>
+         <description>Decrypt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEY</name>
+       <description>Load Key from crypto DMA. This bit is automatically cleared by hardware after the DMA has completed loading the key. When the DMA operation is done, it sets the appropriate crypto DMA Done flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRC</name>
+       <description>Source of Random key.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>cipherKey</name>
+         <description>User cipher key (0x4000_1060).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>regFile</name>
+         <description>Key from battery-backed register file (0x4000_5000 to 0x4000_501F).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>qspiKey_regFile</name>
+         <description>Key from battery-backed register file (0x4000_5020 to 0x4000_502F).</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CIPHER</name>
+       <description>Cipher Operation Select.  Symmetric Block Cipher algorithm selection or memory operation.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes128</name>
+         <description>AES 128.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes192</name>
+         <description>AES 192.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes256</name>
+         <description>AES 256.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>des</name>
+         <description>DES.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>tdes</name>
+         <description>Triple DES.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description>Mode Select. Mode of operation for block cipher or memory operation. DES/TDES cannot be used in CFB, OFB or CTR modes.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ECB</name>
+         <description>ECB Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CBC</name>
+         <description>CBC Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CFB</name>
+         <description>CFB (AES only).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>OFB</name>
+         <description>OFB (AES only).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CTR</name>
+         <description>CTR (AES only).</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>COMPH</name>
+       <description>H Vector Computation.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DTYPE</name>
+       <description>GCM/CCM data type.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CCMM</name>
+       <description>CCM M Parameter.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CCML</name>
+       <description>CCM L Parameter.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HASH_CTRL</name>
+     <description>HASH Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>INIT</name>
+       <description>Initialize. Initializes hash registers with standard constants.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>XOR</name>
+       <description>XOR data with IV from cipher block. Useful when calculating HMAC to XOR the input pad and output pad.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HASH</name>
+       <description>Hash function selection.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha1</name>
+         <description>SHA-1.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha224</name>
+         <description>SHA 224.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha256</name>
+         <description>SHA 256.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha384</name>
+         <description>SHA 384.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha512</name>
+         <description>SHA 512.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LAST</name>
+       <description>Last Message Bit. This bit shall be set along with the HASH_MSG_SZ register prior to hashing the last 512 or 1024-bit block of the message data. It will allow automatic preprocessing of the last message padding, which includes the trailing bit 1, followed by the respective number of zero bits for the last block size and finally the message length represented in bytes. The bit will be automatically cleared at the same time the HASH DONE is set, designating the completion of the last message hash.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEffect</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>lastMsgData</name>
+         <description>Last Message Data.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_CTRL</name>
+     <description>CRC Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>CRC</name>
+       <description>Cyclic Redundancy Check Enable. The CRC cannot be enabled if the PRNG is enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MSB</name>
+       <description>MSB select. This bit selects the order of calculating CRC on data.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lsbFirst</name>
+         <description>LSB First.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>msbFirst</name>
+         <description>MSB First.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CRC">
+       <name>PRNG</name>
+       <description>Pseudo Random Number Generator Enable. If entropy is disabled, this outputs one byte of pseudo random data per clock cycle. If entropy is enabled, data is output at a rate of one bit per clock cycle.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CRC">
+       <name>ENT</name>
+       <description>Entropy Enable. If the PRNG is enabled, this mixes the high frequency ring oscillator with the LFSR. If the PRNG is disabled, the raw entropy data is output at a rate of 1 bit per clock. This makes it possible to characterize the quality of the entropy source.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CRC">
+       <name>HAM</name>
+       <description>Hamming Code Enable. Enable hamming code calculation.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HRST</name>
+       <description>Hamming Reset. Reset Hamming code ECC generator for next block.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+       <enumeratedValues>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>Starts reset operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_SRC</name>
+     <description>Crypto DMA Source Address.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>DMA Source Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_DEST</name>
+     <description>Crypto DMA Destination Address.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>DMA Destination Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_CNT</name>
+     <description>Crypto DMA Byte Count.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>DMA Byte Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CRYPTO_DIN[%s]</name>
+     <description>Crypto Data Input. Data input can be written to this register instead of using the DMA. This register writes to the FIFO. This register occupies four successive words to allow the use of multi-store instructions. Words can be written to any location, they will be placed in the FIFO in the order they are written. The endian swap input control bit affects this register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Crypto Data Input. Input can be written to this register instead of using DMA.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CRYPTO_DOUT[%s]</name>
+     <description>Crypto Data Output. Resulting data from cipher calculation. Data is placed in the lower words of these four registers depending on the algorithm. For block cipher modes, this register holds the result of most recent encryption or decryption operation. These registers are affected by the endian swap bits.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Crypto Data Output. Resulting data from cipher calculation. Data is placed in the lower words of these four registers depending on algorithm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_POLY</name>
+     <description>CRC Polynomial. The polynomial to be used for Galois Field calculations (CRC or LFSR) should be written to this register. This register is affected by the MSB control bit.</description>
+     <addressOffset>0x40</addressOffset>
+     <resetValue>0xEDB88320</resetValue>
+     <fields>
+      <field>
+       <name>POLY</name>
+       <description>CRC Polynomial. The polynomial to be used for Galois Field calculations (CRC or LFSR) should be written to this register. This register is affected by the MSB control bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_VAL</name>
+     <description>CRC Value. This is the state for the Galois Field. This register holds the result of a CRC calculation or the current state of the LFSR. This register is affected by the MSB control bit.</description>
+     <addressOffset>0x44</addressOffset>
+     <resetValue>0xFFFFFFFF</resetValue>
+     <fields>
+      <field>
+       <name>VAL</name>
+       <description>CRC Value. This is the state for the Galois Field. This register holds the result of a CRC calculation or the current state of LFSR. This register is affected by the MSB control bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_PRNG</name>
+     <description>Pseudo-Random Number Generator. Output of the Galois Field shift register. This holds the resulting pseudo-random number if entropy is disabled or true random number if entropy is enabled.</description>
+     <addressOffset>0x48</addressOffset>
+     <resetValue>0</resetValue>
+     <fields>
+      <field>
+       <name>PRNG</name>
+       <description>Pseudo-Random Number Generator. Output of the Galois Field shift register. This holds the resulting pseudo-random number if entropy is disabled or true random number if entropy is enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HAM_ECC</name>
+     <description>Hamming ECC Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>ECC</name>
+       <description>Hamming ECC Value. These bits are the even parity of their corresponding bit groups.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PAR</name>
+       <description>Parity. This is the parity of the entire array.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>even</name>
+         <description>Even.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>odd</name>
+         <description>Odd.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CIPHER_INIT[%s]</name>
+     <description>Initial Vector. For block cipher operations that use CBC, CFB, OFB, or CNTR modes, this register holds the initial value. This register is updated with each encryption or decryption operation. This register is affected by the endian swap bits.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>IVEC</name>
+       <description>Initial Vector. For block cipher operations that use CBC, CFB, OFB, or CNTR modes, this register holds the initial value. This register is updated with each encryption or decryption operation. This register is affected by the endian swap bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CIPHER_KEY[%s]</name>
+     <description>Cipher Key.  This register holds the key used for block cipher operations. The lower words are used for block ciphers that use shorter key lengths. This register is affected by the endian swap input control bits.</description>
+     <addressOffset>0x60</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>KEY</name>
+       <description>Cipher Key. This register holds the key used for block cipher operations. The lower words are used for block ciphers that use shorter kye lengths. This register is affected by the endian swap input control bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>16</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>HASH_DIGEST[%s]</name>
+     <description>This register holds the calculated hash value. This register is affected by the endian swap bits.</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>HASH</name>
+       <description>This register holds the calculated hash value. This register is affected by the endian swap bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>HASH_MSG_SZ[%s]</name>
+     <description>Message Size. This register holds the lowest 32-bit of message size in bytes.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>MSGSZ</name>
+       <description>Message Size. This register holds the lowest 32-bit of message size in bytes.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>A_LENGTH_0</name>
+     <description>.AAD Length Register 0.</description>
+     <addressOffset>0xD0</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>A_LENGTH</name>
+       <description>AAD length in bytes for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>A_LENGTH_1</name>
+     <description>.AAD Length Register 1.</description>
+     <addressOffset>0xD4</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>A_LENGTH</name>
+       <description>AAD length in bytes for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PLD_LENGTH_0</name>
+     <description>.PLD Length Register 0.</description>
+     <addressOffset>0xD8</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>PLD_LENGTH</name>
+       <description>PLD length in bytes for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PLD_LENGTH_1</name>
+     <description>.LENGTH.</description>
+     <addressOffset>0xDC</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>PLD_LENGTH</name>
+       <description>PLD length in bytes for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>TAGMIC[%s]</name>
+     <description>TAG/MIC Registers.</description>
+     <addressOffset>0xE0</addressOffset>
+     <fields>
+      <field>
+       <name>TAGMIC</name>
+       <description>TAG/MIC output for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_CN</name>
+     <description>SCA Control 0 Register.</description>
+     <addressOffset>0x100</addressOffset>
+     <fields>
+      <field>
+       <name>STC</name>
+       <description>Start Calculation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCAIE</name>
+       <description>SCA Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Abort Operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERMEM</name>
+       <description>Erase Cryptographic Memory.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MANPARAM</name>
+       <description>ECC Parameter Source.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HWKEY</name>
+       <description>Hardware Key Select.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OPCODE</name>
+       <description>SCA Opcode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>MODADDR</name>
+       <description>MODULO Address Offset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>ECCSIZE</name>
+       <description>ECC Size.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_ACN</name>
+     <description>SCA Advanced Control Register.</description>
+     <addressOffset>0x104</addressOffset>
+     <fields>
+      <field>
+       <name>MAN</name>
+       <description>SCA Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>auto</name>
+         <description>Auto Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>manual</name>
+         <description>Manual Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTOCARRY</name>
+       <description>Automatically propagate the carry for the next operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PLUSONE</name>
+       <description>Enable Carry propagation for the next operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESSELECT</name>
+       <description>ALU Selection.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CARRYPOS</name>
+       <description>To set Carry location.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_ST</name>
+     <description>SCA Status Register.</description>
+     <addressOffset>0x108</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SCA Busy.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCAIF</name>
+       <description>SCA Interrupt Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PVF1</name>
+       <description>Point 1 Verification Failed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PVF2</name>
+       <description>Point 2 Verification Failed.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FSMERR</name>
+       <description>FSM Transition Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>COMPERR</name>
+       <description>EC Computation Error.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MEMERR</name>
+       <description>SCA Memory Access Error.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARRY</name>
+       <description>Carry on ongoing operation.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GTE2I2</name>
+       <description>Modulo 2x Result.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ALUNEG1</name>
+       <description>ALU 2 SubSign of the subtraction result for ALU_2.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ALUNEG2</name>
+       <description>ALU 2 SubSign of the subtraction result for ALU_2.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PPX_ADDR</name>
+     <description>PPX Coordinate Data Pointer Register.</description>
+     <addressOffset>0x10C</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>PPX_ADDR</name>
+       <description>Point P Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PPY_ADDR</name>
+     <description>PPY Coordinate Data Pointer Register.</description>
+     <addressOffset>0x110</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>PPY_ADDR</name>
+       <description>Point P Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PPZ_ADDR</name>
+     <description>PPZ Coordinate Data Pointer Register.</description>
+     <addressOffset>0x114</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>PPZ_ADDR</name>
+       <description>Point P Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PQX_ADDR</name>
+     <description>PQX Coordinate Data Pointer Register.</description>
+     <addressOffset>0x118</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>PQX_ADDR</name>
+       <description>Point Q Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PQY_ADDR</name>
+     <description>PQY Coordinate Data Pointer Register.</description>
+     <addressOffset>0x11C</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>PQY_ADDR</name>
+       <description>Point Q Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PQZ_ADDR</name>
+     <description>PQZ Coordinate Data Pointer Register.</description>
+     <addressOffset>0x120</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>PQZ_ADDR</name>
+       <description>Point Q Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_RDSA_ADDR</name>
+     <description>SCA RDSA Address Register.</description>
+     <addressOffset>0x124</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>RDSA_ADDR</name>
+       <description>The starting address of the R portion for R, S ECDSA signature.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_RES_ADDR</name>
+     <description>SCA Result Address Register.</description>
+     <addressOffset>0x128</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>RES_ADDR</name>
+       <description>Starting address of result storage.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_OP_BUFF_ADDR</name>
+     <description>SCA Operation Buffer Address Register.</description>
+     <addressOffset>0x12C</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>OPBUFF_ADDR</name>
+       <description>Starting address of operation buffer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_MODDATA</name>
+     <description>SCA Modulo Data Input Register.</description>
+     <addressOffset>0x130</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>MODDATA</name>
+       <description>Used to load the SCA modulo for modular operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CTB The Cryptographic Toolbox is a combination of cryptographic engines and a secure cryptographic accelerator (SCA) used to provide advanced cryptographic security.-->
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0</name>
+    <value>28</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1</name>
+    <value>29</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA2</name>
+    <value>30</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA3</name>
+    <value>31</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CN</name>
+     <description>DMA Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CHIEN</name>
+       <description>Channel 0-3 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>DMA Interrupt Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>IPEND</name>
+       <description>Channel Interrupt.   To clear an interrupt, all active interrupt bits of the DMA_ST must be cleared. The interrupt bits are set only if their corresponding interrupt enable bits are set in DMA_CN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>8</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CFG</name>
+      <description>DMA Channel Configuration Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>CHIEN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQSEL</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0RX</name>
+          <description>SPI0 RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1RX</name>
+          <description>SPI1 RX</description>
+          <value>0x02</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0RX</name>
+          <description>I2C0 RX</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0RX</name>
+          <description>UART0 RX</description>
+          <value>0x1C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0TX</name>
+          <description>SPI0 TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1TX</name>
+          <description>SPI1 TX</description>
+          <value>0x22</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0TX</name>
+          <description>I2C0 TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0TX</name>
+          <description>UART0 TX</description>
+          <value>0x3C</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQWAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TOSEL</name>
+        <description>Timeout Period Select.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PSSEL</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BRST</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>CHDIEN</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZIEN</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>ST</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>CH_ST</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_ST</name>
+        <description>Count-to-Zero (CTZ) Event Interrupt Flag</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>RLD_ST</name>
+        <description>Reload Event Interrupt Flag.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>TO_ST</name>
+        <description>Time-Out Event Interrupt Flag.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>SRC</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>DST</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC_RLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>SRC_RLD</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST_RLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>DST_RLD</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT_RLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT_RLD</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. This bit should be set after the address reload registers have been programmed. This bit is automatically cleared to 0 when reload occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+<!--DMA DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral>
+   <name>FCR</name>
+   <description>Function Control Register.</description>
+   <baseAddress>0x40000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>FCTRL0</name>
+     <description>Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>I2C0_SDA_FILTER_EN</name>
+       <description>I2C0 SDA Glitch Filter Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0_SCL_FILTER_EN</name>
+       <description>I2C0 SCL Glitch Filter Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FCR Function Control Register.-->
+  <peripheral>
+   <name>FLC</name>
+   <description>Flash Memory Control.</description>
+   <prependToName>FLSH_</prependToName>
+   <baseAddress>0x40029000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Flash_Controller</name>
+    <description>Flash Controller interrupt.</description>
+    <value>23</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FLSH_ADDR</name>
+     <description>Flash Write Address.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address for next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FLSH_CLKDIV</name>
+     <description>Flash Clock Divide. The clock (PLL0) is divided by this value to generate a 1 MHz clock for Flash controller.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000064</resetValue>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Flash Clock Divide. The clock is divided by this value to generate a 1MHz clock for flash controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FLSH_CN</name>
+     <description>Flash Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WR</name>
+       <description>Write.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="WR">
+       <name>ME</name>
+       <description>Mass Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="WR">
+       <name>PGE</name>
+       <description>Page Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERASE_CODE</name>
+       <description>Erase Code.  The ERASE_CODE must be set up property before erase operation can be initiated. These bits are automatically cleared after the operation is complete.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>erasePage</name>
+         <description>Enable Page Erase.</description>
+         <value>0x55</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>eraseAll</name>
+         <description>Enable Mass Erase. The debug port must be enabled.</description>
+         <value>0xAA</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PEND</name>
+       <description>Flash Pending.  When Flash operation is in progress (busy), Flash reads and writes will fail. When PEND is set, write to all Flash registers, with exception of the Flash interrupt register, are ignored.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>UNLOCK</name>
+       <description>Flash Unlock.  The correct unlock code must be written to these four bits before any Flash write or erase operation is allowed.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Flash Unlocked.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Flash Locked.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FLSH_INT</name>
+     <description>Flash Interrupt Register.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Flash Done Interrupt.  This bit is set to 1 upon Flash write or erase completion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AF</name>
+       <description>Flash Access Fail.  This bit is set when an attempt is made to write the flash while the flash is busy or the flash is locked. This bit can only be set to 1 by hardware.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONEIE</name>
+       <description>Flash Done Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DONEIE">
+       <name>AFIE</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>FLSH_DATA[%s]</name>
+     <description>Flash Write Data.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACNTL</name>
+     <description>Access Control Register. Writing the ACTRL register with the following values in the order shown, allows read and write access to the system and user Information block:
+		pflc-actrl = 0x3a7f5ca3;
+		pflc-actrl = 0xa1e34f20;
+		pflc-actrl = 0x9608b2c1. When unlocked, a write of any word will disable access to system and user information block. Readback of this register is always zero.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ADATA</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FLC Flash Memory Control.-->
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x40000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SYSCTRL</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>BSTAPEN</name>
+       <description>Boundary Scan TAP enable. When enabled, the JTAG port is connected to the Boundary Scan TAP. Otherwise, the port is connected to the ARM ICE function. This bit is reset by the POR. Reset value and access depend on the part number.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Boundary Scan TAP port disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Boundary Scan TAP port enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLASH0_PAGE_FLIP</name>
+       <description>Flips the Flash bottom and top halves. (Depending on the total flash size, each half is either 256K or 512K). Initiating a flash page flip will cause a flush of both the data buffer on the DCODE bus and the internal instruction buffer.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Physical layout matches logical layout.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>swapped</name>
+         <description>Bottom half mapped to logical top half and vice versa.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICC0_FLUSH</name>
+       <description>Code Cache Flush. This bit is used to flush the code caches and the instruction buffer of the Cortex-M4. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CCHK</name>
+       <description>Compute ROM Checksum. This bit is self-cleared when calculation is completed. Once set, software clearing this bit is ignored and the bit will remain set until the operation is completed.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CHKRES</name>
+       <description>ROM Checksum Result. This bit is only valid when CHKRD=1.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pass</name>
+         <description>ROM Checksum Correct.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fail</name>
+         <description>ROM Checksum Fail.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MDU_KEYSZ</name>
+       <description>MDU Key Size. This register defines the size of AES key that is used in the memory protection logic.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>128b</name>
+         <description>128 bit key</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>256b</name>
+         <description>256 bit key</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>WDT0</name>
+       <description>Watchdog Timer Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO1</name>
+       <description>GPIO1 Reset. Setting this bit to 1 resets GPIO1 pins to their default states.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR0</name>
+       <description>Timer0 Reset. Setting this bit to 1 resets Timer 0 blocks.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR1</name>
+       <description>Timer1 Reset. Setting this bit to 1 resets Timer 1 blocks.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR2</name>
+       <description>Timer2 Reset. Setting this bit to 1 resets Timer 2 blocks.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR3</name>
+       <description>Timer3 Reset. Setting this bit to 1 resets Timer 3 blocks.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART0</name>
+       <description>UART0 Reset. Setting this bit to 1 resets all UART 0 blocks.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI0</name>
+       <description>SPI0 Reset. Setting this bit to 1 resets all SPI 0 blocks.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI1</name>
+       <description>SPI1 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>I2C0</name>
+       <description>I2C0 Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>CRYPTO</name>
+       <description>Cryptographic Reset. Setting this bit to 1 resets the AES block, the SHA block and the DES block.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SOFT</name>
+       <description>Soft Reset. Setting this bit to 1 resets everything except the CPU and the watchdog timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>PERIPH</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SYS</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>SYSCLK_DIV</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the PLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_SEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>Internal Primary Oscilatior Clock</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INRO</name>
+         <description>8kHz Internal Nano Ring Oscillator is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBRO</name>
+         <description>The internal Baud Rate oscillator is used for the system clock.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_RDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CCD</name>
+       <description>Cryptographic clock divider</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>non_div</name>
+         <description>The cryptographic accelerator clock is running in non-divided mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div</name>
+         <description>The cryptographic accelerator clock is running in divided mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IPO_EN</name>
+       <description>96MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="IPO_EN">
+       <name>IBRO_EN</name>
+       <description>8MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_VS</name>
+       <description>7.3728MHz Internal Oscillator Voltage Source Select</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IPO_RDY</name>
+       <description>Internal Primary Oscillator Ready.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="IPO_RDY">
+       <name>IBRO_RDY</name>
+       <description>Internal Baud Rate Oscillator Ready.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="IPO_RDY">
+       <name>INRO_RDY</name>
+       <description>Internal Nano Ring Oscillator Low Frequency Reference Clock Ready.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PM</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This two bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>DeepSleep Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>backup</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO_WE</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IPO_PD</name>
+       <description>Internal Primary Oscilator Power Down. This bit selects the power state in DEEPSLEEP mode. </description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IBRO_PD</name>
+       <description>Internal Baud Rate Oscillator power down. This bit selects the power state in DEEPSLEEP mode. </description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIV</name>
+     <description>Peripheral Clock Divider.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>PCF</name>
+       <description>These bits determine the clock frequency for the UART, I2C and Key Pad peripherals. These peripherals have an adaptive clock generator that dynamically adjusts the peripheral frequency based on the main system bus frequency. These bits are dynamically updated when the PLL0 is selected as the system clock source and are set by hardware. These bits determine the clock frequency for the UART, I2C and Key Pad peripherals. These peripherals have an adaptive clock generator that dynamically adjusts the peripheral frequency based on the main system bus frequency. These bits are dynamically updated when the PLL0 is selected as the system clock source and are set by hardware.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>96MHz</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>48MHz</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>24MHz</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12MHz</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6MHz</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3MHz</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PCFWEN</name>
+       <description>PCF Write Enable. This bit allows the PCF Register bits to be updated by Software.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>blocked</name>
+         <description>Writes to PCF are blocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Writes to PCF are allowed</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AON_CLKDIV</name>
+       <description>Always-ON (AON) domain CLock Divider. These bits define the AON domain clock divider.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div_4</name>
+         <description>PCLK divide by 4.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div_8</name>
+         <description>PCLK divide by 8.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div_16</name>
+         <description>PCLK divide by 16.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div_32</name>
+         <description>PCLK divide by 32.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0</name>
+       <description>GPIO0 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>GPIO1</name>
+       <description>GPIO1 Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>DMA</name>
+       <description>DMA Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI0</name>
+       <description>SPI 0 Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI1</name>
+       <description>SPI 1 Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART0</name>
+       <description>UART 0 Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C0</name>
+       <description>I2C 0 Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>CRYPTO</name>
+       <description>Crypto Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR0</name>
+       <description>Timer 0 Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR1</name>
+       <description>Timer 1 Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR2</name>
+       <description>Timer 2 Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR3</name>
+       <description>Timer 3 Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCTRL</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 2.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>RAMWS_EN</name>
+       <description>SRAM Wait State Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM0LS_EN</name>
+       <description>System RAM 0 Light Sleep Mode.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM1LS_EN</name>
+       <description>System RAM 1 Light Sleep Mode.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM2LS_EN</name>
+       <description>System RAM 2 Light Sleep Mode.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM3LS_EN</name>
+       <description>System RAM 3 Light Sleep Mode.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM4LS_EN</name>
+       <description>System RAM 4 Light Sleep Mode.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>ICC0LS_EN</name>
+       <description>ICache RAM Light Sleep Mode.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>ROMLS_EN</name>
+       <description>ROM Light Sleep Mode.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMZ</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM Block 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM1</name>
+       <description>System RAM Block 1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM2</name>
+       <description>System RAM Block 2.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM3</name>
+       <description>System RAM Block 3.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM4</name>
+       <description>System RAM Block 4.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICC0</name>
+       <description>Instruction Cache.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSST</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICELOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>WDT1</name>
+       <description>WDT1 Reset.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="WDT1">
+       <name>SFES</name>
+       <description>Serial Flash Emulation Slave Reset.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TRNG</name>
+       <description>TRNG Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="TRNG">
+       <name>WDT0</name>
+       <description>WDT0 Clock Disable</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="TRNG">
+       <name>WDT1</name>
+       <description>WDT1 Clock Disable</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="TRNG">
+       <name>SFES</name>
+       <description>Serial Flash emulation slave Clock Disable</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVENTEN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Enable RXEV pin event. When this bit is set, a logic high of GPIO0[24] will cause an RXEV event to wake the CPU from WFE sleep mode. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO[25].</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REVISION</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSIE</name>
+     <description>System Status Interrupt Enable Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEUNLOCK</name>
+       <description>ARM ICE Unlock Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCERR</name>
+     <description>ECC Error Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>ECC System RAM1 Error Flag. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>ECC System RAM2 Error Flag. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>ECC System RAM3 Error Flag. Write 1 to clear.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM4</name>
+       <description>ECC System RAM4 Error Flag. Write 1 to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCCED</name>
+     <description>ECC Not Double Error Detect Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>ECC System RAM1 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>ECC System RAM2 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>ECC System RAM3 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM4</name>
+       <description>ECC System RAM4 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCIE</name>
+     <description>ECC IRQ Enable Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>ECC System RAM0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>ECC System RAM1 Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>ECC System RAM2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>ECC System RAM3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM4</name>
+       <description>ECC System RAM4 Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCADDR</name>
+     <description>ECC Error Address Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>DATARAMADDR</name>
+       <description>ECC Error Address/DATA RAM Error Address</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>DATARAMBANK</name>
+       <description>ECC Error Address/DATA RAM Error Bank</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATARAMERR</name>
+       <description>DATA RAM ERROR</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMADDR</name>
+       <description>ECC Error Address/TAG RAM Error Address</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMBANK</name>
+       <description>ECC Error Address/TAG RAM Error Bank</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMERR</name>
+       <description>TAG RAM ERROR</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCR Global Control Registers.-->
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x40008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN0</name>
+     <description>GPIO Function Enable Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN0</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_SET</name>
+     <description>GPIO Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN0_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN0_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_EN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_EN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT_EN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_EN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT_EN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_OUT bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_IN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_MOD</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_MOD</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_POL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_POL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN_EN</name>
+     <description>GPIO Input Enable</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_IN_EN</name>
+       <description>Connects corresponding input pad to specified input pin for reading the pin state using GPIOn_IN register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_connected</name>
+         <description>Input not connected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>connected</name>
+         <description>Input pin connected to the pad.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_EN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_EN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_STAT</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_INT_STAT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WAKE_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WAKE_EN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WAKE_EN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_DUAL_EDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_DUAL_EDGE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PDPU_SEL0</name>
+     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PDPU_SEL0</name>
+       <description>The two bits in GPIO_PDPU_SEL0 and GPIO_PDPU_SEL1 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PDPU_SEL1</name>
+     <description>GPIO Input Mode Config 2. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PDPU_SEL1</name>
+       <description>The two bits in GPIO_PDPU_SEL0 and GPIO_PDPU_SEL1 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_SET</name>
+     <description>GPIO Alternate Function Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN1_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN1_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS_SEL0</name>
+     <description>GPIO Drive Strength  Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>DS_SEL0</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ld</name>
+         <description>GPIO port pin is in low-drive mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hd</name>
+         <description>GPIO port pin is in high-drive mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS_SEL1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>DS_SEL1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PSSEL</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>PSSEL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GPIO0 Individual I/O for each GPIO-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO1</name>
+   <description>Individual I/O for each GPIO 1</description>
+   <baseAddress>0x40009000</baseAddress>
+   <interrupt>
+    <name>GPIO1</name>
+    <description>GPIO1 IRQ</description>
+    <value>25</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO1 Individual I/O for each GPIO 1-->
+  <peripheral>
+   <name>I2C0</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>I2C</groupName>
+   <baseAddress>0x4001D000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2C0</name>
+    <description>I2C0 IRQ</description>
+    <value>13</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CN</name>
+     <description>Control Register0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>I2CEN</name>
+       <description>I2C Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable I2C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable I2C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST</name>
+       <description>Master Mode Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave_mode</name>
+         <description>Slave Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master_mode</name>
+         <description>Master Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GCEN</name>
+       <description>General Call Address Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Ignore Gneral Call Address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Acknowledge general call address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Interactive Receive Mode.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interactive Receive Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interactive Receive Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACK</name>
+       <description>Data Acknowledge. This bit defines the acknowledge bit returned by the I2C receiver while IRXM = 1 HW forces ACK to 0 when IRXM = 0.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ack</name>
+         <description>return ACK (pulling SDA LOW).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>return NACK (leaving SDA HIGH).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLO</name>
+       <description>SCL Output. This bits control SCL output when SWOE =1.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_scl_low</name>
+         <description>Drive SCL low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_scl</name>
+         <description>Release SCL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDAO</name>
+       <description>SDA Output. This bits control SDA output when SWOE = 1. </description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_sda_low</name>
+         <description>Drive SDA low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_sda</name>
+         <description>Release SDA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL</name>
+       <description>SCL status. This bit reflects the logic gate of SCL signal. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDA</name>
+       <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SWOE</name>
+       <description>Software Output Enable.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>outputs_disable</name>
+         <description>I2C Outputs SCLO and SDAO disabled. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputs_enable</name>
+         <description>I2C Outputs SCLO and SDAO enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read. This bit reflects the R/W bit of an address match (AMI = 1) or general call match (GCI = 1). This bit is valid 3 cycles after the relevant interrupt bit is set.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLSTRD</name>
+       <description>This bit will disable slave clock stretching when set.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Slave clock stretching enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Slave clock stretching disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLPPM</name>
+       <description>SCL Push-Pull Mode. This bit controls whether SCL is operated in a the I2C standard open-drain mode, or in a non-standard push-pull mode where the Hi-Z output isreplaced with Drive-1. The non-standard mode should only be used when operating as a master and communicating with slaves that are guaranteed to never drive SCL low. </description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Standard open-drain operation:
+					drive low for 0, Hi-Z for 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Non-standard push-pull operation:
+					drive low for 0, drive high for 1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ST</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BUS</name>
+       <description>Bus Status.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>I2C Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>I2C Bus Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXE</name>
+       <description>RX empty.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXF</name>
+       <description>RX Full.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXE</name>
+       <description>TX Empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXF</name>
+       <description>TX Full.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CKMD</name>
+       <description>Clock Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_actively_driving_scl_clock</name>
+         <description>Device not actively driving SCL clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>actively_driving_scl_clock</name>
+         <description>Device operating as master and actively driving SCL clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ST</name>
+       <description>Status Controller.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT0</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DONEI</name>
+       <description>Transfer Done Interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXMI</name>
+       <description>Interactive Receive Interrupt.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GCI</name>
+       <description>Slave General Call Address Match Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AMI</name>
+       <description>Slave Address Match Interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXTHI</name>
+       <description>Receive Threshold Interrupt. This bit is automaticcaly cleared when RX_FIFO is below the threshold level.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. RX_FIFO equal or more bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXTHI</name>
+       <description>Transmit Threshold Interrupt. This bit is automaticcaly cleared when TX_FIFO is above the threshold level.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPI</name>
+       <description>STOP Interrupt.</description>
+       <bitRange>[6:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADRACKI</name>
+       <description>Address Acknowledge Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARBERI</name>
+       <description>Arbritation error Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOERI</name>
+       <description>timeout Error Interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADRERI</name>
+       <description>Address NACK Error Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATERI</name>
+       <description>Data NACK Error Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNRERI</name>
+       <description>Do Not Respond Error Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STRTERI</name>
+       <description>Start Error Interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPERI</name>
+       <description>Stop Error Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXLOI</name>
+       <description>Transmit Lock Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>RDAMI</name>
+       <description>Slave Read Address Match Interrupt.</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WRAMI</name>
+       <description>Slave Write Address Match Interrupt.</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN0</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONEIE</name>
+       <description>Transfer Done Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when DONE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXMIE</name>
+       <description>Description not available.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when RX_MODE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GCIE</name>
+       <description>Slave mode general call address match received input enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when GEN_CTRL_ADDR = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AMIE</name>
+       <description>Slave mode incoming address match interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when ADDR_MATCH = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXTHIE</name>
+       <description>RX FIFO Above Treshold Level Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXTHIE</name>
+       <description>TX FIFO Below Treshold Level Interrupt Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPIE</name>
+       <description>Stop Interrupt Enable</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when STOP = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADRACKIE</name>
+       <description>Received Address ACK from Slave Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARBERIE</name>
+       <description>Master Mode Arbitration Lost Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOERIE</name>
+       <description>Timeout Error Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADRERIE</name>
+       <description>Master Mode Address NACK Received Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATERIE</name>
+       <description>Master Mode Data NACK Received Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNRERIE</name>
+       <description>Slave Mode Do Not Respond Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STRTERIE</name>
+       <description>Out of Sequence START condition detected interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPERIE</name>
+       <description>Out of Sequence STOP condition detected interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXLOIE</name>
+       <description>TX FIFO Locked Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT1</name>
+     <description>Interrupt Status Register 1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>RXOFI</name>
+       <description>Receiver Overflow Interrupt. When operating as a slave receiver, this bit is set when you reach the first data bit and the RX FIFO and shift register are both full.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXUFI</name>
+       <description>Transmit Underflow Interrupt. When operating as a slave transmitter, this bit is set when you reach the first data bit and the TX FIFO is empty and the master is still asking for more data (i.e the master hasn't sent a NACK yet).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN1</name>
+     <description>Interrupt Staus Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RXOFIE</name>
+       <description>Receiver Overflow Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXUFIE</name>
+       <description>Transmit Underflow Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RXLEN</name>
+       <description>Receive FIFO Length.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TXLEN</name>
+       <description>Transmit FIFO Length.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCFG</name>
+     <description>Receive Control Register 0.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>DNR</name>
+       <description>Do Not Respond.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Always respond to address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>not_respond_rx_fifo_empty</name>
+         <description>Do not respond to address match when RX_FIFO is not empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXFSH</name>
+       <description>Receive FIFO Flush. This bit is automatically cleared to 0 after the operation. Setting this bit to 1 will affect RX_FIFO status.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush RX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXTH</name>
+       <description>Receive FIFO Threshold. These bits define the RX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RX</name>
+     <description>Receive Control Register 1.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>RXCNT</name>
+       <description>Receive Count Bits. These bits define the number of bytes to be received in a transaction, except for the case RXCNT = 0. RXCNT = 0 means 256 bytes to be received in a transaction.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>RXFIFO</name>
+       <description>Receive FIFO Count. These bits reflect the number of byte in the RX_FIFO. These bits are flushed when I2CEN = 0.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCFG</name>
+     <description>Transmit Control Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>TXPRELD</name>
+       <description>Transmit FIFO Preaload Mode. Setting this bit will allow for high speed application to preload the transmit FIFO prior to Slave Address Match.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TXRDYMMODE</name>
+       <description>Transmit FIFO Ready Manual Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW control of I2CTXRDY enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW control of I2CTXRDY disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXFSH</name>
+       <description>Transmit FIFO Flush. This bit is automatically cleared to 0 after the operation.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush TX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXTH</name>
+       <description>Transmit FIFO Threshold. These bits define the TX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TX</name>
+     <description>Transmit Control Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>TXRDY</name>
+       <description>Transmit FIFO Preload Ready.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TXLAST</name>
+       <description>Transmit Lasr. Used in slave mode only. (Cleared by hardware)</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>TXFIFO</name>
+       <description>Transmit FIFO Count. These bits reflect the number of bytes in the TX_FIFO.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MCN</name>
+     <description>Master Control Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Setting this bit to 1 will start a master transfer.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>RESTART</name>
+       <description>Setting this bit to 1 will generate a repeated START.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Setting this bit to 1 will generate a STOP condition.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>SEA</name>
+       <description>Slave Extend Address Select.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CKL</name>
+     <description>Clock Low Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>CKL</name>
+       <description>Clock low. In master mode, these bits define the SCL low period. In slave mode, these bits define the time SCL will be held low after data is outputted.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CKH</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>CKH</name>
+       <description>Clock High. In master mode, these bits define the SCL high period.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TO</name>
+     <description>Timeout Register</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>TO</name>
+       <description>Timeout</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TXEN</name>
+       <description>TX channel enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXEN</name>
+       <description>RX channel enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLA</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>SLA</name>
+       <description>Slave Address.</description>
+       <bitRange>[9:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EA</name>
+       <description>Extended Address Select. This bit selects whether the SLA contains a 7-bit or 10-bit address.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bit_address</name>
+         <description>7-bit address select.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bit_address</name>
+         <description>10-bit address select.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2C0 Inter-Integrated Circuit.-->
+  <peripheral>
+   <name>ICC0</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x4002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CACHE_ID</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CCHID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCFG</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCHSZ</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEMSZ</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CACHE_CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>CACHE_EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CACHE_RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IA</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ICC0 Instruction Cache Controller Registers-->
+  <peripheral>
+   <name>MCR</name>
+   <description>Misc Control.</description>
+   <baseAddress>0x40006C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>ECCEN</name>
+     <description>ECC Enable Register</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>SYSRAM0ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM1ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM2ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM3ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM4ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FL0ECCEN</name>
+       <description>Flash0 ECC Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FL1ECCEN</name>
+       <description>Flash1 ECC Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--MCR Misc Control.-->
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x40006800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>LPCN</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAMRET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>LDO_DIS</name>
+       <description>LDO Disabled</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VCOREMON_DIS</name>
+       <description>Vcore Monitor Disable. This bit controls the power monitor on the VCore supply in all operating modes.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDAMON_DIS</name>
+       <description>VDDA Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST0</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO0.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN0</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST1</name>
+     <description>Low Power I/O Wakeup Status Register 1. This register indicates the low power wakeup status for GPIO1.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>ST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN1</name>
+     <description>Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup functionality for GPIO1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWKST</name>
+     <description>Low Power Peripheral Wakeup Status Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>BBMOD</name>
+       <description>Battery Back Wakeup Flag (write one to clear). This bit will be set when exiting Battery Backup Mode.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST</name>
+       <description>Reset Detect Wakeup Flag (write one to clear). This bit will be set when the external reset causes wakeup</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SDMA1</name>
+       <description>Smart DMA (1) Detect Wakeup Flag (write one to clear). This bit will be set when the SDMA IRQ transitions from low to high or high to low</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPMEMSD</name>
+     <description>Low Power Memory Shutdown Control.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM block 0 Shut Down.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>System RAM block 1 Shut Down.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>System RAM block 2 Shut Down.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>System RAM block 3 Shut Down.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM4</name>
+       <description>System RAM block 4 Shut Down.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHE</name>
+       <description>Instruction Cache RAM Shut Down.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHEXIP</name>
+       <description>XiP Instruction Cache RAM Shut Down.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROM</name>
+       <description>ROM Shut Down.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GP0</name>
+     <description>Back Up General Purpose Register 0</description>
+     <addressOffset>0x48</addressOffset>
+    </register>
+    <register>
+     <name>GP1</name>
+     <description>Back Up General Purpose Register 1</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--PWRSEQ Power Sequencer / Low Power Control Register.-->
+  <peripheral>
+   <name>SFE</name>
+   <description>Serial Flash Emulator.</description>
+   <baseAddress>0x400A0000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CFG</name>
+     <description>SFE Configuration Register.</description>
+     <addressOffset>0x0400</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DRLE</name>
+       <description>Data Rise Launch Edge Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLOCK</name>
+       <description>Flash Lock.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RD_EN</name>
+       <description>RAM Read Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_EN</name>
+       <description>RAM Write Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RRLOCK</name>
+       <description>RAM Read Lock.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RWLOCK</name>
+       <description>RAM Write Lock.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HFSA</name>
+     <description>SFE Host Flash Start Address Register.</description>
+     <addressOffset>0x0408</addressOffset>
+     <fields>
+      <field>
+       <name>HFSA</name>
+       <description> Serial Flash Host Flash Start Address.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>22</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HRSA</name>
+     <description>SFE Host RAM Start Address Register.</description>
+     <addressOffset>0x040C</addressOffset>
+     <fields>
+      <field>
+       <name>HRSA</name>
+       <description> Serial Flash Host RAM Start Address.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>22</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFDP_SBA</name>
+     <description>SFE Discoverable Parameter System Base Register.</description>
+     <addressOffset>0x0410</addressOffset>
+     <fields>
+      <field>
+       <name>SFDP_SBA</name>
+       <description> SFDP upper 24 bits System Base Address.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FLASH_SBA</name>
+     <description>Flash System Base Address Register.</description>
+     <addressOffset>0x0414</addressOffset>
+     <fields>
+      <field>
+       <name>FLASH_SBA</name>
+       <description> FLASH upper 22 bits System Base Address.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>22</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FLASH_STA</name>
+     <description>Flash System Top Address Register.</description>
+     <addressOffset>0x0418</addressOffset>
+     <fields>
+      <field>
+       <name>FLASH_STA</name>
+       <description> FLASH upper 22 bits System Top Address.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>22</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RAM_SBA</name>
+     <description>RAM System Base Address Register.</description>
+     <addressOffset>0x041C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM_SBA</name>
+       <description> RAM upper 22 bits System Base Address.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>22</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RAM_STA</name>
+     <description>RAM System Top Address Register.</description>
+     <addressOffset>0x0420</addressOffset>
+     <fields>
+      <field>
+       <name>RAM_STA</name>
+       <description> RAM upper 22 bits System Top Address.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>22</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SFE Serial Flash Emulator.-->
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x40000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SISTAT</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>MAGIC</name>
+       <description>Magic Word Validation.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>magicNotSet</name>
+         <description>Magic word was not set (OTP has not been initialized properly).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>magicSet</name>
+         <description>Magic word was set (OTP contains valid settings).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRCERR</name>
+       <description>CRC Error Status.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No CRC errors occurred during the read of the OTP memory block.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>A CRC error occurred while reading the OTP. The address of the failure location in the OTP memory is stored in the ERRADDR register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ERRADDR</name>
+     <description>Read-only field set by the SIB block if a CRC error occurs during the read of the OTP memory. Contains the failing address in OTP memory (when CRCERR equals 1).</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ERRADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FSTAT</name>
+     <description>funcstat register.</description>
+     <addressOffset>0x100</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>FPU</name>
+       <description>FPU Function.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NMI</name>
+       <description>NMI function.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SFES</name>
+       <description>SFES function.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFSTAT</name>
+     <description>secfuncstat register.</description>
+     <addressOffset>0x104</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TRNG</name>
+       <description>TRNG function.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AES</name>
+       <description>AES function.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHA</name>
+       <description>SHA function.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIR System Initialization Registers.-->
+  <peripheral>
+   <name>SMON</name>
+   <description>The Security Monitor block used to monitor system threat conditions.</description>
+   <baseAddress>0x40004000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>EXTSCN</name>
+     <description>External Sensor Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x3800FFC0</resetMask>
+     <fields>
+      <field>
+       <name>EXTS_EN0</name>
+       <description>External Sensor Enable for input/output pair 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN1</name>
+       <description>External Sensor Enable for input/output pair 1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN2</name>
+       <description>External Sensor Enable for input/output pair 2.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN3</name>
+       <description>External Sensor Enable for input/output pair 3.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN4</name>
+       <description>External Sensor Enable for input/output pair 4.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN5</name>
+       <description>External Sensor Enable for input/output pair 5.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTCNT</name>
+       <description>External Sensor Error Counter. These bits set the number of external sensor accepted mismatches that have to occur within a single bit period before an external sensor alarm is triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>EXTFRQ</name>
+       <description>External Sensor Frequency. These bits define the frequency at which the external sensors are clocked to/from the EXTS_IN and EXTS_OUT pair.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq2000Hz</name>
+         <description>Div 4 (2000Hz).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq1000Hz</name>
+         <description>Div 8 (1000Hz).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq500Hz</name>
+         <description>Div 16 (500Hz).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq250Hz</name>
+         <description>Div 32 (250Hz).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq125Hz</name>
+         <description>Div 64 (125Hz).</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq63Hz</name>
+         <description>Div 128 (63Hz).</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq31Hz</name>
+         <description>Div 256 (31Hz).</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RFU</name>
+         <description>Reserved. Do not use.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DIVCLK</name>
+       <description>Clock Divide.  These bits are used to divide the 8KHz input clock. The resulting divided clock is used for all logic within the Security Monitor Block. Note:
+                                                             If the input clock is divided with these bits, the error count threshold table and output frequency will be affected accordingly with the same divide factor.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1 (8000 Hz).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2 (4000 Hz).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4 (2000 Hz).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8 (1000 Hz).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16 (500 Hz).</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32 (250 Hz).</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64 (125 Hz).</description>
+         <value>6</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>Busy. This bit is set to 1 by hardware after EXTSCN register is written to. This bit is automatically cleared to 0 after this register information has been transferred to the security monitor domain.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Update in Progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock Register. Once locked, the EXTSCN register can no longer be modified.  Only a battery disconnect will clear this bit. VBAT powers this register.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTSCN</name>
+     <description>Internal Sensor Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x7F00FFF7</resetMask>
+     <fields>
+      <field>
+       <name>SHIELD_EN</name>
+       <description>Die Shield Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TEMP_EN</name>
+       <description>Temperature Sensor Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VBAT_EN</name>
+       <description>Battery Monitor Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DFD_EN</name>
+       <description>Digital Fault Dector Enable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DFD_NMI</name>
+       <description>Digital Fault NMI Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DFD_STDBY</name>
+       <description>Digital Fault Dector Stand by Enable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PUF_TRIM_ERASE</name>
+       <description>Erase puf trim Enable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LOTEMP_SEL</name>
+       <description>Low Temperature Detection Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>neg50C</name>
+         <description>-50 degrees C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>neg30C</name>
+         <description>-30 degrees C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORELOEN</name>
+       <description>VCORE Undervoltage Detect Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREHIEN</name>
+       <description>VCORE Overvoltage Detect Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDLOEN</name>
+       <description>VDD Undervoltage Detect Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDHIEN</name>
+       <description>VDD Overvoltage Detect Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VGLEN</name>
+       <description>Voltage Glitch Detection Enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock Register. Once locked, the INTSCN register can no longer be modified.  Only a battery disconnect will clear this bit. VBAT powers this register.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECALM</name>
+     <description>Security Alarm Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000000</resetValue>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>DRS</name>
+       <description>Destructive Reset Trigger. Setting this bit will generate a DRS. This bit is self-cleared by hardware.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>Key Wipe Trigger. Set to 1 to initiate a wipe of the AES key register. It does not reset the part, or log a timestamp. AES and DES registers are not affected by this bit. This bit is automatically cleared to 0 after the keys have been wiped.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHIELDF</name>
+       <description>Die Shield Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOTEMP</name>
+       <description>Low Temperature Detect.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HITEMP</name>
+       <description>High Temperature Detect.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATLO</name>
+       <description>Battery Undervoltage Detect.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATHI</name>
+       <description>Battery Overvoltage Detect.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTF</name>
+       <description>External Sensor Flag.   This bit is set to 1 when any of the EXTSTAT bits are set.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDLO</name>
+       <description>VDD Undervoltage Detect Flag.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORELO</name>
+       <description>VCORE Undervoltage Detect Flag.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREHI</name>
+       <description>VCORE Overvoltage Detect Flag.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDHI</name>
+       <description>VDD Overvoltage Flag.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VGL</name>
+       <description>Voltage Glitch Detection Flag.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT0</name>
+       <description>External Sensor 0 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT1</name>
+       <description>External Sensor 1 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT2</name>
+       <description>External Sensor 2 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT3</name>
+       <description>External Sensor 3 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT4</name>
+       <description>External Sensor 4 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT5</name>
+       <description>External Sensor 5 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN0</name>
+       <description>External Sensor 0 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN1</name>
+       <description>External Sensor 1 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN2</name>
+       <description>External Sensor 2 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN3</name>
+       <description>External Sensor 3 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN4</name>
+       <description>External Sensor 4 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN5</name>
+       <description>External Sensor 5 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECDIAG</name>
+     <description>Security Diagnostic Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00000001</resetValue>
+     <resetMask>0xFFC0FE02</resetMask>
+     <fields>
+      <field>
+       <name>BORF</name>
+       <description>Battery-On-Reset Flag. This bit is set once the back up battery is conneted.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHIELDF</name>
+       <description>Die Shield Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOTEMP</name>
+       <description>Low Temperature Detect.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HITEMP</name>
+       <description>High Temperature Detect.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATLO</name>
+       <description>Battery Undervoltage Detect.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATHI</name>
+       <description>Battery Overvoltage Detect.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DYNF</name>
+       <description>Dynamic Sensor Flag.  This bit is set to 1 when any of the EXTSTAT bits are set.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESKT</name>
+       <description>AES Key Transfer.  This bit is set to 1 when AES Key has been transferred from the TRNG to the battery backed AES key register. This bit can only be reset by a BOR.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>incomplete</name>
+         <description>Key has not been transferred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>Key has been transferred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT0</name>
+       <description>External Sensor 0 Detect.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT1</name>
+       <description>External Sensor 1 Detect.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT2</name>
+       <description>External Sensor 2 Detect.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT3</name>
+       <description>External Sensor 3 Detect.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT4</name>
+       <description>External Sensor 4 Detect.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT5</name>
+       <description>External Sensor 5 Detect.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECST</name>
+     <description>Security Monitor Status Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>EXTSRS</name>
+       <description>External Sensor Control Register Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INTSRS</name>
+       <description>Internal Sensor Control Register Status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SECALRS</name>
+       <description>Security Alarm Register Status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SDBE</name>
+     <description>Security Monitor Self Destruct Byte.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>DBYTE</name>
+       <description>Self Destruct Byte</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>SBDEN</name>
+       <description>Self-Destruct Byte ENable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SMON The Security Monitor block used to monitor system threat conditions.-->
+  <peripheral>
+   <name>SPI0</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x40046000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>16</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>DATA32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>DATA16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>DATA32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>DATA8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>DATA32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MSTR_CNTL</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SPIEN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MMEN</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSIO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSCTRL</name>
+       <description>Start Select Control. Used in Master mode to control the behavior of the Slave Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>deassert</name>
+         <description>SPI De-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>assert</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ss0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ss1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ss2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRNMT_SIZE</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATIC_CONFIG</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PHASE</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>rising_edge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>falling_edge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATAWIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>3WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin (s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSPOL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SS_TIME</name>
+     <description>Register for controlling SPI peripheral/Slave Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PRE</name>
+       <description>Slave Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POST</name>
+       <description>Slave Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_CONFIG</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LOW</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HIGH</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCALE</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_FIFO_LEVEL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CLEAR</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CNT</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DMA_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_LEVEL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CLEAR</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CNT</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_DMA_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TXTHRLD</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXEMPTY</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXTHRLD</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXFULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MSTRDONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXOVR</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXUNDR</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXOVR</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXUNDR</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TXTHRLD</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXEMPTY</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXTHRLD</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXFULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MSTRDONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXOVR</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXUNDR</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXOVR</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXUNDR</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_FL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TXTHRLD</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXEMPTY</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXTHRLD</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXFULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TXTHRLD</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXEMPTY</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXTHRLD</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXFULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPI0 SPI peripheral.-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI1</name>
+   <description>SPI peripheral. 1</description>
+   <baseAddress>0x40047000</baseAddress>
+   <interrupt>
+    <name>SPI1</name>
+    <description>SPI1 IRQ</description>
+    <value>17</value>
+   </interrupt>
+  </peripheral>
+<!--SPI1 SPI peripheral. 1-->
+  <peripheral>
+   <name>TMR0</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting.</description>
+   <groupName>Timers</groupName>
+   <baseAddress>0x40010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR0</name>
+    <description>TMR0 IRQ</description>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Count.  This register stores the current timer count.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000001</resetValue>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Compare.  This register stores the compare value, which is used to set the maximum count value to initiate a reload of the timer to 0x0001.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x0000FFFF</resetValue>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>PWM.  This register stores the value that is compared to the current timer count.</description>
+     <addressOffset>0x08</addressOffset>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Clear Interrupt. Writing a value (0 or 1) to a bit in this register clears the associated interrupt.</description>
+     <addressOffset>0x0C</addressOffset>
+     <modifiedWriteValues>oneToClear</modifiedWriteValues>
+     <fields>
+      <field>
+       <name>IRQ_CLR</name>
+       <description>Clear Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CN</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>TMODE</name>
+       <description>Timer Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>oneShot</name>
+         <description>One Shot Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Continuous Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>counter</name>
+         <description>Counter Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pwm</name>
+         <description>PWM Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>capture</name>
+         <description>Capture Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>compare</name>
+         <description>Compare Mode.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>gated</name>
+         <description>Gated Mode.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>captureCompare</name>
+         <description>Capture/Compare Mode.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES</name>
+       <description>Prescaler.  Set the Timer's prescaler value. The prescaler divides the PCLK input to the timer and sets the Timer's Count Clock, F_CNT_CLK = PCLK (HZ) /prescaler. The Timer's prescaler setting is a 4-bit value with pres3:pres[2:0].</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TPOL</name>
+       <description>Timer input/output polarity bit.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TEN</name>
+       <description>Timer Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES3</name>
+       <description>MSB of prescaler value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC</name>
+       <description>Timer PWM Synchronization Mode Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NOLHPOL</name>
+       <description>Timer PWM output 0A polarity bit.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NOLLPOL</name>
+       <description>Timer PWM output 0A' polarity bit.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PWMCKBD</name>
+       <description>Timer PWM output 0A Mode Disable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TMR0 32-bit reloadable timer that can be used for timing and event counting.-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR1</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 1</description>
+   <baseAddress>0x40011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+<!--TMR1 32-bit reloadable timer that can be used for timing and event counting. 1-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR2</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 2</description>
+   <baseAddress>0x40012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+<!--TMR2 32-bit reloadable timer that can be used for timing and event counting. 2-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR3</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 3</description>
+   <baseAddress>0x40013000</baseAddress>
+   <interrupt>
+    <name>TMR3</name>
+    <description>TMR3 IRQ</description>
+    <value>8</value>
+   </interrupt>
+  </peripheral>
+<!--TMR3 32-bit reloadable timer that can be used for timing and event counting. 3-->
+  <peripheral>
+   <name>TRNG</name>
+   <description>Random Number Generator.</description>
+   <baseAddress>0x4004D000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TRNG</name>
+    <description>TRNG interrupt.</description>
+    <value>4</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CN</name>
+     <description>TRNG Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000003</resetValue>
+     <fields>
+      <field>
+       <name>RND_IRQ_EN</name>
+       <description>To enable IRQ generation when a new 32-bit Random number is ready.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESKG_MEMPROTE</name>
+       <description>AES Key Generate. When enabled, the key for securing NVSRAM is generated and transferred to the secure key register automatically without user visibility or intervention. This bit is cleared by hardware once the key has been transferred to the secure key register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ST</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RND_RDY</name>
+       <description>32-bit random data is ready to read from TRNG_DATA register. Reading TRNG_DATA when RND_RDY=0 will return all 0's. IRQ is generated when RND_RDY=1 if TRNG_CN.RND_IRQ_EN=1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Busy</name>
+         <description>TRNG Busy</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Ready</name>
+         <description>32 bit random data is ready</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESKGD_MEU_S</name>
+       <description>Automatically AES transfer on going</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data. The content of this register is valid only when RNG_IS =1. When TNRG is disabled, read returns 0x0000 0000.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRNG Random Number Generator.-->
+  <peripheral>
+   <name>UART0</name>
+   <description>UART</description>
+   <baseAddress>0x40042000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>UART0</name>
+    <description>UART0 IRQ</description>
+    <value>14</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>RXTHD</name>
+       <description>Receive Threshhold.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>PAREN</name>
+       <description>Enable/disable Parity bit (9th character).</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Parity </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Parity enabled as 9th bit</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PAREO</name>
+       <description>When PARITY_EN=1, selects odd or even parity.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Even</name>
+         <description>Even parity selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ODD</name>
+         <description>Odd parity selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PARMD</name>
+       <description>Selects parity based on 1s or 0s count (when PARITY_EN=1).</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1</name>
+         <description>Parity calculation is based on number of 1s in frame.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>0</name>
+         <description>Parity calculation is based on number of 0s in frame.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXFLUSH</name>
+       <description>Flushes the TX FIFO buffer.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXFLUSH</name>
+       <description>Flushes the RX FIFO buffer.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SIZE</name>
+       <description>Selects UART character size.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5</name>
+         <description>5 bits.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6</name>
+         <description>6 bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7</name>
+         <description>7 bits.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8</name>
+         <description>8 bits.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Selects the number of stop bits that will be generated.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1</name>
+         <description>1 stop bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_5</name>
+         <description>1.5 stop bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TXBUSY</name>
+       <description>Read-only flag indicating the UART transmit status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RXBUSY</name>
+       <description>Read-only flag indicating the UART receiver status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RXEMPTY</name>
+       <description>Read-only flag indicating the RX FIFO state.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RXFULL</name>
+       <description>Read-only flag indicating the RX FIFO state.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TXEMPTY</name>
+       <description>Read-only flag indicating the TX FIFO state.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TXFULL</name>
+       <description>Read-only flag indicating the TX FIFO state.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RXELT</name>
+       <description>Indicates the number of bytes currently in the RX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TXELT</name>
+       <description>Indicates the number of bytes currently in the TX FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>FRAMIE</name>
+       <description>Enable for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PARITYIE</name>
+       <description>Enable for RX Parity Error interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OVERIE</name>
+       <description>Enable for RX FIFO OVerrun interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FFRXIE</name>
+       <description>Enable for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FFTXOIE</name>
+       <description>Enable for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FFTXHIE</name>
+       <description>Enable for interrupt when TX FIFO reaches half the number of bytes allowed in the fifo or less.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_STAT</name>
+     <description>Interrupt Status Flags.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>32</size>
+     <modifiedWriteValues>oneToClear</modifiedWriteValues>
+     <fields>
+      <field>
+       <name>FRAMIS</name>
+       <description>FLAG for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PARITYIS</name>
+       <description>FLAG for RX Parity Error interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OVERIS</name>
+       <description>FLAG for RX FIFO Overrun interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FFRXIS</name>
+       <description>FLAG for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FFTXOIS</name>
+       <description>FLAG for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FFTXHIS</name>
+       <description>FLAG for interrupt when TX FIFO reaches half the number of bytes allowed in the fifo or less.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BAUD0</name>
+     <description>Baud rate register. Integer portion.</description>
+     <addressOffset>0x10</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>IDIV</name>
+       <description>Integer portion of baud rate divisor value. IBAUD = InputClock / (factor * Baud Rate Frequency).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BAUD1</name>
+     <description>Baud rate register. Decimal Setting.</description>
+     <addressOffset>0x14</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DDIV</name>
+       <description>Decimal portion of baud rate divisor value. DIV = InputClock/(factor*Baud Rate Frequency). DDIV=(DIV-IDIV)*128.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>FIFO Data buffer.</description>
+     <addressOffset>0x20</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>PARITY</name>
+       <description>Parity error flag for next byte to be read from FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration.</description>
+     <addressOffset>0x30</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>TXCNT</name>
+       <description>TX threshold for DMA transmission.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TXEN</name>
+       <description>TX DMA channel enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>DMA is disabled </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>DMA is enabled </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXCNT</name>
+       <description>RX threshold for DMA transmission.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RXEN</name>
+       <description>RX DMA channel enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>DMA is disabled </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>DMA is enabled </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--UART0 UART-->
+  <peripheral>
+   <name>WDT0</name>
+   <description>Watchdog Timer 0</description>
+   <baseAddress>0x40003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WDT0</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x7FFFF000</resetMask>
+     <fields>
+      <field>
+       <name>INT_PERIOD</name>
+       <description>Watchdog Interrupt Period. The watchdog timer will assert an interrupt, if enabled, if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_PERIOD</name>
+       <description>Watchdog Reset Period. The watchdog timer will assert a reset, if enabled, if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_EN</name>
+       <description>Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_FLAG</name>
+       <description>Watchdog Timer Interrupt Flag.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EN</name>
+       <description>Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EN</name>
+       <description>Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_FLAG</name>
+       <description>Watchdog Timer Reset Flag.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>WDT_RST</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WDT0 Watchdog Timer 0-->
+  <peripheral derivedFrom="WDT0">
+   <name>WDT1</name>
+   <description>Watchdog Timer 0 1</description>
+   <baseAddress>0x40003400</baseAddress>
+   <interrupt>
+    <name>WDT1</name>
+    <description>WDT1 IRQ</description>
+    <value>57</value>
+   </interrupt>
+  </peripheral>
+<!--WDT1 Watchdog Timer 0 1-->
+ </peripherals>
+</device>

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32570/Include/max32570.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32570/Include/max32570.svd
@@ -1,0 +1,23039 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max32570</name>
+ <series>ARMCM4</series>
+ <version>1.0</version>
+ <description>MAX32570 32-bit ARM Cortex-M4 microcontroller, 1024KB of flash, 760KB of system RAM, 128KB of Boot ROM.</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>ADC</name>
+   <description>10-bit Analog to Digital Converter</description>
+   <baseAddress>0x40034000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>ADC</name>
+    <description>ADC IRQ</description>
+    <value>20</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>ADC Control</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Start ADC Conversion</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PWR</name>
+       <description>ADC Power Up</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>REBUF_PWR</name>
+       <description>ADC Reference Buffer Power Up</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CHGPUMP_PWR</name>
+       <description>ADC Charge Pump Power Up</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>REF_SCALE</name>
+       <description>ADC Reference Scale</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SCALE</name>
+       <description>ADC Scale</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLK_EN</name>
+       <description>ADC Clock Enable</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_SEL</name>
+       <description>ADC Channel Select</description>
+       <bitRange>[16:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AIN0</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN1</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN2</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN3</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN4</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN5</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN6</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN7</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VcoreA</name>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VcoreB</name>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vrxout</name>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vtxout</name>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VddA</name>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VddB</name>
+         <description>VddB/4</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vddio</name>
+         <description>Vddio/4</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vddioh</name>
+         <description>Vddioh/4</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VregI</name>
+         <description>VregI/4</description>
+         <value>16</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADC_DIVSEL</name>
+       <description>Scales the external inputs, all inputs are scaled the same</description>
+       <bitRange>[18:17]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV3</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ALIGN</name>
+       <description>ADC Data Alignment Select</description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>ADC Status</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ACTIVE</name>
+       <description>ADC Conversion In Progress</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>AFE_PWR_UP_ACTIVE</name>
+       <description>AFE Power Up Delay Active</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>OVERFLOW</name>
+       <description>ADC Overflow</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>ADC Output Data</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>ADC Converted Sample Data Output</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>ADC Interrupt Control Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONE_IE</name>
+       <description>ADC Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>REF_READY_IE</name>
+       <description>ADC Reference Ready Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>HI_LIMIT_IE</name>
+       <description>ADC Hi Limit Monitor Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>LO_LIMIT_IE</name>
+       <description>ADC Lo Limit Monitor Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OVERFLOW_IE</name>
+       <description>ADC Overflow Interrupt Enable</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DONE_IF</name>
+       <description>ADC Done Interrupt Flag</description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>REF_READY_IF</name>
+       <description>ADC Reference Ready Interrupt Flag</description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>HI_LIMIT_IF</name>
+       <description>ADC Hi Limit Monitor Interrupt Flag</description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>LO_LIMIT_IF</name>
+       <description>ADC Lo Limit Monitor Interrupt Flag</description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>OVERFLOW_IF</name>
+       <description>ADC Overflow Interrupt Flag</description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>PENDING</name>
+       <description>ADC Interrupt Pending Status</description>
+       <bitRange>[22:22]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>LIMIT[%s]</name>
+     <description>ADC Limit</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CH_LO_LIMIT</name>
+       <description>Low Limit Threshold</description>
+       <bitRange>[9:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_HI_LIMIT</name>
+       <description>High Limit Threshold</description>
+       <bitRange>[21:12]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_SEL</name>
+       <description>ADC Channel Select</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_LO_LIMIT_EN</name>
+       <description>Low Limit Monitoring Enable</description>
+       <bitRange>[29:29]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_HI_LIMIT_EN</name>
+       <description>High Limit Monitoring Enable</description>
+       <bitRange>[30:30]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ADC 10-bit Analog to Digital Converter-->
+  <peripheral>
+   <name>AESKEYS</name>
+   <description>AES Keys.</description>
+   <baseAddress>0x40005000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SRAM_KEY</name>
+     <description>AES SRAM KEY</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CODE_KEY</name>
+     <description>AES CODE Key </description>
+     <addressOffset>0x20</addressOffset>
+    </register>
+    <register>
+     <name>DATA_KEY</name>
+     <description>AES DATA KEY</description>
+     <addressOffset>0x40</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--AESKEYS AES Keys.-->
+  <peripheral>
+   <name>FCR</name>
+   <description>Function Control Register.</description>
+   <baseAddress>0x40000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>FCTRL0</name>
+     <description>Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>USB_EXTCLK_SEL</name>
+       <description>USB External Core Clock Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>sys</name>
+         <description>Generated clock from system clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dig</name>
+         <description>Digital clock from a GPIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0_SDA_FILTER_EN</name>
+       <description>I2C0 SDA Glitch Filter Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0_SCL_FILTER_EN</name>
+       <description>I2C0 SCL Glitch Filter Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1_SDA_FILTER_EN</name>
+       <description>I2C1 SDA Glitch Filter Enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1_SCL_FILTER_EN</name>
+       <description>I2C1 SCL Glitch Filter Enable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2AF2_SDA_FILTER_EN</name>
+       <description>I2C2 AF2 SDA Glitch Filter Enable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2AF2_SCL_FILTER_EN</name>
+       <description>I2C2 AF2 SCL Glitch Filter Enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2AF3_SDA_FILTER_EN</name>
+       <description>I2C2 AF3 SDA Glitch Filter Enable.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2AF3_SCL_FILTER_EN</name>
+       <description>I2C2 AF3 SCL Glitch Filter Enable.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2AF4_SDA_FILTER_EN</name>
+       <description>I2C2 AF4 SDA Glitch Filter Enable</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2AF4_SCL_FILTER_EN</name>
+       <description>I2C2 AF4 SCL Glitch Filter Enable</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL0</name>
+     <description>Register 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SEL</name>
+       <description>Auto-calibration Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Autocalibration Run.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOAD</name>
+       <description>Load Trim.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INVERT</name>
+       <description>Invert Gain.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ATOMIC</name>
+       <description>Atomic mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GAIN</name>
+       <description>MU value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>TRIM</name>
+       <description>150MHz HFIO Auto Calibration Trim</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL1</name>
+     <description>Register 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>NFC_FWD_EN</name>
+       <description>Enabled FWD mode for NFC block</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NFC_CLK_EN</name>
+       <description>Enabled the NFC blocks clock divider in Analog</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NFC_FWD_TX_DATA_OVR</name>
+       <description>FWD input for NFC block</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>XO_EN_DGL</name>
+       <description>TBD</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_BIAS_PD</name>
+       <description>Power down enable for NFC receiver analog block</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_BIAS_EN</name>
+       <description>Enable the NFC receiver analog blocks</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_TM_VBG_VABUS</name>
+       <description>TBD</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_TM_BIAS</name>
+       <description>TBD</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NFC_FWD_DOUT</name>
+       <description>FWD output from FNC block</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL2</name>
+     <description>Register 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RUNTIME</name>
+       <description>Automatic Calibration Run Time.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FCR Function Control Register.-->
+  <peripheral>
+   <name>TRIMSIR</name>
+   <description>Trim System Initilazation Registers</description>
+   <baseAddress>0x40005400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>rsv0</name>
+     <description>RFU</description>
+     <addressOffset>0x00</addressOffset>
+    </register>
+    <register>
+     <name>BB_SIR2</name>
+     <description>System Init. Configuration Register 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>BB_SIR3</name>
+     <description>System Init. Configuration Register 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRIMSIR Trim System Initilazation Registers-->
+  <peripheral>
+   <name>MCR</name>
+   <description>Misc Control.</description>
+   <baseAddress>0x40006C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>ECCEN</name>
+     <description>ECC Enable Register</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>SYSRAM0ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM1ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM2ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM3ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM4ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM5ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IC0ECCEN</name>
+       <description>Icache0 ECC Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICXIPECCEN</name>
+       <description>IcacheXIP ECC Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FL0ECCEN</name>
+       <description>Flash0 ECC Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FL1ECCEN</name>
+       <description>Flash1 ECC Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PDOWN</name>
+     <description>PDOWN Drive Strength</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>PDOWNDS</name>
+       <description>PDOWN Drive Strength</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>PDOWNVS</name>
+       <description>PDOWN Voltage Select</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Misc Power State Control Register</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>VDDCSW</name>
+       <description>Controls switching of VCORE</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>USBSWEN_N</name>
+       <description>USB Switch Control</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>off</name>
+         <description>USB SW off in LP modes</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>on</name>
+         <description>USB SW On</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>P1M</name>
+       <description>Enable the Reset Pad Pull Up Resistors</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1m</name>
+         <description>1MOhm Pullup</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>25k</name>
+         <description>25kOhm Pullup.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>rstn_voltage_sel</name>
+       <description>Error! Description not Found!</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--MCR Misc Control.-->
+  <peripheral>
+   <name>CAMERAIF</name>
+   <description>Parallel Camera Interface.</description>
+   <baseAddress>0x4000E000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>CameraIF</name>
+    <value>91</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>VER</name>
+     <description>Hardware Version.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>minor</name>
+       <description>Minor Version Number.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>major</name>
+       <description>Major Version Number.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO_SIZE</name>
+     <description>FIFO Depth.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>fifo_size</name>
+       <description>FIFO size.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register.</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>READ_MODE</name>
+       <description>Read Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Camera Interface Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>single_img</name>
+         <description>Single Image Capture.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Continuous Image Capture.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>Data Width.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>8bit</name>
+         <description>8 bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10bit</name>
+         <description>10 bit.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12bit</name>
+         <description>12 bit.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DS_TIMING_EN</name>
+       <description>DS Timing Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Timing from VSYNC and HSYNC.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Timing embedded in data using SAV and EAV codes.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FIFO_THRSH</name>
+       <description>Data FIFO Threshold.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_DMA</name>
+       <description>DMA Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>DMA disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>DMA enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_DMA_THRSH</name>
+       <description>DMA Threshold.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PCIF_SYS</name>
+       <description>PCIF Control.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PCIF disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PCIF enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interupt Enable Register.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IMG_DONE</name>
+       <description>Image Done.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_FULL</name>
+       <description>FIFO Full.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_THRESH</name>
+       <description>FIFO Threshold Level Met.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_NOT_EMPTY</name>
+       <description>FIFO Not Empty.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Interupt Flag Register.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IMG_DONE</name>
+       <description>Image Done.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_FULL</name>
+       <description>FIFO Full.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_THRESH</name>
+       <description>FIFO Threshold Level Met.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_NOT_EMPTY</name>
+       <description>FIFO Not Empty.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS_TIMING_CODES</name>
+     <description>DS Timing Code Register.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SAV</name>
+       <description>Start Active Video Code.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EAV</name>
+       <description>End Active Video Code.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO_DATA</name>
+     <description>FIFO DATA Register.</description>
+     <addressOffset>0x0030</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data from FIFO to be read by DMA.</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CAMERAIF Parallel Camera Interface.-->
+  <peripheral>
+   <name>CTB</name>
+   <description>The Cryptographic Toolbox is a combination of cryptographic engines and a secure cryptographic accelerator (SCA) used to provide advanced cryptographic security.</description>
+   <baseAddress>0x40001000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Crypto_Engine</name>
+    <description>Crypto Engine interrupt.</description>
+    <value>27</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CRYPTO_CTRL</name>
+     <description>Crypto Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0xC0000000</resetValue>
+     <fields>
+      <field>
+       <name>RST</name>
+       <description>Reset. This bit is used to reset the crypto accelerator.  All crypto internal states and related registers are reset to their default reset values. Control register such as CRYPTO_CTRL, CIPHER_CTRL, HASH_CTRL, CRC_CTRL, MAA_CTRL (with the exception of the STC bit), HASH_MSG_SZ_[3:0] and MAA_MAWS will retain their values. This bit will automatically clear itself after one cycle.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_write</name>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>Starts reset operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INTR</name>
+       <description>Interrupt Enable. Generates an interrupt when done or error set.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRC</name>
+       <description>Source Select.  This bit selects the hash function and CRC generator input source.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inputFIFO</name>
+         <description>Input FIFO</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputFIFO</name>
+         <description>Output FIFO</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="INTR">
+       <name>BSO</name>
+       <description>Byte Swap Output. Note. No byte swap will occur if there is not a full word.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="INTR">
+       <name>BSI</name>
+       <description>Byte Swap Input. Note. No byte swap will occur if there is not a full word.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="INTR">
+       <name>WAIT_EN</name>
+       <description>Wait Pin Enable. This can be used to hold off the crypto DMA until an external memory is ready. This is useful for transferring pages from NAND flash which may take several microseconds to become ready.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WAIT_POL</name>
+       <description>Wait Pin Polarity. When the wait pin is enabled, this bit selects its active state.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRSRC</name>
+       <description>Write FIFO Source Select. This field determines where data written to the write FIFO comes from. When data is written to the write FIFO, it is always written out the DMA. To decrypt or encrypt data, the write FIFO source should be set to the cipher output. To implement memcpy() or memset() functions, or to fill memory with random data, the write FIFO source should be set to the read FIFO. When calculating a HASH or CMAC, the write FIFO should be disabled.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>none</name>
+         <description>None.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cipherOutput</name>
+         <description>Cipher Output.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>readFIFO</name>
+         <description>Read FIFO.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDSRC</name>
+       <description>Read FIFO Source Select. This field selects the source of the read FIFO. Typically, it is set to use the DMA. To implement a memset() function, the read FIFO DMA should be disabled. To fill memory with random data or to hash random numbers, the read FIFO source should be set to the random number generator.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dmaDisabled</name>
+         <description>DMA Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dmaOrApb</name>
+         <description>DMA Or APB.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rng</name>
+         <description>RNG.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLAG_MODE</name>
+       <description>Done Flag Mode. This bit configures the access behavior of the individual CRYPTO_CTRL Done flags (CRYPTO_CTRL[27:24]). This bit is cleared only on reset to limit upkeep, i.e. once set, it will remain set until a reset occurs.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unres_wr</name>
+         <description>Unrestricted write (0 or 1) of CRYPTO_CTRL[27:24] flags.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>res_wr</name>
+         <description>Access to CRYPTO_CTRL[27:24] are write 1 to clear/write 0 no effect.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMADNEMSK</name>
+       <description>DMA Done Flag Mask. This bit masks the DMA_DONE flag from being used to generate the CRYPTO_CTRL.DONE flag, and this disables a DMA_DONE condition from generating and interrupt. The DMA_DONE flag itself is unaffected and still may be monitored. This allows more optimal interrupt-driven crypto operations using DMA.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_used</name>
+         <description>DMA_DONE not used in setting CRYPTO_CTRL.DONE bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>used</name>
+         <description>DMA_DONE used in setting CRYPTO_CTRL.DONE bit.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMA_DONE</name>
+       <description>DMA Done. DMA write/read operation is complete. This bit must be cleared before starting a DMA operation.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notDone</name>
+         <description>Not Done.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>done</name>
+         <description>Done.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>GLS_DONE</name>
+       <description>Galois Done. FIFO is full and CRC or Hamming Code Generator is enabled. This bit must be cleared before starting a CRC operation Note that DMA_DONE must be polled instead of this bit to determine the end of DMA operation during the utilization of Hamming Code Generator.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>HSH_DONE</name>
+       <description>Hash Done. SHA operation is complete. This bit must be cleared before starting a HASH operation.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>CPH_DONE</name>
+       <description>Cipher Done. Either AES or DES encryption/decryption operation is complete. This bit must be cleared before starting a cipher operation.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERR</name>
+       <description>AHB Bus Error. This bit is set when the DMA encounters a bus error during a read or write operation. Once this bit is set, the DMA will stop. This bit can only be cleared by resetting the crypto block.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Ready. Crypto block ready for more data.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>DONE</name>
+       <description>Done. One or more cryptographic calculations complete (logical OR of done flags).</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CIPHER_CTRL</name>
+     <description>Cipher Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ENC</name>
+       <description>Encrypt. Select encryption or decryption of input data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>encrypt</name>
+         <description>Encrypt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>decrypt</name>
+         <description>Decrypt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEY</name>
+       <description>Load Key from crypto DMA. This bit is automatically cleared by hardware after the DMA has completed loading the key. When the DMA operation is done, it sets the appropriate crypto DMA Done flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRC</name>
+       <description>Source of Random key.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>cipherKey</name>
+         <description>User cipher key (0x4000_1060).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>regFile</name>
+         <description>Key from battery-backed register file (0x4000_5000 to 0x4000_501F).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>qspiKey_regFile</name>
+         <description>Key from battery-backed register file (0x4000_5020 to 0x4000_502F).</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CIPHER</name>
+       <description>Cipher Operation Select.  Symmetric Block Cipher algorithm selection or memory operation.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes128</name>
+         <description>AES 128.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes192</name>
+         <description>AES 192.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes256</name>
+         <description>AES 256.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>des</name>
+         <description>DES.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>tdes</name>
+         <description>Triple DES.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description>Mode Select. Mode of operation for block cipher or memory operation. DES/TDES cannot be used in CFB, OFB or CTR modes.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ECB</name>
+         <description>ECB Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CBC</name>
+         <description>CBC Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CFB</name>
+         <description>CFB (AES only).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>OFB</name>
+         <description>OFB (AES only).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CTR</name>
+         <description>CTR (AES only).</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HVC</name>
+       <description>H Vector Computation.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DTYPE</name>
+       <description>GCM/CCM data type.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CCMM</name>
+       <description>CCM M Parameter.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CCML</name>
+       <description>CCM L Parameter.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HASH_CTRL</name>
+     <description>HASH Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>INIT</name>
+       <description>Initialize. Initializes hash registers with standard constants.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>XOR</name>
+       <description>XOR data with IV from cipher block. Useful when calculating HMAC to XOR the input pad and output pad.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HASH</name>
+       <description>Hash function selection.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha1</name>
+         <description>SHA-1.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha224</name>
+         <description>SHA 224.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha256</name>
+         <description>SHA 256.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha384</name>
+         <description>SHA 384.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha512</name>
+         <description>SHA 512.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LAST</name>
+       <description>Last Message Bit. This bit shall be set along with the HASH_MSG_SZ register prior to hashing the last 512 or 1024-bit block of the message data. It will allow automatic preprocessing of the last message padding, which includes the trailing bit 1, followed by the respective number of zero bits for the last block size and finally the message length represented in bytes. The bit will be automatically cleared at the same time the HASH DONE is set, designating the completion of the last message hash.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEffect</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>lastMsgData</name>
+         <description>Last Message Data.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_CTRL</name>
+     <description>CRC Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>CRC</name>
+       <description>Cyclic Redundancy Check Enable. The CRC cannot be enabled if the PRNG is enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MSB</name>
+       <description>MSB select. This bit selects the order of calculating CRC on data.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lsbFirst</name>
+         <description>LSB First.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>msbFirst</name>
+         <description>MSB First.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CRC">
+       <name>PRNG</name>
+       <description>Pseudo Random Number Generator Enable. If entropy is disabled, this outputs one byte of pseudo random data per clock cycle. If entropy is enabled, data is output at a rate of one bit per clock cycle.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CRC">
+       <name>ENT</name>
+       <description>Entropy Enable. If the PRNG is enabled, this mixes the high frequency ring oscillator with the LFSR. If the PRNG is disabled, the raw entropy data is output at a rate of 1 bit per clock. This makes it possible to characterize the quality of the entropy source.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CRC">
+       <name>HAM</name>
+       <description>Hamming Code Enable. Enable hamming code calculation.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HRST</name>
+       <description>Hamming Reset. Reset Hamming code ECC generator for next block.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+       <enumeratedValues>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>Starts reset operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_SRC</name>
+     <description>Crypto DMA Source Address.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>DMA Source Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_DEST</name>
+     <description>Crypto DMA Destination Address.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>DMA Destination Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_CNT</name>
+     <description>Crypto DMA Byte Count.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>DMA Byte Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CRYPTO_DIN[%s]</name>
+     <description>Crypto Data Input. Data input can be written to this register instead of using the DMA. This register writes to the FIFO. This register occupies four successive words to allow the use of multi-store instructions. Words can be written to any location, they will be placed in the FIFO in the order they are written. The endian swap input control bit affects this register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Crypto Data Input. Input can be written to this register instead of using DMA.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CRYPTO_DOUT[%s]</name>
+     <description>Crypto Data Output. Resulting data from cipher calculation. Data is placed in the lower words of these four registers depending on the algorithm. For block cipher modes, this register holds the result of most recent encryption or decryption operation. These registers are affected by the endian swap bits.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Crypto Data Output. Resulting data from cipher calculation. Data is placed in the lower words of these four registers depending on algorithm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_POLY</name>
+     <description>CRC Polynomial. The polynomial to be used for Galois Field calculations (CRC or LFSR) should be written to this register. This register is affected by the MSB control bit.</description>
+     <addressOffset>0x40</addressOffset>
+     <resetValue>0xEDB88320</resetValue>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Polynomial. The polynomial to be used for Galois Field calculations (CRC or LFSR) should be written to this register. This register is affected by the MSB control bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_VAL</name>
+     <description>CRC Value. This is the state for the Galois Field. This register holds the result of a CRC calculation or the current state of the LFSR. This register is affected by the MSB control bit.</description>
+     <addressOffset>0x44</addressOffset>
+     <resetValue>0xFFFFFFFF</resetValue>
+     <fields>
+      <field>
+       <name>VAL</name>
+       <description>CRC Value. This is the state for the Galois Field. This register holds the result of a CRC calculation or the current state of LFSR. This register is affected by the MSB control bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HAM_ECC</name>
+     <description>Hamming ECC Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>ECC</name>
+       <description>Hamming ECC Value. These bits are the even parity of their corresponding bit groups.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PAR</name>
+       <description>Parity. This is the parity of the entire array.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>even</name>
+         <description>Even.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>odd</name>
+         <description>Odd.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CIPHER_INIT[%s]</name>
+     <description>Initial Vector. For block cipher operations that use CBC, CFB, OFB, or CNTR modes, this register holds the initial value. This register is updated with each encryption or decryption operation. This register is affected by the endian swap bits.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>IVEC</name>
+       <description>Initial Vector. For block cipher operations that use CBC, CFB, OFB, or CNTR modes, this register holds the initial value. This register is updated with each encryption or decryption operation. This register is affected by the endian swap bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CIPHER_KEY[%s]</name>
+     <description>Cipher Key.  This register holds the key used for block cipher operations. The lower words are used for block ciphers that use shorter key lengths. This register is affected by the endian swap input control bits.</description>
+     <addressOffset>0x60</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>KEY</name>
+       <description>Cipher Key. This register holds the key used for block cipher operations. The lower words are used for block ciphers that use shorter kye lengths. This register is affected by the endian swap input control bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>16</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>HASH_DIGEST[%s]</name>
+     <description>This register holds the calculated hash value. This register is affected by the endian swap bits.</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>HASH</name>
+       <description>This register holds the calculated hash value. This register is affected by the endian swap bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>HASH_MSG_SZ[%s]</name>
+     <description>Message Size. This register holds the lowest 32-bit of message size in bytes.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>MSGSZ</name>
+       <description>Message Size. This register holds the lowest 32-bit of message size in bytes.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AAD_LENGTH_0</name>
+     <description>.AAD Length Register 0.</description>
+     <addressOffset>0xD0</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>LENGTH</name>
+       <description>AAD length in bytes for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AAD_LENGTH_1</name>
+     <description>.AAD Length Register 1.</description>
+     <addressOffset>0xD4</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>LENGTH</name>
+       <description>AAD length in bytes for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PLD_LENGTH_0</name>
+     <description>.PLD Length Register 0.</description>
+     <addressOffset>0xD8</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>LENGTH</name>
+       <description>PLD length in bytes for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PLD_LENGTH_1</name>
+     <description>.LENGTH.</description>
+     <addressOffset>0xDC</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>LENGTH</name>
+       <description>PLD length in bytes for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>TAGMIC[%s]</name>
+     <description>TAG/MIC Registers.</description>
+     <addressOffset>0xE0</addressOffset>
+     <fields>
+      <field>
+       <name>LENGTH</name>
+       <description>TAG/MIC output for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_CTRL0</name>
+     <description>SCA Control 0 Register.</description>
+     <addressOffset>0x100</addressOffset>
+     <fields>
+      <field>
+       <name>STC</name>
+       <description>Start Calculation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCAIE</name>
+       <description>SCA Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Abort Operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERMEM</name>
+       <description>Erase Cryptographic Memory.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MANPARAM</name>
+       <description>ECC Parameter Source.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HWKEY</name>
+       <description>Hardware Key Select.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OPCODE</name>
+       <description>SCA Opcode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>MODADDR</name>
+       <description>MODULO Address Offset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>ECCSIZE</name>
+       <description>ECC Size.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_CTRL1</name>
+     <description>SCA Advanced Control Register.</description>
+     <addressOffset>0x104</addressOffset>
+     <fields>
+      <field>
+       <name>MAN</name>
+       <description>SCA Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>auto</name>
+         <description>Auto Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>manual</name>
+         <description>Manual Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTOCARRY</name>
+       <description>Automatically propagate the carry for the next operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PLUSONE</name>
+       <description>Enable Carry propagation for the next operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESSELECT</name>
+       <description>ALU Selection.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CARRYPOS</name>
+       <description>To set Carry location.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_STAT</name>
+     <description>SCA Status Register.</description>
+     <addressOffset>0x108</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SCA Busy.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCAIF</name>
+       <description>SCA Interrupt Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PVF1</name>
+       <description>Point 1 Verification Failed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PVF2</name>
+       <description>Point 2 Verification Failed.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FSMERR</name>
+       <description>FSM Transition Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>COMPERR</name>
+       <description>EC Computation Error.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MEMERR</name>
+       <description>SCA Memory Access Error.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARRY</name>
+       <description>Carry on ongoing operation.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GTE2I2</name>
+       <description>Modulo 2x Result.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ALUNEG1</name>
+       <description>ALU 2 SubSign of the subtraction result for ALU_2.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ALUNEG2</name>
+       <description>ALU 2 SubSign of the subtraction result for ALU_2.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PPX_ADDR</name>
+     <description>PPX Coordinate Data Pointer Register.</description>
+     <addressOffset>0x10C</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point P Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PPY_ADDR</name>
+     <description>PPY Coordinate Data Pointer Register.</description>
+     <addressOffset>0x110</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point P Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PPZ_ADDR</name>
+     <description>PPZ Coordinate Data Pointer Register.</description>
+     <addressOffset>0x114</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point P Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PQX_ADDR</name>
+     <description>PQX Coordinate Data Pointer Register.</description>
+     <addressOffset>0x118</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point Q Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PQY_ADDR</name>
+     <description>PQY Coordinate Data Pointer Register.</description>
+     <addressOffset>0x11C</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point Q Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PQZ_ADDR</name>
+     <description>PQZ Coordinate Data Pointer Register.</description>
+     <addressOffset>0x120</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point Q Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_RDSA_ADDR</name>
+     <description>SCA RDSA Address Register.</description>
+     <addressOffset>0x124</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>The starting address of the R portion for R, S ECDSA signature.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_RES_ADDR</name>
+     <description>SCA Result Address Register.</description>
+     <addressOffset>0x128</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Starting address of result storage.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_OP_BUFF_ADDR</name>
+     <description>SCA Operation Buffer Address Register.</description>
+     <addressOffset>0x12C</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Starting address of operation buffer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_MODDATA</name>
+     <description>SCA Modulo Data Input Register.</description>
+     <addressOffset>0x130</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Used to load the SCA modulo for modular operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CTB The Cryptographic Toolbox is a combination of cryptographic engines and a secure cryptographic accelerator (SCA) used to provide advanced cryptographic security.-->
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0</name>
+    <value>28</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1</name>
+    <value>29</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA2</name>
+    <value>30</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA3</name>
+    <value>31</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA4</name>
+    <value>68</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA5</name>
+    <value>69</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA6</name>
+    <value>70</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA7</name>
+    <value>71</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA8</name>
+    <value>72</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA9</name>
+    <value>73</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA10</name>
+    <value>74</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA11</name>
+    <value>75</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA12</name>
+    <value>76</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA13</name>
+    <value>77</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA14</name>
+    <value>78</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA15</name>
+    <value>79</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CN</name>
+     <description>DMA Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CH0_IEN</name>
+       <description>Channel 0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0_IEN">
+       <name>CH2_IEN</name>
+       <description>Channel 2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IEN">
+       <name>CH3_IEN</name>
+       <description>Channel 3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IEN">
+       <name>CH4_IEN</name>
+       <description>Channel 4 Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IEN">
+       <name>CH5_IEN</name>
+       <description>Channel 5 Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IEN">
+       <name>CH6_IEN</name>
+       <description>Channel 6 Interrupt Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IEN">
+       <name>CH7_IEN</name>
+       <description>Channel 7 Interrupt Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>DMA Interrupt Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CH0_IPEND</name>
+       <description>Channel Interrupt.   To clear an interrupt, all active interrupt bits of the DMA_ST must be cleared. The interrupt bits are set only if their corresponding interrupt enable bits are set in DMA_CN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0_IPEND">
+       <name>CH1_IPEND</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IPEND">
+       <name>CH2_IPEND</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IPEND">
+       <name>CH3_IPEND</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IPEND">
+       <name>CH4_IPEND</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IPEND">
+       <name>CH5_IPEND</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IPEND">
+       <name>CH6_IPEND</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IPEND">
+       <name>CH7_IPEND</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>8</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CFG</name>
+      <description>DMA Channel Configuration Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>CHEN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQSEL</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0RX</name>
+          <description>SPI0 RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1RX</name>
+          <description>SPI1 RX</description>
+          <value>0x02</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0RX</name>
+          <description>UART0 RX</description>
+          <value>0x04</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1RX</name>
+          <description>UART1 RX</description>
+          <value>0x05</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0RX</name>
+          <description>I2C0 RX</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1RX</name>
+          <description>I2C1 RX</description>
+          <value>0x08</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>ADC</name>
+          <description>Analog-to-Digital Converter Channel</description>
+          <value>0x09</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2RX</name>
+          <description>I2C2 RX</description>
+          <value>0x0A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2RX</name>
+          <description>UART2 RX</description>
+          <value>0x0E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI2RX</name>
+          <description>SPI2 RX</description>
+          <value>0x0F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP1</name>
+          <description>USB Endpoint 1 RX</description>
+          <value>0x11</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP2</name>
+          <description>USB Endpoint 2 RX</description>
+          <value>0x12</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP3</name>
+          <description>USB Endpoint 3 RX</description>
+          <value>0x13</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP4</name>
+          <description>USB Endpoint 4 RX</description>
+          <value>0x14</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP5</name>
+          <description>USB Endpoint 5 RX</description>
+          <value>0x15</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP6</name>
+          <description>USB Endpoint 6 RX</description>
+          <value>0x16</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP7</name>
+          <description>USB Endpoint 7 RX</description>
+          <value>0x17</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP8</name>
+          <description>USB Endpoint 8 RX</description>
+          <value>0x18</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP9</name>
+          <description>USB Endpoint 9 RX</description>
+          <value>0x19</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP10</name>
+          <description>USB Endpoint 10 RX</description>
+          <value>0x1A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP11</name>
+          <description>USB Endpoint 11 RX</description>
+          <value>0x1B</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0TX</name>
+          <description>SPI0 TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1TX</name>
+          <description>SPI1 TX</description>
+          <value>0x22</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0TX</name>
+          <description>UART0 TX</description>
+          <value>0x24</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1TX</name>
+          <description>UART1 TX</description>
+          <value>0x25</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0TX</name>
+          <description>I2C0 TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1TX</name>
+          <description>I2C1 TX</description>
+          <value>0x28</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2TX</name>
+          <description>I2C2 TX</description>
+          <value>0x2A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2TX</name>
+          <description>UART2 TX</description>
+          <value>0x2E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI2TX</name>
+          <description>SPI3 TX</description>
+          <value>0x2F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP1</name>
+          <description>USB Endpoint 1 TX</description>
+          <value>0x31</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP2</name>
+          <description>USB Endpoint 2 TX</description>
+          <value>0x32</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP3</name>
+          <description>USB Endpoint 3 TX</description>
+          <value>0x33</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP4</name>
+          <description>USB Endpoint 4 TX</description>
+          <value>0x34</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP5</name>
+          <description>USB Endpoint 5 TX</description>
+          <value>0x35</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP6</name>
+          <description>USB Endpoint 6 TX</description>
+          <value>0x36</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP7</name>
+          <description>USB Endpoint 7 TX</description>
+          <value>0x37</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP8</name>
+          <description>USB Endpoint 8 TX</description>
+          <value>0x38</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP9</name>
+          <description>USB Endpoint 9 TX</description>
+          <value>0x39</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP10</name>
+          <description>USB Endpoint 10 TX</description>
+          <value>0x3A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP11</name>
+          <description>USB Endpoint 11 TX</description>
+          <value>0x3B</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQWAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TOSEL</name>
+        <description>Timeout Period Select.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PSSEL</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BRST</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>CHDIEN</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZIEN</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>ST</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>CH_ST</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_ST</name>
+        <description>Count-to-Zero (CTZ) Event Interrupt Flag</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>RLD_ST</name>
+        <description>Reload Event Interrupt Flag.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>TO_ST</name>
+        <description>Time-Out Event Interrupt Flag.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>SRC</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>DST</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC_RLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>SRC_RLD</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST_RLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>DST_RLD</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT_RLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT_RLD</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. This bit should be set after the address reload registers have been programmed. This bit is automatically cleared to 0 when reload occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+<!--DMA DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral>
+   <name>EMAC</name>
+   <description>10/100 Ethernet MAC.</description>
+   <baseAddress>0x4004F000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>EMAC</name>
+    <description>EMAC IRQ</description>
+    <value>64</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CN</name>
+     <description>Network Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00</resetValue>
+     <fields>
+      <field>
+       <name>LB</name>
+       <description>Loopback.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>LBL</name>
+       <description>Loopback local.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RXEN</name>
+       <description>Receive Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TXEN</name>
+       <description>Transmit Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MPEN</name>
+       <description>Management Port Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLST</name>
+       <description>Clear Statistics.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>INCST</name>
+       <description>Increment Statistics.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>WREN</name>
+       <description>Write enable for statistics registers.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BP</name>
+       <description>Back pressure.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TXSTART</name>
+       <description>Transmission start.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TXHALT</name>
+       <description>Transmit halt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TXPF</name>
+       <description>Transmit pause frame.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TXZQPF</name>
+       <description>Transmit zero quantum pause frame.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG</name>
+     <description>Network Configuration Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>SPEED</name>
+       <description>Speed Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FULLDPLX</name>
+       <description>Full Duplex. If set to 1 the transmit block ignores the state of collision and carrier sense and allows Rx while transmitting.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BITRATE</name>
+       <description>Bit Rate. Writing 1 to this bit configures the interface for serial operation. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>JUMBOFR</name>
+       <description>Jumbo Frames. Writing 1 to this bit enables jumbo frames of up to 10,240 bytes to be accepted.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>COPYAF</name>
+       <description>Copy All Frames. If 1, all valid frames will be received.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>NOBC</name>
+       <description>No Broadcast. If 1, frames addressed to the broadcast address of all ones will not be received.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>MHEN</name>
+       <description>Multicast Hash Enable. If 1, multicast frames will be received when the 6 bit hash function of the destination address points to a bit that is set in the hash register.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>UHEN</name>
+       <description>Unicast Hash Enable. If 1, unicast frames will be received when the 6 bit hash function of the destination address points to a bit that is set in the hash register.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RXFR</name>
+       <description>Receive 1536 Byte Frames. Writing 1 to this bit means the MAC receives packets up to 1536 bytes in length. Normally the MAC rejects any packet above 1518 bytes</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MDCCLK</name>
+       <description>MDC Frequency. Set according to PCLK speed. This field determines by what number PCLK is divided to generate MDC.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>write-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>PCLK up to 20MHz</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>PCLK up to 40MHz</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>PCLK up to 80MHz</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>PCLK up to 160MHz</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RTTST</name>
+       <description>Retry Test. Must be set to zero for normal operation. If set to 1, the back-off between collisions is always one slot time.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PAUSEEN</name>
+       <description>Pause Enable. If 1, Ethernet packet transmission pauses when a valid pause packet is received.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>RXBUFFOFS</name>
+       <description>Receive buffer offset. These bits indicate the number of bytes by which the received data is offset from the start of the first receive buffer.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>RXLFCEN</name>
+       <description>Receive length field checking enable. If 1, packets with measured lengths shorter than their length fields are discarded. Packets containing a type ID in bytes 13 and 14 (length/type field &gt;=0600) are not counted as length errors.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>DCRXFCS</name>
+       <description>Discard receive FCS. If 1, the FCS field of received frames will not be copied to memory.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>HDPLXRXEN</name>
+       <description>Enable packets to be received in half-duplex mode while transmitting.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>IGNRXFCS</name>
+       <description>Ignore RX FCS. If 1, packets with FCS/CRC errors are not rejected and no FCS error statistics are counted. For normal operation, this bit must be set to 0.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Network Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>LINK</name>
+       <description>LINK pin status. Returns status of EMAC_LINK pin.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>MDIO</name>
+       <description>MDIO pin status. Returns status of the EMAC_MDIO pin. Use the PHY maintenance register for reading managed frames rather than this bit.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>IDLE</name>
+       <description>PHY management logic status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TX_ST</name>
+     <description>Transmit Status Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>UBR</name>
+       <description>Used Bit Read. Set when a transmit buffer descriptor is read with its used bit set. Write 1 to clear this bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>COLS</name>
+       <description>Collision Occurred. Set when a collision occurs. Write 1 to clear this bit.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RTYLIM</name>
+       <description>Retry Limit Exceeded. Set when the retry limit has been exceeded. Write 1 to clear this bit. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TXGO</name>
+       <description>Transmit Go. If 1, transmit is active.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BEMF</name>
+       <description>Buffers Exhausted Mid Frame. If the buffers run out during transmission of a frame then transmission stops, FCS shall be bad and EMAC_TXER asserted. Write 1 to clear this bit.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TXCMPL</name>
+       <description>Transmit Complete. Set when a frame has been transmitted. Write 1 to clear this bit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TXUR</name>
+       <description>Transmit Underrun. Set when the MAC transmit FIFO was read while was empty. If this happens the transmitter forces bad. Write 1 to clear this bit.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXBUF_PTR</name>
+     <description>Receive Buffer Queue Pointer Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RXBUF</name>
+       <description>Receive buffer queue pointer. Written with the address of the start of the receive queue, reads as a pointer to the current buffer being used.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>30</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXBUF_PTR</name>
+     <description>Transmit Buffer Queue Pointer Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>TXBUF</name>
+       <description>Transmit buffer queue pointer. Written with the address of the start of the transmit queue, reads as a pointer to the first buffer of the frame being transmitted or about to be transmitted.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>30</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RX_ST</name>
+     <description>Receive Status Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>BNA</name>
+       <description>Buffer Not Available. An attempt was made to get a new buffer and the pointer indicated that it was owned by the processor. The DMA will reread the pointer each time a new frame starts until a valid pointer is found. This bit will be set at each attempt that fails even if it has not had a successful pointer read since it has been cleared. Write 1 to clear this bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FR</name>
+       <description>Frame Received. One or more frames have been received and placed in memory. Write 1 to clear this bit.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RXOR</name>
+       <description>Receive Overrun. The DMA block was unable to store the receive frame to memory. Either because the AHB bus was not granted in time or because a not OK hresp was returned. The buffer will be recovered if this happens. Write 1 to clear this bit.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_ST</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>MPS</name>
+       <description>Management Packet Sent Interrupt Status. The PHY maintenance register has completed its operation. Cleared when read.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RXCMPL</name>
+       <description>Receive Complete Interrupt Status. Set when a frame has been stored in memory. Cleared when read.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RXUBR</name>
+       <description>RX Used Bit Read Interrupt Status. Set when a receive buffer descriptor is read with its used bit set. Cleared when read.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TXUBR</name>
+       <description>TX Used Bit Read Interrupt Status. Set when a transmit buffer descriptor is read with its used bit set. Cleared when read</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TXUR</name>
+       <description>Ethernet Transmit Underrun Interrupt Status. Set when the MAC transmit FIFO was read while was empty. If this happens the transmitter forces bad CRC and forces EMAC_TXER high. Cleared when read.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RLE</name>
+       <description>Retry Limit Exceeded Interrupt Status. Transmit error. Cleared when read.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TXERR</name>
+       <description>Transmit Buffers Exhausted In Mid-frame Interrupt Status. Transmit error. Cleared when read.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TXCMPL</name>
+       <description>Transmit Complete Interrupt Status. Set when a frame has been transmitted. Cleared when read.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>LC</name>
+       <description>Link Change Interrupt Status. Set when the external link signal changes. Cleared when read.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RXOR</name>
+       <description>Receive Overrun Interrupt Status. Set when the receive overrun status bit gets set. Cleared when read.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>HRESPNO</name>
+       <description>hresp not OK Interrupt Status. Set when the DMA block sees hresp not OK. Cleared when read.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PPR</name>
+       <description>Pause Packet Received Interrupt Status. Indicates a valid pause packet has been received. Cleared when read.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PTZ</name>
+       <description>Pause Time Zero Interrupt Status. Set when the MAC Pause Time register (MAC_PT) decrements to zero. Cleared when read.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>MPS</name>
+       <description>Management Packet Sent Interrupt Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>RXCMPL</name>
+       <description>Receive Complete Interrupt Enable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>RXUBR</name>
+       <description>RX Used Bit Read Interrupt Enable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TXUBR</name>
+       <description>TX Used Bit Read Interrupt Enable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TXUR</name>
+       <description>Ethernet Transmit Underrun Interrupt Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>RLE</name>
+       <description>Retry Limit Exceeded Interrupt Enable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TXERR</name>
+       <description>Transmit Buffers Exhausted In Mid-frame Interrupt Enable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TXCMPL</name>
+       <description>Transmit Complete Interrupt Enable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>LC</name>
+       <description>Link Change Interrupt Enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>RXOR</name>
+       <description>Receive Overrun Interrupt Enable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>HRESPNO</name>
+       <description>hresp not OK Interrupt Enable</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PPR</name>
+       <description>Pause Packet Received Interrupt Enable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PTZ</name>
+       <description>Pause Time Zero Interrupt Enable</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_DIS</name>
+     <description>Interrupt Disable Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>MPS</name>
+       <description>Management Packet Sent Interrupt Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>RXCMPL</name>
+       <description>Receive Complete Interrupt Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>RXUBR</name>
+       <description>RX Used Bit Read Interrupt Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TXUBR</name>
+       <description>TX Used Bit Read Interrupt Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TXUR</name>
+       <description>Ethernet Transmit Underrun Interrupt Disable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>RLE</name>
+       <description>Retry Limit Exceeded Interrupt Disable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TXERR</name>
+       <description>Transmit Buffers Exhausted In Mid-frame Interrupt Disable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TXCMPL</name>
+       <description>Transmit Complete Interrupt Disable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>LC</name>
+       <description>Link Change Interrupt Disable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>RXOR</name>
+       <description>Receive Overrun Interrupt Disable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>HRESPNO</name>
+       <description>hresp not OK Interrupt Disable</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PPR</name>
+       <description>Pause Packet Received Interrupt Disable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PTZ</name>
+       <description>Pause Time Zero Interrupt Disable</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_MASK</name>
+     <description>Interrupt Mask Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>MPS</name>
+       <description>Management Packet Sent Interrupt Mask</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RXCMPL</name>
+       <description>Receive Complete Interrupt Mask</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RXUBR</name>
+       <description>RX Used Bit Read Interrupt Mask</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TXUBR</name>
+       <description>TX Used Bit Read Interrupt Mask</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TXUR</name>
+       <description>Ethernet Transmit Underrun Interrupt Mask</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RLE</name>
+       <description>Retry Limit Exceeded Interrupt Mask</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TXERR</name>
+       <description>Transmit Buffers Exhausted In Mid-frame Interrupt Mask</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TXCMPL</name>
+       <description>Transmit Complete Interrupt Mask</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>LC</name>
+       <description>Link Change Interrupt Mask</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RXOR</name>
+       <description>Receive Overrun Interrupt Mask</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HRESPNO</name>
+       <description>hresp not OK Interrupt Mask</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>PPR</name>
+       <description>Pause Packet Received Interrupt Mask</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>PTZ</name>
+       <description>Pause Time Zero Interrupt Mask</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PHY_MT</name>
+     <description>PHY Maintenance Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>PHY Data. For a write operation this field is the data to be written to the PHY. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>REGADDR</name>
+       <description>Register Address. Specifies the register in the PHY to access.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PHYADDR</name>
+       <description>PHY Address. Specifies the PHY to access.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OP</name>
+       <description>Operation</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SOP</name>
+       <description>TBD </description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PT</name>
+     <description>Pause Time Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TIME</name>
+       <description>Pause Time. Stores the current value of the pause time register, which is decremented every 512 bit times.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PFR</name>
+     <description>Pause Frame Received OK.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>PFR</name>
+       <description>Pause Frames Received OK. A 16-bit register counting the number of good pause frames received. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FTOK</name>
+     <description>Frames Transmitted OK.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>FTOK</name>
+       <description>Frames Transmitted OK. A 32-bit register counting the number of frames successfully transmitted, i.e. no underrun and not too many retries.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCF</name>
+     <description>Single Collision Frames.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>SCF</name>
+       <description>Single Collision Frames. A 16-bit register counting the number of frames experiencing a single collision before being successfully transmitted, i.e. no underrun.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MCF</name>
+     <description>Multiple Collision Frames.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>MCF</name>
+       <description>Multiple Collision Frames. A 16-bit register counting the number of frames experiencing between two and fifteen collisions prior to being successfully transmitted, i.e. no underrun and not too many retries.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FROK</name>
+     <description>Fames Received OK.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>FROK</name>
+       <description>Frames Received OK. A 24-bit register counting the number of good packets received</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>24</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FCS_ERR</name>
+     <description>Frame Check Sequence Errors.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>FCSERR</name>
+       <description>Frame Check Sequence Errors.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ALGN_ERR</name>
+     <description>Alignment Errors.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ALGNERR</name>
+       <description>Alignment Errors. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DFTXF</name>
+     <description>Deferred Transmission Frames.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>DFTXF</name>
+       <description>Deferred Transmission Frames. A 16-bit register counting the number of packets experiencing deferral due to carrier sense being active on their first attempt at transmission</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LC</name>
+     <description>Late Collisions.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>LC</name>
+       <description>Late Collisions. An 8-bit register counting the number of packets that experience a collision after the slot time (512 bits) has expired.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EC</name>
+     <description>Excessive Collisions.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>EC</name>
+       <description>Excessive Collisions. An 8-bit register counting the number of packets that failed to be transmitted because they experienced 16 collisions.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TUR_ERR</name>
+     <description>Transmit Underrun Errors.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>TURERR</name>
+       <description>Transmit Underrun Error. An 8-bit register counting the number of packets not transmitted due to a transmit FIFO underrun.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CS_ERR</name>
+     <description>Carrier Sense Errors.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>CSERR</name>
+       <description>An 8-bit register counting the number of packets transmitted where carrier sense was not seen during transmission or where carrier sense was deasserted after being asserted in a transmit packet without collision (no underrun).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RR_ERR</name>
+     <description>Receive Resource Errors.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>RRERR</name>
+       <description>Receive Resource Errors. A 16 bit register counting the number of frames that were address matched but could not be copied to memory because no receive buffer was available.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ROR_ERR</name>
+     <description>Receive Overrun Errors.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>RORERR</name>
+       <description>Receive Overruns. An 8 bit register counting the number of frames that are address recognized but were not copied to memory due to a receive DMA overrun.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RS_ERR</name>
+     <description>Receive Symbol Errors.</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>RSERR</name>
+       <description>Receive Symbol Errors. An 8-bit register counting the number of packets that had EMAC_RXER asserted during reception.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EL_ERR</name>
+     <description>Excessive Length Errors.</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>ELERR</name>
+       <description>Excessive Length Errors. An 8-bit register counting the number of packets received exceeding 1518 bytes in length (1536 if RXFR is set in the MAC_CFG register;</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RJ</name>
+     <description>Receive Jabber.</description>
+     <addressOffset>0x7C</addressOffset>
+     <fields>
+      <field>
+       <name>RJERR</name>
+       <description>Receive Jabbers. An 8-bit register counting the number of packets received exceeding 1518 bytes in length (1536 if RXFR is set in the MAC_CFG register; </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>USF</name>
+     <description>Undersize Frames.</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>USF</name>
+       <description>Undersize Frames. An 8-bit register counting the number of packets received less than 64 bytes in length but do not have either a CRC error, an alignment error or a receive symbol error.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SQE_ERR</name>
+     <description>SQE Test Errors.</description>
+     <addressOffset>0x84</addressOffset>
+     <fields>
+      <field>
+       <name>SQEERR</name>
+       <description>SQE Test Errors. An 8-bit register counting the number of packets where collision was not asserted within 96 bit times (an interframe gap) of EMAC_TXEN being deasserted in half duplex mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLFM</name>
+     <description>Received Length Field Mismatch.</description>
+     <addressOffset>0x88</addressOffset>
+     <fields>
+      <field>
+       <name>RLFM</name>
+       <description>Receive length field mismatch </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TPF</name>
+     <description>Transmitted Pause Frames.</description>
+     <addressOffset>0x8C</addressOffset>
+     <fields>
+      <field>
+       <name>TPF</name>
+       <description>Transmitted Pause Frames. A 16-bit register counting the number of pause packets transmitted.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HASHL</name>
+     <description>Hash Register Bottom [31:0].</description>
+     <addressOffset>0x90</addressOffset>
+     <fields>
+      <field>
+       <name>HASH</name>
+       <description>Bits 31:0 of the hash address register. See Hash Addressing</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HASHH</name>
+     <description>Hash Register top [63:32].</description>
+     <addressOffset>0x94</addressOffset>
+     <fields>
+      <field>
+       <name>HASH</name>
+       <description>Bits 63:32 of the hash address register. See Hash Addressing</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SA1L</name>
+     <description>Specific Address 1 Bottom.</description>
+     <addressOffset>0x98</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>MAC Specific Address 1 [31:0]. Least significant bits of the MAC specific address 1, i.e. bits 31:0. This field is used for transmission of pause packets</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SA1H</name>
+     <description>Specific Address 1 Top.</description>
+     <addressOffset>0x9C</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>MAC Specific Address 1 [47:32]. Most significant bits of the MAC specific address 1, i.e. bits 47:32.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SA2L</name>
+     <description>Specific Address 2 Bottom.</description>
+     <addressOffset>0xA0</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>MAC Specific Address 2 [31:0]. Least significant bits of the MAC specific address 2, i.e. bits 31:0. This field is used for transmission of pause packets</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SA2H</name>
+     <description>Specific Address 2 Top.</description>
+     <addressOffset>0xA4</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>MAC Specific Address 2 [47:32]. Most significant bits of the MAC specific address 2, i.e. bits 47:32.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SA3L</name>
+     <description>Specific Address 3 Bottom.</description>
+     <addressOffset>0xA8</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>MAC Specific Address 3 [31:0]. Least significant bits of the MAC specific address 3, i.e. bits 31:0. This field is used for transmission of pause packets</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SA3H</name>
+     <description>Specific Address 3 Top.</description>
+     <addressOffset>0xAC</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>MAC Specific Address 3 [47:32]. Most significant bits of the MAC specific address 3, i.e. bits 47:32.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SA4L</name>
+     <description>Specific Address 4 Bottom.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>MAC Specific Address 4 [31:0]. Least significant bits of the MAC specific address 4, i.e. bits 31:0. This field is used for transmission of pause packets</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SA4H</name>
+     <description>Specific Address 4 Top.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>MAC Specific Address 4 [47:32]. Most significant bits of the MAC specific address 4, i.e. bits 47:32.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TID_CK</name>
+     <description>Type ID Checking.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>TID</name>
+       <description>Type ID Checking. For use in comparisons with received frames TypeID/Length field.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TPQ</name>
+     <description>Transmit Pause Quantum.</description>
+     <addressOffset>0xBC</addressOffset>
+     <fields>
+      <field>
+       <name>TPQ</name>
+       <description>Transmit Pause Quantum. Used in hardware generation of transmitted pause packets as value for pause quantum</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REV</name>
+     <description>Revision register.</description>
+     <addressOffset>0xFC</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REV</name>
+       <description>Revision Reference. Fixed two byte value specific to revision of design.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>PART</name>
+       <description>Part Reference. For Ethernet MAC design, this is fixed at 0x01.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--EMAC 10/100 Ethernet MAC.-->
+  <peripheral>
+   <name>SRCC</name>
+   <description>SPIX Cache Controller Registers.</description>
+   <baseAddress>0x40033000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>INFO</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SZ</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCH</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEM</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_ALLOC_EN</name>
+       <description>Write Allocate Enable. This bit only writable while the cache is disabled.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Write-no-allocate.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Write-allocate enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CWFST_DIS</name>
+       <description>Critical word first and streaming disable. This bit only writeable while the cache is disabled.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Critical word first and streaming disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Critical word first and streaming enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Cache Contents. Any time this register location is written (regardless of the data value), the cache controller immediately begins invalidating the entire contents of the cache memory. The cache will be in bypass mode until the invalidate operation is complete. System software can examine the Cache Ready bit (CACHE_CTRL.CACHE_RDY) to determine when the invalidate operation is complete. Note that it is not necessary to disable the cache controller prior to beginning this operation. Reads from this register always return 0.</description>
+     <addressOffset>0x0700</addressOffset>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate all cache contents.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SRCC SPIX Cache Controller Registers.-->
+  <peripheral>
+   <name>FLC</name>
+   <description>Flash Memory Control.</description>
+   <prependToName>FLSH_</prependToName>
+   <baseAddress>0x40029000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Flash_Controller</name>
+    <description>Flash Controller interrupt.</description>
+    <value>23</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ADDR</name>
+     <description>Flash Write Address.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address for next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Flash Clock Divide. The clock (PLL0) is divided by this value to generate a 1 MHz clock for Flash controller.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000064</resetValue>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Flash Clock Divide. The clock is divided by this value to generate a 1MHz clock for flash controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CN</name>
+     <description>Flash Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WR</name>
+       <description>Write.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="WR">
+       <name>ME</name>
+       <description>Mass Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="WR">
+       <name>PGE</name>
+       <description>Page Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERASE_CODE</name>
+       <description>Erase Code.  The ERASE_CODE must be set up property before erase operation can be initiated. These bits are automatically cleared after the operation is complete.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>erasePage</name>
+         <description>Enable Page Erase.</description>
+         <value>0x55</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>eraseAll</name>
+         <description>Enable Mass Erase. The debug port must be enabled.</description>
+         <value>0xAA</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PEND</name>
+       <description>Flash Pending.  When Flash operation is in progress (busy), Flash reads and writes will fail. When PEND is set, write to all Flash registers, with exception of the Flash interrupt register, are ignored.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>UNLOCK</name>
+       <description>Flash Unlock.  The correct unlock code must be written to these four bits before any Flash write or erase operation is allowed.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Flash Unlocked.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Flash Locked.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Flash Interrupt Register.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Flash Done Interrupt.  This bit is set to 1 upon Flash write or erase completion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AF</name>
+       <description>Flash Access Fail.  This bit is set when an attempt is made to write the flash while the flash is busy or the flash is locked. This bit can only be set to 1 by hardware.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONEIE</name>
+       <description>Flash Done Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DONEIE">
+       <name>AFIE</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECC_DATA</name>
+     <description>ECC Data Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>ECC_EVEN</name>
+       <description>Error Correction Code Odd Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>ECC_ODD</name>
+       <description>Error Correction Code Even Data.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA[%s]</name>
+     <description>Flash Write Data.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FLC Flash Memory Control.-->
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x40000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SYSCTRL</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>BSTAPEN</name>
+       <description>Boundary Scan TAP enable. When enabled, the JTAG port is connected to the Boundary Scan TAP. Otherwise, the port is connected to the ARM ICE function. This bit is reset by the POR. Reset value and access depend on the part number.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Boundary Scan TAP port disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Boundary Scan TAP port enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SBUSARB</name>
+       <description>System bus abritration scheme. These bits are used to select between Fixed-burst abritration and Round-Robin scheme. The Round-Robin scheme is selected by default. These bits are reset by the system reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>fix</name>
+         <description>Fixed Burst abritration.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>round</name>
+         <description>Round-robin scheme.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLASH0_PAGE_FLIP</name>
+       <description>Flips the Flash bottom and top halves. (Depending on the total flash size, each half is either 256K or 512K). Initiating a flash page flip will cause a flush of both the data buffer on the DCODE bus and the internal instruction buffer.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Physical layout matches logical layout.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>swapped</name>
+         <description>Bottom half mapped to logical top half and vice versa.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FPU_DIS</name>
+       <description>Cortex M4 Floating Point Disable This bit is used to disable the floating-point unit of the Cortex-M4.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0_FLUSH</name>
+       <description>Code Cache Flush. This bit is used to flush the code caches and the instruction buffer of the Cortex-M4. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRCC_FLUSH</name>
+       <description>Data Cache Flush. The system cache (s) will be flushed when this bit is set. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal System Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>System Cache is flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRCC_DIS</name>
+       <description>Data Cache Disable. The system cache (s) will be completely disabled when this bit is set.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CCHK</name>
+       <description>Compute ROM Checksum. This bit is self-cleared when calculation is completed. Once set, software clearing this bit is ignored and the bit will remain set until the operation is completed.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CHKRES</name>
+       <description>ROM Checksum Result. This bit is only valid when CHKRD=1.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pass</name>
+         <description>ROM Checksum Correct.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fail</name>
+         <description>ROM Checksum Fail.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>WDT0</name>
+       <description>Watchdog Timer Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO1</name>
+       <description>GPIO1 Reset. Setting this bit to 1 resets GPIO1 pins to their default states.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO2</name>
+       <description>GPIO2 Reset. Setting this bit to 1 resets GPIO2 pins to their default states.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR0</name>
+       <description>Timer0 Reset. Setting this bit to 1 resets Timer 0 blocks.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR1</name>
+       <description>Timer1 Reset. Setting this bit to 1 resets Timer 1 blocks.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR2</name>
+       <description>Timer2 Reset. Setting this bit to 1 resets Timer 2 blocks.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR3</name>
+       <description>Timer3 Reset. Setting this bit to 1 resets Timer 3 blocks.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR4</name>
+       <description>Timer4 Reset. Setting this bit to 1 resets Timer 4 blocks.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR5</name>
+       <description>Timer5 Reset. Setting this bit to 1 resets Timer 5 blocks.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART0</name>
+       <description>UART0 Reset. Setting this bit to 1 resets all UART 0 blocks.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART1</name>
+       <description>UART1 Reset. Setting this bit to 1 resets all UART 1 blocks.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI0</name>
+       <description>SPI0 Reset. Setting this bit to 1 resets all SPI 0 blocks.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI1</name>
+       <description>SPI1 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI2</name>
+       <description>SPI2 Reset. Setting this bit to 1 resets all SPI 2 blocks.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>I2C0</name>
+       <description>I2C0 Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>RTC</name>
+       <description>Real Time Clock Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>CRYPTO</name>
+       <description>Cryptographic Reset. Setting this bit to 1 resets the AES block, the SHA block and the DES block.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR6</name>
+       <description>Timer6 Reset. Setting this bit to 1 resets Timer 6 blocks.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR7</name>
+       <description>Timer7 Reset. Setting this bit to 1 resets Timer 7 blocks.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>CLCD</name>
+       <description>CLCD Reset. Setting this bit to 1 resets the CLCD block.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>USB</name>
+       <description>USB Reset. Setting this bit resets both USB blocks.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>ADC</name>
+       <description>Analog to Digital Reset.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART2</name>
+       <description>UART2 Reset. Setting this bit to 1 resets all UART 2 blocks.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SOFT</name>
+       <description>Soft Reset. Setting this bit to 1 resets everything except the CPU and the watchdog timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>PERIPH</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SYS</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>SYSCLK_DIV</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the PLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_SEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ISO</name>
+         <description>Internal Secondary Oscilatior Clock</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERFO</name>
+         <description>27MHz Crystal is used for the system clock.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INRO</name>
+         <description>8kHz Internal Nano Ring Oscillator is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>The internal Primary oscillator is used for the system clock.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBRO</name>
+         <description>The internal Baud Rate oscillator is used for the system clock.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERTCO</name>
+         <description> 32kHz is used for the system clock.</description>
+         <value>6</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_RDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CCD</name>
+       <description>Cryptographic clock divider</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>non_div</name>
+         <description>The cryptographic accelerator clock is running in non-divided mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div</name>
+         <description>The cryptographic accelerator clock is running in divided mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_EN</name>
+       <description>27MHz Crystal Oscillator Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>32kHz Crystal Oscillator Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>ISO_EN</name>
+       <description>60MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>IPO_EN</name>
+       <description>96MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>IBRO_EN</name>
+       <description>8MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_VS</name>
+       <description>7.3728MHz Internal Oscillator Voltage Source Select</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_RDY</name>
+       <description>27MHz Crystal Oscillator Ready</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERTCO_RDY</name>
+       <description>32kHz Crystal Oscillator Ready</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>ISO_RDY</name>
+       <description>60MHz ISO Ready.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>IPO_RDY</name>
+       <description>Internal Primary Oscillator Ready.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>IBRO_RDY</name>
+       <description>Internal Baud Rate Oscillator Ready.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>INRO_RDY</name>
+       <description>Internal Nano Ring Oscillator Low Frequency Reference Clock Ready.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PM</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This two bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>DeepSleep Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>backup</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO_WE</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>RTC_WE</name>
+       <description>RTC Alarm Wake Up Enable. This bit enables RTC alarm as wakeup source. If enabled, the desired RTC alarm must be configured via the RTC control registers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>USB_WE</name>
+       <description>USB Wake Up Enable. This bit enables USB activity as wakeup source.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>HA0_WE</name>
+       <description>Hardware Accelerator 0 Wake Up Enable. This bit enables USB activity as wakeup source.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>HA1_WE</name>
+       <description>Hardware Accelerator 1 Wake Up Enable. This bit enables USB activity as wakeup source.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_PD</name>
+       <description>Radio Frequency oscilator Crystal Power Down. This bit selects the power state in DEEPSLEEP mode. </description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ISO_PD</name>
+       <description>Internal Secondary Oscilator Power Down. This bit selects the power state in DEEPSLEEP mode. </description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IPO_PD</name>
+       <description>Internal Primary Oscilatory power down. This bit selects the power state in DEEPSLEEP mode. </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IBRO_PD</name>
+       <description>Internal Baud Rate Oscillator power down. This bit selects the power state in DEEPSLEEP mode. </description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NFC_PD</name>
+       <description>When set, the NFC radio becomes inactive when the upon entering DEEPSLEEP mode</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>XTALBP</name>
+       <description>XTAL Bypass </description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bypass</name>
+         <description>Bypass</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIV</name>
+     <description>Peripheral Clock Divider.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>PCF</name>
+       <description>These bits determine the clock frequency for the UART, I2C and Key Pad peripherals. These peripherals have an adaptive clock generator that dynamically adjusts the peripheral frequency based on the main system bus frequency. These bits are dynamically updated when the PLL0 is selected as the system clock source and are set by hardware. These bits determine the clock frequency for the UART, I2C and Key Pad peripherals. These peripherals have an adaptive clock generator that dynamically adjusts the peripheral frequency based on the main system bus frequency. These bits are dynamically updated when the PLL0 is selected as the system clock source and are set by hardware.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>96MHz</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>48MHz</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>24MHz</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12MHz</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6MHz</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3MHz</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PCFWEN</name>
+       <description>PCF Write Enable. This bit allows the PCF Register bits to be updated by Software.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>blocked</name>
+         <description>Writes to PCF are blocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Writes to PCF are allowed</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDHCFRQ</name>
+       <description>SDHC Clock Frequency. This bits defines the clock frequency of SDHC.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>48MHz</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>24MHz</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADCFRQ</name>
+       <description>ADC clock Frequency. These bits define the ADC clock frequency. FADC = FPCLK/ (ADCFRQ).</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>AON_CLKDIV</name>
+       <description>Always-ON (AON) domain CLock Divider. These bits define the AON domain clock divider.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div_4</name>
+         <description>PCLK divide by 4.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div_8</name>
+         <description>PCLK divide by 8.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div_16</name>
+         <description>PCLK divide by 16.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div_32</name>
+         <description>PCLK divide by 32.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0</name>
+       <description>GPIO0 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>GPIO1</name>
+       <description>GPIO1 Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>GPIO2</name>
+       <description>GPIO2 Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>USB</name>
+       <description>USB Disable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>CLCD</name>
+       <description>CLCD Disable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>DMA</name>
+       <description>DMA Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI0</name>
+       <description>SPI 0 Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI1</name>
+       <description>SPI 1 Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI2</name>
+       <description>SPI 2 Disable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART0</name>
+       <description>UART 0 Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART1</name>
+       <description>UART 1 Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C0</name>
+       <description>I2C 0 Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>CRYPTO</name>
+       <description>Crypto Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR0</name>
+       <description>Timer 0 Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR1</name>
+       <description>Timer 1 Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR2</name>
+       <description>Timer 2 Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR3</name>
+       <description>Timer 3 Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR4</name>
+       <description>Timer 4 Disable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR5</name>
+       <description>Timer 5 Disable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>KBD</name>
+       <description>Secure Keyboard Disable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>ADC</name>
+       <description>ADC Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR6</name>
+       <description>Timer 6 Disable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR7</name>
+       <description>Timer 7 Disable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>HTMR0</name>
+       <description>HTimer 0 Disable.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>HTMR1</name>
+       <description>HTimer 1 Disable.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C1</name>
+       <description>I2C 1 Disable.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>PT</name>
+       <description>PT Clock Disable.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPIXIP</name>
+       <description>SPI XiP Disable.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPIM</name>
+       <description>SPI XiP Master Controller Disable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCTRL</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 2.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>RAMWS_EN</name>
+       <description>SRAM Wait State Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM0LS_EN</name>
+       <description>System RAM 0 Light Sleep Mode.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM1LS_EN</name>
+       <description>System RAM 1 Light Sleep Mode.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM2LS_EN</name>
+       <description>System RAM 2 Light Sleep Mode.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM3LS_EN</name>
+       <description>System RAM 3 Light Sleep Mode.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM4LS_EN</name>
+       <description>System RAM 4 Light Sleep Mode.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM5LS_EN</name>
+       <description>System RAM 5 Light Sleep Mode.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>ICC0LS_EN</name>
+       <description>ICache RAM Light Sleep Mode.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>ICCXIPLS_EN</name>
+       <description>ICACHE-XIP RAM Light Sleep Mode.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>SRCCLS_EN</name>
+       <description>SysCache RAM Light Sleep Mode.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>CRYPTOLS_EN</name>
+       <description>CRYPTO RAM Light Sleep Mode.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>USBLS_EN</name>
+       <description>USB FIFO Light Sleep Mode.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>ROMLS_EN</name>
+       <description>ROM Light Sleep Mode.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMZ</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM Block 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM1</name>
+       <description>System RAM Block 1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM2</name>
+       <description>System RAM Block 2.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM3</name>
+       <description>System RAM Block 3.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM4</name>
+       <description>System RAM Block 4.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM5</name>
+       <description>System RAM Block 5.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM6</name>
+       <description>System RAM Block 6.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICC0</name>
+       <description>Instruction Cache.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICCXIP</name>
+       <description>Instruction Cache XIP Data and Tag Ram zeroizatoin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>SCACHEDATA</name>
+       <description>System Cache Data Ram Zeroization.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>SCACHETAG</name>
+       <description>System Cache Tag Zeroization.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>CRYPTO</name>
+       <description>Crypto (MAA) Memory.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>USBFIFO</name>
+       <description>USB FIFO Zeroization.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCCK</name>
+     <description>Smart Card Clock Control.</description>
+     <addressOffset>0x34</addressOffset>
+     <resetValue>0x00000000</resetValue>
+     <fields>
+      <field>
+       <name>SC0CD</name>
+       <description>Smart Card0 Clock Divider</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>SC1CD</name>
+       <description>Smart Card1 Clock Divider</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSST</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICELOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CODEINTERR</name>
+       <description>Code Integrity Error Flag. This bit indicates a code integrity error has occured in XiP interface. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>norm</name>
+         <description>Normal Operating Condition.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>code</name>
+         <description>Code Integrity Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCMEMF</name>
+       <description>System Cache Memory Fault Flag. This bit indicates a memory fault has occured in the System Cache while receiving data from the Hyperbus Interface.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>norm</name>
+         <description>Normal Operating Condition.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>memory</name>
+         <description>Memory Fault.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>I2C1</name>
+       <description>I2C1 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>PT</name>
+       <description>PT Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPIXIP</name>
+       <description>SPI XiP Master Reset.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>XSPIM</name>
+       <description>GSPI XiP Master Controller Reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>GPIO3</name>
+       <description>GPIO3 Reset.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SDHC</name>
+       <description>SDHC/SDIO Reset.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>OWIRE</name>
+       <description>OWIRE Reset.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>WDT1</name>
+       <description>WDT1 Reset.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPI3</name>
+       <description>SPI3 Reset.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AC</name>
+       <description>AC Reset.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPIXMEM</name>
+       <description>SPIXMEM Reset.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2C2</name>
+       <description>I2C2 Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>UART3</name>
+       <description>UART3 Reset.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>UART4</name>
+       <description>UART4 Reset.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>UART5</name>
+       <description>UART5 Reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>KBD</name>
+       <description>KBD Reset.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>ADC9</name>
+       <description>ADC9 Reset.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SC0</name>
+       <description>SC0 Reset.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SC1</name>
+       <description>SC1 Reset.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>NFC</name>
+       <description>NFC Reset.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>EMAC</name>
+       <description>EMAC Reset.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>PCIF</name>
+       <description>PCIF Reset.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>HTMR0</name>
+       <description>HTIMER0 Reset.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>HTMR1</name>
+       <description>HTIMER1 Reset.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>UART2</name>
+       <description>UART2 Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="UART2">
+       <name>TRNG</name>
+       <description>TRNG Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>WDT0</name>
+       <description>WDT0 Clock Disable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>WDT1</name>
+       <description>WDT1 Clock Disable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>GPIO3</name>
+       <description>GPIO3 Disable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SCACHE</name>
+       <description>System Cache Clock Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>HA0</name>
+       <description>Hardware Accelerator 0 Clock Disable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SDHC</name>
+       <description>SDHC/SDIO Clock Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>ICC0</name>
+       <description>ICache Clock Disable. </description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>ICCXIP</name>
+       <description>ICache XIP Clock Disable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>OWIRE</name>
+       <description>One-Wire Clock Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SPI3</name>
+       <description>SPI3 Clock Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SPIXIP</name>
+       <description>SPI-XIP Data Clock Disable</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>I2C2</name>
+       <description>I2C2 Clock Disable</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>UART3</name>
+       <description>UART3 Clock Disable</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>UART4</name>
+       <description>UART4 Clock Disable</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>UART5</name>
+       <description>UART5 Clock Disable</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>ADC9</name>
+       <description>ADC9 Clock Disable</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SC0</name>
+       <description>SC0 Clock Disable</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SC1</name>
+       <description>SC1 Clock Disable</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>NFC</name>
+       <description>NFC Clock Disable</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>EMAC</name>
+       <description>EMAC Clock Disable</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>HA1</name>
+       <description>Hardware Accelerator 1 Clock Disable</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>PCIF</name>
+       <description>PCIF Clock Disable</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVENTEN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Enable RXEV pin event. When this bit is set, a logic high of GPIO0[24] will cause an RXEV event to wake the CPU from WFE sleep mode. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO[25].</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REVISION</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSIE</name>
+     <description>System Status Interrupt Enable Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEUNLOCK</name>
+       <description>ARM ICE Unlock Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ICEUNLOCK">
+       <name>CIE</name>
+       <description>Code Integrity Error Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ICEUNLOCK">
+       <name>SCMF</name>
+       <description>System Cache Memory Fault Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPOCNT</name>
+     <description>IPO Warmup Count Register.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>WMUPCNT</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCERR</name>
+     <description>ECC Error Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>ECC System RAM1 Error Flag. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>ECC System RAM2 Error Flag. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>ECC System RAM3 Error Flag. Write 1 to clear.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM4</name>
+       <description>ECC System RAM4 Error Flag. Write 1 to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM5</name>
+       <description>ECC System RAM5 Error Flag. Write 1 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0</name>
+       <description>ECC Icache0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICSPIXF</name>
+       <description>ECC SFCC Instruction Cache Error Flag. Write 1 to clear.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH0</name>
+       <description>ECC Flash0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH1</name>
+       <description>ECC Flash1 Error Flag. Write 1 to clear.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCCED</name>
+     <description>ECC Not Double Error Detect Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>ECC System RAM1 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>ECC System RAM2 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>ECC System RAM3 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM4</name>
+       <description>ECC System RAM4 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM5</name>
+       <description>ECC System RAM5 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0</name>
+       <description>ECC Icache0 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICSPIXF</name>
+       <description>ECC IcacheXIP Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH0</name>
+       <description>ECC Flash0 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH1</name>
+       <description>ECC Flash1 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCIE</name>
+     <description>ECC IRQ Enable Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>ECC System RAM0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>ECC System RAM1 Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>ECC System RAM2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>ECC System RAM3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM4</name>
+       <description>ECC System RAM4 Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM5</name>
+       <description>ECC System RAM5 Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0</name>
+       <description>ECC Icache0 Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICSPIXF</name>
+       <description>ECC IcacheXIP Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH0</name>
+       <description>ECC Flash0 Interrupt Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH1</name>
+       <description>ECC Flash1 Interrupt Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCADDR</name>
+     <description>ECC Error Address Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>DATARAMADDR</name>
+       <description>ECC Error Address/DATA RAM Error Address</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>DATARAMBANK</name>
+       <description>ECC Error Address/DATA RAM Error Bank</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATARAMERR</name>
+       <description>DATA RAM ERROR</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMADDR</name>
+       <description>ECC Error Address/TAG RAM Error Address</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMBANK</name>
+       <description>ECC Error Address/TAG RAM Error Bank</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMERR</name>
+       <description>TAG RAM ERROR</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NFC_LDOCR</name>
+     <description>NFC LDO Control Register</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enabled the dedicated NFC LDO</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PULLD</name>
+       <description>Enabled the dedicated NFC LDO pin pulldown</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VSEL</name>
+       <description>Voltage Selection for NFC LDO</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>BYPEN</name>
+       <description>Bypass enable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DISCH</name>
+       <description>TBD</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_DLY</name>
+       <description>TBD</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYP_EN_DLY</name>
+       <description>TBD</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NFCLDO_DLY</name>
+     <description>NFC LDO Delay Register</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>BYPCNT</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>ENCNT</name>
+       <description>TBD</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCR Global Control Registers.-->
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x40008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN0</name>
+     <description>GPIO Function Enable Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_SET</name>
+     <description>GPIO Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_EN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_EN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_EN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_OUT bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_IN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_MODE</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_MODE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_POL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_POL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN_EN</name>
+     <description>GPIO Input Enable</description>
+     <addressOffset>0x30</addressOffset>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_EN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_EN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_STAT</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_INT_STAT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WAKE_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_DUAL_EDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_DUAL_EDGE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PAD_CFG1</name>
+     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PAD_CFG1</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PAD_CFG2</name>
+     <description>GPIO Input Mode Config 2. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PAD_CFG2</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_SET</name>
+     <description>GPIO Alternate Function Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN2</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_SET</name>
+     <description>GPIO Alternate Function 2 Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN2 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_CLR</name>
+     <description>GPIO Wake Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN2 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x7C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS</name>
+     <description>GPIO Drive Strength  Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ld</name>
+         <description>GPIO port pin is in low-drive mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hd</name>
+         <description>GPIO port pin is in high-drive mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PS</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VSSEL</name>
+     <description>GPIO Voltage Select.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GPIO0 Individual I/O for each GPIO-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO1</name>
+   <description>Individual I/O for each GPIO 1</description>
+   <baseAddress>0x40009000</baseAddress>
+   <interrupt>
+    <name>GPIO1</name>
+    <description>GPIO1 IRQ</description>
+    <value>25</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO1 Individual I/O for each GPIO 1-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO2</name>
+   <description>Individual I/O for each GPIO 2</description>
+   <baseAddress>0x4000A000</baseAddress>
+   <interrupt>
+    <name>GPIO2</name>
+    <description>GPIO2 IRQ</description>
+    <value>26</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO2 Individual I/O for each GPIO 2-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO3</name>
+   <description>Individual I/O for each GPIO 3</description>
+   <baseAddress>0x4000B000</baseAddress>
+   <interrupt>
+    <name>GPIO3</name>
+    <description>GPIO3 IRQ</description>
+    <value>58</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO3 Individual I/O for each GPIO 3-->
+  <peripheral>
+   <name>HTMR</name>
+   <description>High Speed Timer Module.</description>
+   <baseAddress>0x4001B000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0xFFF</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>HTimer</name>
+    <description>HTimer interrupt.</description>
+    <value>93</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>HTimer Long-Interval Counter. This register contains the 32 most significant bits of the counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>RTS</name>
+       <description>HTimer Long Interval Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>HTimer Short Interval Counter. This counter ticks every t_htclk (16.48uS). HTIMER_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>RTSS</name>
+       <description>HTimer Short Interval Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RAS</name>
+     <description>Long Interval Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>RAS</name>
+       <description>HTimer Long Interval Alarm. An Alarm is triggered when this value matches HTIMER_SEC[19:0]</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RSSA</name>
+     <description>HTimer Short Interval Alarm. This register contains the reload value for the short interval alarm, HTIMER_CTRL.alarm_ss_fl is raised on rollover.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>RSSA</name>
+       <description>This register contains the reload value for the short interval alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>HTimer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>HTEN</name>
+       <description>HTimer Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADE</name>
+       <description>Long Interval Alarm Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ASE</name>
+       <description>Short Interval Alarm Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>HTimer Busy. This bit is set to 1 by hardware when changes to HTimer registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>HTimer Ready. This bit is set to 1 by hardware when the HTimer count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the HTimer count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDYE</name>
+       <description>HTimer Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ALDF</name>
+       <description>Long Interval Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ALSF</name>
+       <description>Short Interval Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WE</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical HTimer bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--HTMR High Speed Timer Module.-->
+  <peripheral derivedFrom="HTMR">
+   <name>HTMR1</name>
+   <description>High Speed Timer Module. 1</description>
+   <baseAddress>0x4001C000</baseAddress>
+   <interrupt>
+    <name>HTMR1</name>
+    <description>HTMR1 IRQ</description>
+    <value>94</value>
+   </interrupt>
+  </peripheral>
+<!--HTMR1 High Speed Timer Module. 1-->
+  <peripheral>
+   <name>I2C0</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>I2C</groupName>
+   <baseAddress>0x4001D000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2C0</name>
+    <description>I2C0 IRQ</description>
+    <value>13</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>I2C_EN</name>
+       <description>I2C Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable I2C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable I2C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST</name>
+       <description>Master Mode Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave_mode</name>
+         <description>Slave Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master_mode</name>
+         <description>Master Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GEN_CALL_ADDR</name>
+       <description>General Call Address Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Ignore Gneral Call Address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Acknowledge general call address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_MODE</name>
+       <description>Interactive Receive Mode.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interactive Receive Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interactive Receive Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_MODE_ACK</name>
+       <description>Data Acknowledge. This bit defines the acknowledge bit returned by the I2C receiver while IRXM = 1 HW forces ACK to 0 when IRXM = 0.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ack</name>
+         <description>return ACK (pulling SDA LOW).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>return NACK (leaving SDA HIGH).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_OUT</name>
+       <description>SCL Output. This bits control SCL output when SWOE =1.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_scl_low</name>
+         <description>Drive SCL low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_scl</name>
+         <description>Release SCL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDA_OUT</name>
+       <description>SDA Output. This bits control SDA output when SWOE = 1. </description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_sda_low</name>
+         <description>Drive SDA low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_sda</name>
+         <description>Release SDA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL</name>
+       <description>SCL status. This bit reflects the logic gate of SCL signal. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDA</name>
+       <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SW_OUT_EN</name>
+       <description>Software Output Enable.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>outputs_disable</name>
+         <description>I2C Outputs SCLO and SDAO disabled. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputs_enable</name>
+         <description>I2C Outputs SCLO and SDAO enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read. This bit reflects the R/W bit of an address match (AMI = 1) or general call match (GCI = 1). This bit is valid 3 cycles after the relevant interrupt bit is set.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_CLK_STRETCH_DIS</name>
+       <description>This bit will disable slave clock stretching when set.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Slave clock stretching enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Slave clock stretching disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_PP_MODE</name>
+       <description>SCL Push-Pull Mode. This bit controls whether SCL is operated in a the I2C standard open-drain mode, or in a non-standard push-pull mode where the Hi-Z output isreplaced with Drive-1. The non-standard mode should only be used when operating as a master and communicating with slaves that are guaranteed to never drive SCL low. </description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Standard open-drain operation:
+					drive low for 0, Hi-Z for 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Non-standard push-pull operation:
+					drive low for 0, drive high for 1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BUS</name>
+       <description>Bus Status.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>I2C Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>I2C Bus Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EMPTY</name>
+       <description>RX empty.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX Full.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX Empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>TX Full.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLK_MODE</name>
+       <description>Clock Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_actively_driving_scl_clock</name>
+         <description>Device not actively driving SCL clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>actively_driving_scl_clock</name>
+         <description>Device operating as master and actively driving SCL clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL0</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_MODE</name>
+       <description>Interactive Receive Interrupt.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GEN_CALL_ADDR</name>
+       <description>Slave General Call Address Match Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave Address Match Interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>Receive Threshold Interrupt. This bit is automaticcaly cleared when RX_FIFO is below the threshold level.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. RX_FIFO equal or more bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THRESH</name>
+       <description>Transmit Threshold Interrupt. This bit is automaticcaly cleared when TX_FIFO is above the threshold level.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP Interrupt.</description>
+       <bitRange>[6:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Address Acknowledge Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ER</name>
+       <description>Arbritation error Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ER</name>
+       <description>timeout Error Interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ER</name>
+       <description>Address NACK Error Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ER</name>
+       <description>Data NACK Error Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DO_NOT_RESP_ER</name>
+       <description>Do Not Respond Error Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ER</name>
+       <description>Start Error Interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ER</name>
+       <description>Stop Error Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCK_OUT</name>
+       <description>Transmit Lock Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>TX FIFO not locked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>TX FIFO locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no_match</name>
+         <description>No address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>match</name>
+         <description>Address match.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no_match</name>
+         <description>No address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>match</name>
+         <description>Address match.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN0</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when DONE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_MODE</name>
+       <description>Description not available.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when RX_MODE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GEN_CALL_ADDR</name>
+       <description>Slave mode general call address match received input enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when GEN_CTRL_ADDR = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave mode incoming address match interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when ADDR_MATCH = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>RX FIFO Above Treshold Level Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THRESH</name>
+       <description>TX FIFO Below Treshold Level Interrupt Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Stop Interrupt Enable</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when STOP = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Received Address ACK from Slave Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ER</name>
+       <description>Master Mode Arbitration Lost Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ER</name>
+       <description>Timeout Error Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Master Mode Address NACK Received Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ER</name>
+       <description>Master Mode Data NACK Received Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DO_NOT_RESP_ER</name>
+       <description>Slave Mode Do Not Respond Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ER</name>
+       <description>Out of Sequence START condition detected interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ER</name>
+       <description>Out of Sequence STOP condition detected interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCK_OUT</name>
+       <description>TX FIFO Locked Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL1</name>
+     <description>Interrupt Status Register 1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OVERFLOW</name>
+       <description>Receiver Overflow Interrupt. When operating as a slave receiver, this bit is set when you reach the first data bit and the RX FIFO and shift register are both full.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UNDERFLOW</name>
+       <description>Transmit Underflow Interrupt. When operating as a slave transmitter, this bit is set when you reach the first data bit and the TX FIFO is empty and the master is still asking for more data (i.e the master hasn't sent a NACK yet).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Status Flag.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_detected</name>
+         <description>START condition not detected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>detected</name>
+         <description>START condition detected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN1</name>
+     <description>Interrupt Staus Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_OVERFLOW</name>
+       <description>Receiver Overflow Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UNDERFLOW</name>
+       <description>Transmit Underflow Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable START condition interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable START condition interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO_LEN</name>
+     <description>FIFO Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RX_LEN</name>
+       <description>Receive FIFO Length.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_LEN</name>
+       <description>Transmit FIFO Length.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RX_CTRL0</name>
+     <description>Receive Control Register 0.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>DNR</name>
+       <description>Do Not Respond.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Always respond to address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>not_respond_rx_fifo_empty</name>
+         <description>Do not respond to address match when RX_FIFO is not empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Receive FIFO Flush. This bit is automatically cleared to 0 after the operation. Setting this bit to 1 will affect RX_FIFO status.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush RX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>Receive FIFO Threshold. These bits define the RX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RX_CTRL1</name>
+     <description>Receive Control Register 1.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>RX_CNT</name>
+       <description>Receive Count Bits. These bits define the number of bytes to be received in a transaction, except for the case RXCNT = 0. RXCNT = 0 means 256 bytes to be received in a transaction.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>RX_FIFO</name>
+       <description>Receive FIFO Count. These bits reflect the number of byte in the RX_FIFO. These bits are flushed when I2CEN = 0.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TX_CTRL0</name>
+     <description>Transmit Control Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>TX_PRELOAD</name>
+       <description>Transmit FIFO Preaload Mode. Setting this bit will allow for high speed application to preload the transmit FIFO prior to Slave Address Match.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TX_READY_MODE</name>
+       <description>Transmit FIFO Ready Manual Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW control of I2CTXRDY enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW control of I2CTXRDY disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_AMGC_AFD</name>
+       <description>TX FIFO General Call Address Match Auto Flush Disable.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_AMW_AFD</name>
+       <description>TX FIFO Slave Address Match Write Auto Flush Disable.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_AMR_AFD</name>
+       <description>TX FIFO Slave Address Match Read Auto Flush Disable.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_NACK_AFD</name>
+       <description>TX FIFO received NACK Auto Flush Disable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Transmit FIFO Flush. This bit is automatically cleared to 0 after the operation.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush TX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THRESH</name>
+       <description>Transmit FIFO Threshold. These bits define the TX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TX_CTRL1</name>
+     <description>Transmit Control Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>TX_READY</name>
+       <description>Transmit FIFO Preload Ready.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TX_FIFO</name>
+       <description>Transmit FIFO Count. These bits reflect the number of bytes in the TX_FIFO.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MASTER_CTRL</name>
+     <description>Master Control Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Setting this bit to 1 will start a master transfer.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>RESTART</name>
+       <description>Setting this bit to 1 will generate a repeated START.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Setting this bit to 1 will generate a STOP condition.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>SL_EX_ADDR</name>
+       <description>Slave Extend Address Select.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_LO</name>
+     <description>Clock Low Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_LO</name>
+       <description>Clock low. In master mode, these bits define the SCL low period. In slave mode, these bits define the time SCL will be held low after data is outputted.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_HI</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_HI</name>
+       <description>Clock High. In master mode, these bits define the SCL high period.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TIMEOUT</name>
+     <description>Timeout Register</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>TO</name>
+       <description>Timeout</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLAVE_ADDR</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>SLAVE_ADDR</name>
+       <description>Slave Address.</description>
+       <bitRange>[9:0]</bitRange>
+      </field>
+      <field>
+       <name>EX_ADDR</name>
+       <description>Extended Address Select.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2C0 Inter-Integrated Circuit.-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C1</name>
+   <description>Inter-Integrated Circuit. 1</description>
+   <baseAddress>0x4001E000</baseAddress>
+   <interrupt>
+    <name>I2C1</name>
+    <description>I2C1 IRQ</description>
+    <value>36</value>
+   </interrupt>
+  </peripheral>
+<!--I2C1 Inter-Integrated Circuit. 1-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C2</name>
+   <description>Inter-Integrated Circuit. 2</description>
+   <baseAddress>0x4001F000</baseAddress>
+   <interrupt>
+    <name>I2C2</name>
+    <description>I2C2 IRQ</description>
+    <value>62</value>
+   </interrupt>
+  </peripheral>
+<!--I2C2 Inter-Integrated Circuit. 2-->
+  <peripheral>
+   <name>ICC0</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x4002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CACHE_ID</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CCHID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCFG</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCHSZ</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEMSZ</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CACHE_CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>invalid</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ICC0 Instruction Cache Controller Registers-->
+  <peripheral>
+   <name>OWM</name>
+   <description>1-Wire Master Interface.</description>
+   <baseAddress>0x4003D000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>OneWire</name>
+    <value>67</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CFG</name>
+     <description>1-Wire Master Configuration.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>long_line_mode</name>
+       <description>Long Line Mode.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>force_pres_det</name>
+       <description>Force Line During Presence Detect.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_en</name>
+       <description>Bit Bang Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_mode</name>
+       <description>Provide an extra output control to control an external pullup.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_enable</name>
+       <description>Enable External Pullup.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>single_bit_mode</name>
+       <description>Enable Single Bit TX/RX Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>overdrive</name>
+       <description>Enables overdrive speed for 1-Wire operations.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>int_pullup_enable</name>
+       <description>Enable intenral pullup.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_DIV_1US</name>
+     <description>1-Wire Master Clock Divisor.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>divisor</name>
+       <description>Clock Divisor for 1Mhz.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL_STAT</name>
+     <description>1-Wire Master Control/Status.</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>start_ow_reset</name>
+       <description>Start OW Reset.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>sra_mode</name>
+       <description>SRA Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_oe</name>
+       <description>Bit Bang Output Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ow_input</name>
+       <description>OW Input State.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>od_spec_mode</name>
+       <description>Overdrive Spec Mode.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>presence_detect</name>
+       <description>Presence Pulse Detected.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>1-Wire Master Data Buffer.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>tx_rx</name>
+       <description>TX/RX Buffer.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>1-Wire Master Interrupt Flags.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>TX Data Empty Interrupt Flag.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>RX Data Ready Interrupt Flag</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Flag.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Flag.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>1-Wire Master Interrupt Enables.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>Tx Data Empty Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>Rx Data Ready Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Enable.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--OWM 1-Wire Master Interface.-->
+  <peripheral>
+   <name>PTG</name>
+   <description>Pulse Train Generation</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0020</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>PT</name>
+    <description>Pulse Train IRQ</description>
+    <value>59</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ENABLE</name>
+     <description>Global Enable/Disable Controls for All Pulse Trains</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Enable/Disable control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Enable/Disable control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Enable/Disable control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Enable/Disable control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Enable/Disable control for PT4</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Enable/Disable control for PT5</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Enable/Disable control for PT6</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Enable/Disable control for PT7</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESYNC</name>
+     <description>Global Resync (All Pulse Trains) Control</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Resync control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Resync control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Resync control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Resync control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Resync control for PT4</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Resync control for PT5</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Resync control for PT6</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Resync control for PT7</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Pulse Train Interrupt Flags</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Flag</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Flag</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Flag</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Pulse Train Interrupt Enable/Disable</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_EN</name>
+     <description>Pulse Train Global Safe Enable.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_DIS</name>
+     <description>Pulse Train Global Safe Disable.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTFL</name>
+     <description>Pulse Train Ready Interrupt Flags</description>
+     <addressOffset>0x0018</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Flag</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Flag</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Flag</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTEN</name>
+     <description>Pulse Train Ready Interrupt Enable/Disable</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PTG Pulse Train Generation-->
+  <peripheral>
+   <name>PT</name>
+   <description>Pulse Train</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C020</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0010</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RATE_LENGTH</name>
+     <description>Pulse Train Configuration</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>rate_control</name>
+       <description>Pulse Train Enable and Rate Control. Set to 0 to disable the Pulse Train.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>27</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>mode</name>
+       <description>Pulse Train Output Mode/Train Length</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>32_BIT</name>
+         <description>Pulse train, 32 bit pattern.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SQUARE_WAVE</name>
+         <description>Square wave mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_BIT</name>
+         <description>Pulse train, 2 bit pattern.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_BIT</name>
+         <description>Pulse train, 3 bit pattern.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_BIT</name>
+         <description>Pulse train, 4 bit pattern.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5_BIT</name>
+         <description>Pulse train, 5 bit pattern.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_BIT</name>
+         <description>Pulse train, 6 bit pattern.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7_BIT</name>
+         <description>Pulse train, 7 bit pattern.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_BIT</name>
+         <description>Pulse train, 8 bit pattern.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9_BIT</name>
+         <description>Pulse train, 9 bit pattern.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_BIT</name>
+         <description>Pulse train, 10 bit pattern.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11_BIT</name>
+         <description>Pulse train, 11 bit pattern.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_BIT</name>
+         <description>Pulse train, 12 bit pattern.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13_BIT</name>
+         <description>Pulse train, 13 bit pattern.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14_BIT</name>
+         <description>Pulse train, 14 bit pattern.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15_BIT</name>
+         <description>Pulse train, 15 bit pattern.</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_BIT</name>
+         <description>Pulse train, 16 bit pattern.</description>
+         <value>16</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>17_BIT</name>
+         <description>Pulse train, 17 bit pattern.</description>
+         <value>17</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>18_BIT</name>
+         <description>Pulse train, 18 bit pattern.</description>
+         <value>18</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>19_BIT</name>
+         <description>Pulse train, 19 bit pattern.</description>
+         <value>19</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>20_BIT</name>
+         <description>Pulse train, 20 bit pattern.</description>
+         <value>20</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>21_BIT</name>
+         <description>Pulse train, 21 bit pattern.</description>
+         <value>21</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>22_BIT</name>
+         <description>Pulse train, 22 bit pattern.</description>
+         <value>22</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>23_BIT</name>
+         <description>Pulse train, 23 bit pattern.</description>
+         <value>23</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>24_BIT</name>
+         <description>Pulse train, 24 bit pattern.</description>
+         <value>24</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>25_BIT</name>
+         <description>Pulse train, 25 bit pattern.</description>
+         <value>25</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>26_BIT</name>
+         <description>Pulse train, 26 bit pattern.</description>
+         <value>26</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>27_BIT</name>
+         <description>Pulse train, 27 bit pattern.</description>
+         <value>27</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>28_BIT</name>
+         <description>Pulse train, 28 bit pattern.</description>
+         <value>28</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>29_BIT</name>
+         <description>Pulse train, 29 bit pattern.</description>
+         <value>29</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30_BIT</name>
+         <description>Pulse train, 30 bit pattern.</description>
+         <value>30</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>31_BIT</name>
+         <description>Pulse train, 31 bit pattern.</description>
+         <value>31</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRAIN</name>
+     <description>Write the repeating bit pattern that is shifted out, LSB first, when configured in Pulse Train mode. See PT_RATE_LENGTH.mode for setting the length.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>LOOP</name>
+     <description>Pulse Train Loop Count</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>count</name>
+       <description>Number of loops for this pulse train to repeat.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>delay</name>
+       <description>Delay between loops of the Pulse Train in PT Peripheral Clock cycles</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>12</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESTART</name>
+     <description> Pulse Train Auto-Restart Configuration.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt_x_select</name>
+       <description>Auto-Restart PT X Select</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_x_loop_exit</name>
+       <description>Enable Auto-Restart on PT X Loop Exit</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt_y_select</name>
+       <description>Auto-Restart PT Y Select</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_y_loop_exit</name>
+       <description>Enable Auto-Restart on PT Y Loop Exit</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PT Pulse Train-->
+  <peripheral derivedFrom="PT">
+   <name>PT1</name>
+   <description>Pulse Train 1</description>
+   <baseAddress>0x4003C040</baseAddress>
+  </peripheral>
+<!--PT1 Pulse Train 1-->
+  <peripheral derivedFrom="PT">
+   <name>PT2</name>
+   <description>Pulse Train 2</description>
+   <baseAddress>0x4003C060</baseAddress>
+  </peripheral>
+<!--PT2 Pulse Train 2-->
+  <peripheral derivedFrom="PT">
+   <name>PT3</name>
+   <description>Pulse Train 3</description>
+   <baseAddress>0x4003C080</baseAddress>
+  </peripheral>
+<!--PT3 Pulse Train 3-->
+  <peripheral derivedFrom="PT">
+   <name>PT4</name>
+   <description>Pulse Train 4</description>
+   <baseAddress>0x4003C0A0</baseAddress>
+  </peripheral>
+<!--PT4 Pulse Train 4-->
+  <peripheral derivedFrom="PT">
+   <name>PT5</name>
+   <description>Pulse Train 5</description>
+   <baseAddress>0x4003C0C0</baseAddress>
+  </peripheral>
+<!--PT5 Pulse Train 5-->
+  <peripheral derivedFrom="PT">
+   <name>PT6</name>
+   <description>Pulse Train 6</description>
+   <baseAddress>0x4003C0E0</baseAddress>
+  </peripheral>
+<!--PT6 Pulse Train 6-->
+  <peripheral derivedFrom="PT">
+   <name>PT7</name>
+   <description>Pulse Train 7</description>
+   <baseAddress>0x4003C100</baseAddress>
+  </peripheral>
+<!--PT7 Pulse Train 7-->
+  <peripheral derivedFrom="PT">
+   <name>PT8</name>
+   <description>Pulse Train 8</description>
+   <baseAddress />
+  </peripheral>
+<!--PT8 Pulse Train 8-->
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x40006800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>LPCN</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAMRET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>OVR</name>
+       <description>Operating Voltage Range</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_9V</name>
+         <description>0.9V 24MHz</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0V</name>
+         <description>1.0V 48MHz</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1V</name>
+         <description>1.1V 96MHz</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RETREG_EN</name>
+       <description>Retention Regulator Enable. This bit controls the retention regulator in BACKUP mode. </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FASTWK_EN</name>
+       <description>Fast Wake-Up Mode. This bit enables fast wake-up from DeepSleep mode. (5uS typical). </description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BG_DIS</name>
+       <description>Bandgap OFF. This controls the System Bandgap in DeepSleep mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>Bandgap is always ON.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>Bandgap is OFF in DeepSleep mode (default).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREPOR_DIS</name>
+       <description>VCore Power-On Reset Monitor Disable. This bit controls the Power-On Reset monitor on VDDC supply in DeepSleep and BACKUP mode.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDO_DIS</name>
+       <description>Disable Main LDO</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VCOREMON_DIS</name>
+       <description>Vcore Monitor Disable. This bit controls the power monitor on the VCore supply in all operating modes.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VRTCMON_DIS</name>
+       <description>VRTC Monitor Disable. This bit controls the power monitor on the Always-On Supply in all operating modes.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDAMON_DIS</name>
+       <description>VDDA Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDIOMON_DIS</name>
+       <description>VDDIO Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDIOHMON_DIS</name>
+       <description>VFDDIOH Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PORVDDBMON_DIS</name>
+       <description>VDDB Power-On Reset Monitor Disable. This bit controls the Power-On Reset monitor on VDDB supply in all operating mods.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST0</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO0.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN0</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register derivedFrom="LPWKST0">
+     <name>LPWKST1</name>
+     <description>Low Power I/O Wakeup Status Register 1. This register indicates the low power wakeup status for GPIO1.</description>
+     <addressOffset>0x0C</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN1</name>
+     <description>Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup functionality for GPIO1.</description>
+     <addressOffset>0x10</addressOffset>
+    </register>
+    <register derivedFrom="LPWKST0">
+     <name>LPWKST2</name>
+     <description>Low Power I/O Wakeup Status Register 2. This register indicates the low power wakeup status for GPIO2.</description>
+     <addressOffset>0x14</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN2</name>
+     <description>Low Power I/O Wakeup Enable Register 2. This register enables low power wakeup functionality for GPIO2.</description>
+     <addressOffset>0x18</addressOffset>
+    </register>
+    <register derivedFrom="LPWKST0">
+     <name>LPWKST3</name>
+     <description>Low Power I/O Wakeup Status Register 3. This register indicates the low power wakeup status for GPIO3.</description>
+     <addressOffset>0x1C</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN3</name>
+     <description>Low Power I/O Wakeup Enable Register 3. This register enables low power wakeup functionality for GPIO3.</description>
+     <addressOffset>0x20</addressOffset>
+    </register>
+    <register>
+     <name>LPPWKST</name>
+     <description>Low Power Peripheral Wakeup Status Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>USBLS</name>
+       <description>USB UTMI Linestate Detect Wakeup Flag (write one to clear). One or both of these bits will be set when the USB bus activity causes the linestate to change and the device to wake while USB wakeup is enabled using PMLUSBWKEN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>USBVBUS</name>
+       <description>USB VBUS Detect Wakeup Flag (write one to clear). This bit will be set when the USB power supply is powered on or powered off.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HA0</name>
+       <description>Hardware Accelerator 0 Detect Wakeup Status Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BBMOD</name>
+       <description>Battery Back Wakeup Flag (write one to clear). This bit will be set when exiting Battery Backup Mode.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST</name>
+       <description>Reset Detect Wakeup Flag (write one to clear). This bit will be set when the external reset causes wakeup</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SDMA1</name>
+       <description>Smart DMA (1) Detect Wakeup Flag (write one to clear). This bit will be set when the SDMA IRQ transitions from low to high or high to low</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWKEN</name>
+     <description>Low Power Peripheral Wakeup Enable Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>USBLS</name>
+       <description>USB UTMI Linestate Detect Wakeup Enable. These bits allow wakeup from the corresponding USB linestate signal (s) on transition (s) from low to high or high to low when PM.USBWKEN is set.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>USBVBUS</name>
+       <description>USB VBUS Detect Wakeup Enable. This bit allows wakeup from the USB power supply on or off status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SDMA0</name>
+       <description>Smart DMA Wakeup Enable. This bit allows wakeup from the Smart DMA IRQ.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SDMA1</name>
+       <description>Smart DMA Wakeup Enable. This bit allows wakeup from the Smart DMA IRQ.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPMEMSD</name>
+     <description>Low Power Memory Shutdown Control.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM block 0 Shut Down.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>System RAM block 1 Shut Down.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>System RAM block 2 Shut Down.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>System RAM block 3 Shut Down.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM4</name>
+       <description>System RAM block 4 Shut Down.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM5</name>
+       <description>System RAM block 5 Shut Down.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHE</name>
+       <description>Instruction Cache RAM Shut Down.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHEXIP</name>
+       <description>XiP Instruction Cache RAM Shut Down.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRCC</name>
+       <description>System Cache RAM Shut Down.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USBFIFO</name>
+       <description>USB FIFO Shut Down.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROM</name>
+       <description>ROM Shut Down.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPVDDPD</name>
+     <description>Low Power VDD Domain Power Down Control.</description>
+     <addressOffset>0x44</addressOffset>
+    </register>
+    <register>
+     <name>GP0</name>
+     <description>General Purpose Register 0</description>
+     <addressOffset>0x48</addressOffset>
+    </register>
+    <register>
+     <name>GP1</name>
+     <description>General Purpose Register 1</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--PWRSEQ Power Sequencer / Low Power Control Register.-->
+  <peripheral>
+   <name>RTC</name>
+   <description>Real Time Clock and Alarm.</description>
+   <baseAddress>0x40006000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>RTC</name>
+    <description>RTC interrupt.</description>
+    <value>3</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC</name>
+       <description>Sub-Seconds Counter (12-bit).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TODA</name>
+     <description>Time-of-day Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-day Alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSECA</name>
+     <description>RTC sub-second alarm.  This register contains the reload value for the sub-second alarm.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>This register contains the reload value for the sub-second alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>RTC Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>RTCE</name>
+       <description>Real Time Clock Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADE</name>
+       <description>Alarm Time-of-Day Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ASE</name>
+       <description>Alarm Sub-second Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>RTC Busy. This bit is set to 1 by hardware when changes to RTC registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>RTC Ready. This bit is set to 1 by hardware when the RTC count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the RTC count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDYE</name>
+       <description>RTC Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ALDF</name>
+       <description>Time-of-Day Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ALSF</name>
+       <description>Sub-second Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQE</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FT</name>
+       <description>Frequency Output Selection. When SQE=1, these bits specify the output frequency on the SQW pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq1Hz</name>
+         <description>1 Hz (Compensated).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq512Hz</name>
+         <description>512 Hz (Compensated).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq4KHz</name>
+         <description>4 KHz.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACRE</name>
+       <description>Asynchronous Counter Read Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>sync</name>
+         <description>Synchronous.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>async</name>
+         <description>Asynchronous.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WE</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical RTC bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ignore</name>
+         <description>Ignored.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>allow</name>
+         <description>Allowed.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIM</name>
+     <description>RTC Trim Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>RTC Trim. This register contains the 2's complement value that specifies the trim resolution. Each increment or decrement of the bit adds or subtracts 1ppm at each 4KHz clock value, with a maximum correction of +/- 127ppm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>COUNT</name>
+       <description>VBAT Timer Value. When RTC is running off of VBAT, this field is incremented every 32 seconds.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>RTC Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>BYPASS</name>
+       <description>RTC Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>32KOUT</name>
+       <description>RTC 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--RTC Real Time Clock and Alarm.-->
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x40000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SISTAT</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>MAGIC</name>
+       <description>Magic Word Validation.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>magicNotSet</name>
+         <description>Magic word was not set (OTP has not been initialized properly).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>magicSet</name>
+         <description>Magic word was set (OTP contains valid settings).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRCERR</name>
+       <description>CRC Error Status.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No CRC errors occurred during the read of the OTP memory block.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>A CRC error occurred while reading the OTP. The address of the failure location in the OTP memory is stored in the ERRADDR register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ERRADDR</name>
+     <description>Read-only field set by the SIB block if a CRC error occurs during the read of the OTP memory. Contains the failing address in OTP memory (when CRCERR equals 1).</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ERRADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FSTAT</name>
+     <description>funcstat register.</description>
+     <addressOffset>0x100</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>FPU</name>
+       <description>FPU Function.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USB</name>
+       <description>USB Device.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADC</name>
+       <description>10-bit Sigma Delta ADC.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>XIP</name>
+       <description>XiP function.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDHC</name>
+       <description>SDHC function.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SMPHR</name>
+       <description>SMPHR function.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRCC</name>
+       <description>SRCC function.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADC9</name>
+       <description>ADC9 function.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SC</name>
+       <description>SC function.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NMI</name>
+       <description>NMI function.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFSTAT</name>
+     <description>secfuncstat register.</description>
+     <addressOffset>0x104</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SBD</name>
+       <description>SBD function.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SLD</name>
+       <description>SLD function.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TRNGD</name>
+       <description>TRNG function.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESD</name>
+       <description>AES function.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHAD</name>
+       <description>SHA function.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SMD</name>
+       <description>SMD function.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIR System Initialization Registers.-->
+  <peripheral>
+   <name>SDHC</name>
+   <description>SDHC/SDIO Controller</description>
+   <baseAddress>0x40037000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SDHC</name>
+    <value>66</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SDMA</name>
+     <description>SDMA System Address / Argument 2.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>SDMA System Address / Argument 2  of Auto CMD23.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_SIZE</name>
+     <description>Block Size.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>TRANS</name>
+       <description>Transfer Block Size.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>HOST_BUFF</name>
+       <description>Host SDMA Buffer Boundary.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_CNT</name>
+     <description>Block Count.</description>
+     <addressOffset>0x06</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>TRANS</name>
+       <description>Blocks Count For Current Transfer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ARG_1</name>
+     <description>Argument 1.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>CMD</name>
+       <description>Command Argument 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRANS</name>
+     <description>Transfer Mode.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>DMA_EN</name>
+       <description>DMA Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>enable</name>
+        <enumeratedValue>
+         <name>dma_transfer</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>non_dma_transfer</name>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BLK_CNT_EN</name>
+       <description>Block Count Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>count</name>
+        <enumeratedValue>
+         <name>enable</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTO_CMD_EN</name>
+       <description>Auto CMD Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <name>CMD</name>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cmd12</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cmd23</name>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ_WRITE</name>
+       <description>Data Transfer Direction Select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>read</name>
+        <enumeratedValue>
+         <name>read</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>write</name>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MULTI</name>
+       <description>Multi / Single Block Select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>multi</name>
+        <enumeratedValue>
+         <name>enable</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMD</name>
+     <description>Command.</description>
+     <addressOffset>0x0E</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>RESP_TYPE</name>
+       <description>Response Type Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CRC_CHK_EN</name>
+       <description>Command CRC Check Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IDX_CHK_EN</name>
+       <description>Command Index Check Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_PRES_SEL</name>
+       <description>Data Present Select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TYPE</name>
+       <description>Command Type.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>IDX</name>
+       <description>Command Index.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>RESP[%s]</name>
+     <description>Response 0 Register 0-7.</description>
+     <addressOffset>0x010</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>CMD_RESP</name>
+       <description>Command Response.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUFFER</name>
+     <description>Buffer Data Port.</description>
+     <addressOffset>0x20</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Buffer Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESENT</name>
+     <description>Present State.</description>
+     <addressOffset>0x024</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CMD</name>
+       <description>Command Inhibit (CMD).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DAT</name>
+       <description>Command Inhibit (DAT).</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DAT_LINE_ACTIVE</name>
+       <description>DAT Line Active.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Request.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WRITE_TRANSFER</name>
+       <description>Write Transfer Active.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>READ_TRANSFER</name>
+       <description>Read Transfer Active.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BUFFER_WRITE</name>
+       <description>Buffer Write Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BUFFER_READ</name>
+       <description>Buffer Read Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CARD_INSERTED</name>
+       <description>Card Inserted.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CARD_STATE</name>
+       <description>Card State Stable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CARD_DETECT</name>
+       <description>Card Detect Pin Level.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WP</name>
+       <description>Write Protect Switch Pin Level.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DAT_SIGNAL_LEVEL</name>
+       <description>DAT[3:0] Line Signal Level.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CMD_SIGNAL_LEVEL</name>
+       <description>CMD Line Signal Level.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HOST_CN_1</name>
+     <description>Host Control 1.</description>
+     <addressOffset>0x028</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>LED_CN</name>
+       <description>LED Control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TRANSFER_WIDTH</name>
+       <description>Data Transfer Width.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HS_EN</name>
+       <description>High Speed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA_SELECT</name>
+       <description>DMA Select.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>EXT_DATA_TRANSFER_WIDTH</name>
+       <description>Extended Data Transfer Width.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_DETECT_TEST</name>
+       <description>Card Detect Test Level.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_DETECT_SIGNAL</name>
+       <description>Card Detect Signal Selection.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWR</name>
+     <description>Power Control.</description>
+     <addressOffset>0x029</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>BUS_POWER</name>
+       <description>SD Bus Power.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUS_VOLT_SEL</name>
+       <description>SD Bus Voltage Select.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_GAP</name>
+     <description>Block Gap Control.</description>
+     <addressOffset>0x02A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>STOP</name>
+       <description>Stop At Block Gap Request.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CONT</name>
+       <description>Continue Request.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>READ_WAIT</name>
+       <description>Read Wait Control.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTR</name>
+       <description>Interrupt At Block Gap.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKEUP</name>
+     <description>Wakeup Control.</description>
+     <addressOffset>0x02B</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>CARD_INT</name>
+       <description>Wakeup Event Enable On Card Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INS</name>
+       <description>Wakeup Event Enable On SD Card Insertion.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REM</name>
+       <description>Wakeup Event Enable On SD Card Removal.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_CN</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x02C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>INTERNAL_CLK_EN</name>
+       <description>Internal Clock Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTERNAL_CLK_STABLE</name>
+       <description>Internal Clock Stable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SD_CLK_EN</name>
+       <description>SD Clock Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLK_GEN_SEL</name>
+       <description>Clock Generator Select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>UPPER_SDCLK_FREQ_SEL</name>
+       <description>Upper Bits of SDCLK Frequency Select.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SDCLK_FREQ_SEL</name>
+       <description>SDCLK Frequency Select.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TO</name>
+     <description>Timeout Control.</description>
+     <addressOffset>0x02E</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>DATA_COUNT_VALUE</name>
+       <description>Data Timeout Counter Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SW_RESET</name>
+     <description>Software Reset.</description>
+     <addressOffset>0x02F</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RESET_ALL</name>
+       <description>Software Reset For All.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESET_CMD</name>
+       <description>Software Reset For CMD Line.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESET_DAT</name>
+       <description>Software Reset For DAT Line.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_STAT</name>
+     <description>Normal Interrupt Status.</description>
+     <addressOffset>0x030</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_COMP</name>
+       <description>Command Complete.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRANS_COMP</name>
+       <description>Transfer Complete.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BLK_GAP_EVENT</name>
+       <description>Block Gap Event.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFF_WR_READY</name>
+       <description>Buffer Write Ready.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFF_RD_READY</name>
+       <description>Buffer Read Ready.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INSERTION</name>
+       <description>Card Insertion.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REMOVAL</name>
+       <description>Card Removal.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INTR</name>
+       <description>Card Interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Event.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERR_INTR</name>
+       <description>Error Interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ER_INT_STAT</name>
+     <description>Error Interrupt Status.</description>
+     <addressOffset>0x032</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Command Timeout Error.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Command CRC Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Command End Bit Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_IDX</name>
+       <description>Command Index Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Data Timeout Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Data CRC Error.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Data End Bit Error.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CURRENT_LIMIT</name>
+       <description>Current Limit Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AUTO_CMD_12</name>
+       <description>Auto CMD Error.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>ADMA Error.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Error.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Normal Interrupt Status Enable.</description>
+     <addressOffset>0x034</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_COMP</name>
+       <description>Command Complete Status Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRANS_COMP</name>
+       <description>Transfer Complete Status Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BLK_GAP</name>
+       <description>Block Gap Event Status Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Interrupt Status Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_WR</name>
+       <description>Buffer Write Ready Status Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_RD</name>
+       <description>Buffer Read Ready Status Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INSERT</name>
+       <description>Card Insertion Status Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REMOVAL</name>
+       <description>Card Removal Status Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INT</name>
+       <description>Card Interrupt Status Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Event Status Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ER_INT_EN</name>
+     <description>Error Interrupt Status Enable.</description>
+     <addressOffset>0x36</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Command Timeout Error Status Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Command CRC Error Status Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Command End Bit Error Status Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_IDX</name>
+       <description>Command Index Error Status Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Data Timeout Error Status Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Data CRC Error Status Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Data End Bit Error Status Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AUTO_CMD</name>
+       <description>Auto CMD Error Status Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>ADMA Error Status Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TUNING</name>
+       <description>Tuning Error Status Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VENDOR</name>
+       <description>Vendor Specific Error Status Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_SIGNAL</name>
+     <description>Normal Interrupt Signal Enable.</description>
+     <addressOffset>0x038</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_COMP</name>
+       <description>Command Complete Signal Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRANS_COMP</name>
+       <description>Transfer Complete Signal Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BLK_GAP</name>
+       <description>Block Gap Event Signal Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Interrupt Signal Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_WR</name>
+       <description>Buffer Write Ready Signal Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_RD</name>
+       <description>Buffer Read Ready Signal Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INSERT</name>
+       <description>Card Insertion Signal Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REMOVAL</name>
+       <description>Card Removal Signal Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INT</name>
+       <description>Card Interrupt Signal Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Event Signal Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ER_INT_SIGNAL</name>
+     <description>Error Interrupt Signal Enable.</description>
+     <addressOffset>0x03A</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Command Timeout Error Signal Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Command CRC Error Signal Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Command End Bit Error Signal Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_IDX</name>
+       <description>Command Index Error Signal Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Data Timeout Error Signal Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Data CRC Error Signal Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Data End Bit Error Signal Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CURR_LIM</name>
+       <description>Current Limit Error Signal Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AUTO_CMD</name>
+       <description>Auto CMD Error Signal Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>ADMA Error Signal Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TUNING</name>
+       <description>Tuning Error Signal Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAR_RESP</name>
+       <description>Target Response Error Signal Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTO_CMD_ER</name>
+     <description>Auto CMD Error Status.</description>
+     <addressOffset>0x03C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>NOT_EXCUTED</name>
+       <description>Auto CMD12 Not Executed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TO</name>
+       <description>Auto CMD Timeout Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRC</name>
+       <description>Auto CMD CRC Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>END_BIT</name>
+       <description>Auto CMD End Bit Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INDEX</name>
+       <description>Auto CMD Index Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOT_ISSUED</name>
+       <description>Command Not Issued By Auto CMD12 Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HOST_CN_2</name>
+     <description>Host Control 2.</description>
+     <addressOffset>0x03E</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>UHS</name>
+       <description>UHS Mode Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SIGNAL_V1_8</name>
+       <description>1.8V Signaling Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>EXCUTE</name>
+       <description>Execute Tuning.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SAMPLING_CLK</name>
+       <description>Sampling Clock Select.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ASYNCH_INT</name>
+       <description>Asynchronous Interrupt Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PRESET_VAL_EN</name>
+       <description>Preset Value Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_0</name>
+     <description>Capabilities 0-31.</description>
+     <addressOffset>0x040</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TO_CLK_FREQ</name>
+       <description>Timeout Clock Frequency.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TO_CLK_UNIT</name>
+       <description>Timeout Clock Unit.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_FREQ</name>
+       <description>Base Clock Frequency For SD Clock.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>MAX_BLK_LEN</name>
+       <description>Max Block Length.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BIT_8</name>
+       <description>8-bit Support for Embedded Device.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ADMA2</name>
+       <description>ADMA2 Support.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS</name>
+       <description>High Speed Support.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDMA</name>
+       <description>SDMA Support.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SUSPEND</name>
+       <description>Suspend/Resume Support.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>V3_3</name>
+       <description>Voltage Support 3.3V.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>V3_0</name>
+       <description>Voltage Support 3.0V.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>V1_8</name>
+       <description>Voltage Support 1.8V.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BIT_64_SYS_BUS</name>
+       <description>64-bit System Bus Support.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ASYNC_INT</name>
+       <description>Asynchronous Interrupt Support.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SLOT_TYPE</name>
+       <description>Slot Type.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_1</name>
+     <description>Capabilities 32-63.</description>
+     <addressOffset>0x044</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDR50</name>
+       <description>SDR50 Support.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDR104</name>
+       <description>SDR104 Support.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>0</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DDR50</name>
+       <description>DDR50 Support.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_A</name>
+       <description>Driver Type A Support.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_C</name>
+       <description>Driver Type C Support.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_D</name>
+       <description>Driver Type D Support.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TIMER_CNT_TUNING</name>
+       <description>Timer Count for Re-Tuning.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TUNING_SDR50</name>
+       <description>Use Tuning for SDR50.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Modes.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_MULTI</name>
+       <description>Clock Multiplier.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAX_CURR_CFG</name>
+     <description>Maximum Current Capabilities.</description>
+     <addressOffset>0x048</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>V3_3</name>
+       <description>Maximum Current for 3.3V.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>V3_0</name>
+       <description>Maximum Current for 3.0V.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>V1_8</name>
+       <description>Maximum Current for 1.8V.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FORCE_CMD</name>
+     <description>Force Event for Auto CMD Error Status.</description>
+     <addressOffset>0x050</addressOffset>
+     <size>16</size>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>NOT_EXCU</name>
+       <description>Force Event for Auto CMD12 Not Executed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TO</name>
+       <description>Force Event for Auto CMD Timeout Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>CRC</name>
+       <description>Force Event for Auto CMD CRC Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>END_BIT</name>
+       <description>Force Event for Auto CMD End Bit Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>INDEX</name>
+       <description>Force Event for Auto CMD Index Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>NOT_ISSUED</name>
+       <description>Force Event for Command Not Issued By Auto CMD12 Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FORCE_EVENT_INT_STAT</name>
+     <description>Force Event for Error Interrupt Status.</description>
+     <addressOffset>0x052</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Force Event for Command Timeout Error.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Force Event for Command CRC Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Force Event for Command End Bit Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CMD_INDEX</name>
+       <description>Force Event for Command Index Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Force Event for Data Timeout Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Force Event for Data CRC Error.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Force Event for Data End Bit Error.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CURR_LIMIT</name>
+       <description>Force Event for Current Limit Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>AUTO_CMD</name>
+       <description>Force Event for Auto CMD Error.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>Force Event for ADMA Error.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VENDOR</name>
+       <description>Force Event for Vendor Specific Error Status.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADMA_ER</name>
+     <description>ADMA Error Status.</description>
+     <addressOffset>0x054</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>STATE</name>
+       <description>ADMA Error State.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>LEN_MISMATCH</name>
+       <description>ADMA Length Mismatch Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADMA_ADDR_0</name>
+     <description>ADMA System Address 0-31.</description>
+     <addressOffset>0x058</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>ADMA System Address  Part 1 (part 2 is ADMA_ADDR_1).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADMA_ADDR_1</name>
+     <description>ADMA System Address 32-63.</description>
+     <addressOffset>0x05C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>ADMA System Address  Part 1 (part 2 is ADMA_ADDR_1).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_0</name>
+     <description>Preset Value for Initialization.</description>
+     <addressOffset>0x060</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_1</name>
+     <description>Preset Value for Default Speed.</description>
+     <addressOffset>0x062</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_2</name>
+     <description>Preset Value for High Speed.</description>
+     <addressOffset>0x064</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_3</name>
+     <description>Preset Value for SDR12.</description>
+     <addressOffset>0x066</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_4</name>
+     <description>Preset Value for SDR25.</description>
+     <addressOffset>0x068</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_5</name>
+     <description>Preset Value for SDR50.</description>
+     <addressOffset>0x06A</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_6</name>
+     <description>Preset Value for SDR104.</description>
+     <addressOffset>0x06C</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_7</name>
+     <description>Preset Value for DDR50.</description>
+     <addressOffset>0x06E</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLOT_INT</name>
+     <description>Slot Interrupt Status.</description>
+     <addressOffset>0x0FC</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>INT_SIGNALS</name>
+       <description>Interrupt Signal For Each Slot.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HOST_CN_VER</name>
+     <description>Host Controller Version.</description>
+     <addressOffset>0x0FE</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>SPEC_VER</name>
+       <description>Specification Version Number.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VEND_VER</name>
+       <description>Vendor Version Number.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SDHC SDHC/SDIO Controller-->
+  <peripheral>
+   <name>HA</name>
+   <description>Hardware Accelerator</description>
+   <baseAddress>0x40036000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>HA</name>
+    <description>Smart DMA interrupt.</description>
+    <value>60</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>IP</name>
+     <description>Q30E Instruction Pointer.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>SP</name>
+     <description>Q30E Stack Pointer.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>DP0</name>
+     <description>Q30E Data Pointer 0.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>DP1</name>
+     <description>Q30E Data Pointer 1.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>BP</name>
+     <description>Q30E Frame Pointer Base.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>OFFS</name>
+     <description>Q30E Frame Pointer Offset.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>LC0</name>
+     <description>Q30E Loop Counter 0.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>LC1</name>
+     <description>Q30E Loop Counter 1.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>A0</name>
+     <description>Q30E Accumulator 0.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>A1</name>
+     <description>Q30E Accumulator 1.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>A2</name>
+     <description>Q30E Accumulator 2.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>A3</name>
+     <description>Q30E Accumulator 3.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>WDCN</name>
+     <description>Q30E Watchdog Control.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>INT_MUX_CTRL0</name>
+     <description>Interrupt Mux Control 0.</description>
+     <addressOffset>0x80</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INTSEL16</name>
+       <description>Interrupt Selection For 16th Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>INTSEL17</name>
+       <description>Interrupt Selection For 17th Interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>INTSEL18</name>
+       <description>Interrupt Selection For 18th Interrupt.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>INTSEL19</name>
+       <description>Interrupt Selection For 19th Interrupt.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_MUX_CTRL1</name>
+     <description>Interrupt Mux Control 1.</description>
+     <addressOffset>0x84</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INTSEL20</name>
+       <description>Interrupt Selection For 20th Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>INTSEL21</name>
+       <description>Interrupt Selection For 21st Interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>INTSEL22</name>
+       <description>Interrupt Selection For 22nd Interrupt.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>INTSEL23</name>
+       <description>Interrupt Selection For 23rd Interrupt.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_MUX_CTRL2</name>
+     <description>Interrupt Mux Control 2.</description>
+     <addressOffset>0x88</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INTSEL24</name>
+       <description>Interrupt Selection For 24th Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>INTSEL25</name>
+       <description>Interrupt Selection For 25th Interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>INTSEL26</name>
+       <description>Interrupt Selection For 26th Interrupt.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>INTSEL27</name>
+       <description>Interrupt Selection For 27th Interrupt.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_MUX_CTRL3</name>
+     <description>Interrupt Mux Control 3.</description>
+     <addressOffset>0x8C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INTSEL28</name>
+       <description>Interrupt Selection For 28th Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>INTSEL29</name>
+       <description>Interrupt Selection For 29th Interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>INTSEL30</name>
+       <description>Interrupt Selection For 30th Interrupt.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>INTSEL31</name>
+       <description>Interrupt Selection For 31st Interrupt.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IP_ADDR</name>
+     <description>Configurable starting IP address for Q30E.</description>
+     <addressOffset>0x90</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>START_IP_ADDR</name>
+       <description>Starting IP address for Q30E</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register.</description>
+     <addressOffset>0x94</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enable SDMA.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable SDMA.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable SDMA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_IN_CTRL</name>
+     <description>Interrupt Input From CPU Control Register.</description>
+     <addressOffset>0xA0</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INTSET</name>
+       <description>Set Interrupt Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Set interrupt Flag to 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set Interrupt Flag to 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_IN_FLAG</name>
+     <description>Interrupt Input From CPU Flag.</description>
+     <addressOffset>0xA4</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INTFLAG</name>
+       <description>Interrupt Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no_eff</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>INT_IN_FLAG =0</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_IN_IE</name>
+     <description>Interrupt Input From CPU Enable.</description>
+     <addressOffset>0xA8</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INT_IN_EN</name>
+       <description>Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IRQ_FLAG</name>
+     <description>Interrupt Output To CPU Flag.</description>
+     <addressOffset>0xB0</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ_FLAG</name>
+       <description>Interrupt Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IRQ_IE</name>
+     <description>Interrupt Output To CPU Control Register.</description>
+     <addressOffset>0xB4</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ_EN</name>
+       <description>Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--HA Hardware Accelerator-->
+  <peripheral>
+   <name>SEMA</name>
+   <description>The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.</description>
+   <baseAddress>0x4003E000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>0x04</dimIncrement>
+     <name>SEMAPHORES[%s]</name>
+     <description>Read to test and set, returns prior value. Write 0 to clear semaphore.</description>
+     <addressOffset>0x000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>sema</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>status</name>
+     <description>Semaphore status bits. 0 indicates the semaphore is free, 1 indicates taken.</description>
+     <addressOffset>0x100</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>STATUS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SEMA The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.-->
+  <peripheral>
+   <name>SMON</name>
+   <description>The Security Monitor block used to monitor system threat conditions.</description>
+   <baseAddress>0x40004000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>EXTSCN</name>
+     <description>External Sensor Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x3800FFC0</resetMask>
+     <fields>
+      <field>
+       <name>EXTS_EN0</name>
+       <description>External Sensor Enable for input/output pair 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN1</name>
+       <description>External Sensor Enable for input/output pair 1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN2</name>
+       <description>External Sensor Enable for input/output pair 2.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN3</name>
+       <description>External Sensor Enable for input/output pair 3.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN4</name>
+       <description>External Sensor Enable for input/output pair 4.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN5</name>
+       <description>External Sensor Enable for input/output pair 5.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTCNT</name>
+       <description>External Sensor Error Counter. These bits set the number of external sensor accepted mismatches that have to occur within a single bit period before an external sensor alarm is triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>EXTFRQ</name>
+       <description>External Sensor Frequency. These bits define the frequency at which the external sensors are clocked to/from the EXTS_IN and EXTS_OUT pair.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq2000Hz</name>
+         <description>Div 4 (2000Hz).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq1000Hz</name>
+         <description>Div 8 (1000Hz).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq500Hz</name>
+         <description>Div 16 (500Hz).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq250Hz</name>
+         <description>Div 32 (250Hz).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq125Hz</name>
+         <description>Div 64 (125Hz).</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq63Hz</name>
+         <description>Div 128 (63Hz).</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq31Hz</name>
+         <description>Div 256 (31Hz).</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RFU</name>
+         <description>Reserved. Do not use.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DIVCLK</name>
+       <description>Clock Divide.  These bits are used to divide the 8KHz input clock. The resulting divided clock is used for all logic within the Security Monitor Block. Note:
+                                                             If the input clock is divided with these bits, the error count threshold table and output frequency will be affected accordingly with the same divide factor.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1 (8000 Hz).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2 (4000 Hz).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4 (2000 Hz).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8 (1000 Hz).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16 (500 Hz).</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32 (250 Hz).</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64 (125 Hz).</description>
+         <value>6</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>Busy. This bit is set to 1 by hardware after EXTSCN register is written to. This bit is automatically cleared to 0 after this register information has been transferred to the security monitor domain.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Update in Progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock Register. Once locked, the EXTSCN register can no longer be modified.  Only a battery disconnect will clear this bit. VBAT powers this register.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTSCN</name>
+     <description>Internal Sensor Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x7F00FFF7</resetMask>
+     <fields>
+      <field>
+       <name>SHIELD_EN</name>
+       <description>Die Shield Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TEMP_EN</name>
+       <description>Temperature Sensor Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VBAT_EN</name>
+       <description>Battery Monitor Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DFD_EN</name>
+       <description>Digital Fault Dector Enable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DFD_NMI</name>
+       <description>Digital Fault NMI Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DFD_STDBY</name>
+       <description>Digital Fault Dector Stand by Enable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LOTEMP_SEL</name>
+       <description>Low Temperature Detection Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>neg50C</name>
+         <description>-50 degrees C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>neg30C</name>
+         <description>-30 degrees C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VTM_LOTHSEL</name>
+       <description>VTM Low Threshold Detection</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1_6V</name>
+         <description>1.6V</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_2V</name>
+         <description>2.2V</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_8V</name>
+         <description>2.8V</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock Register. Once locked, the INTSCN register can no longer be modified.  Only a battery disconnect will clear this bit. VBAT powers this register.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECALM</name>
+     <description>Security Alarm Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000000</resetValue>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>DRS</name>
+       <description>Destructive Reset Trigger. Setting this bit will generate a DRS. This bit is self-cleared by hardware.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>Key Wipe Trigger. Set to 1 to initiate a wipe of the AES key register. It does not reset the part, or log a timestamp. AES and DES registers are not affected by this bit. This bit is automatically cleared to 0 after the keys have been wiped.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHIELDF</name>
+       <description>Die Shield Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOTEMP</name>
+       <description>Low Temperature Detect.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HITEMP</name>
+       <description>High Temperature Detect.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATLO</name>
+       <description>Battery Undervoltage Detect.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATHI</name>
+       <description>Battery Overvoltage Detect.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTF</name>
+       <description>External Sensor Flag. This bit is set to 1 when any of the EXTSTAT bits are set.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DFD</name>
+       <description>Digital Fault Detector.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VMAINPF</name>
+       <description>VMAIN Power Fail Flag.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT0</name>
+       <description>External Sensor 0 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT1</name>
+       <description>External Sensor 1 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT2</name>
+       <description>External Sensor 2 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT3</name>
+       <description>External Sensor 3 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT4</name>
+       <description>External Sensor 4 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT5</name>
+       <description>External Sensor 5 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN0</name>
+       <description>External Sensor 0 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN1</name>
+       <description>External Sensor 1 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN2</name>
+       <description>External Sensor 2 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN3</name>
+       <description>External Sensor 3 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN4</name>
+       <description>External Sensor 4 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN5</name>
+       <description>External Sensor 5 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECDIAG</name>
+     <description>Security Diagnostic Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <resetValue>0x00000001</resetValue>
+     <resetMask>0xFFC0FE02</resetMask>
+     <fields>
+      <field>
+       <name>PORF</name>
+       <description>Power-On-Reset Flag. This bit is set once the power supply is conneted.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHIELDF</name>
+       <description>Die Shield Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOTEMP</name>
+       <description>Low Temperature Detect.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HITEMP</name>
+       <description>High Temperature Detect.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATLO</name>
+       <description>Battery Undervoltage Detect.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATHI</name>
+       <description>Battery Overvoltage Detect.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DYNF</name>
+       <description>Dynamic Sensor Flag.  This bit is set to 1 when any of the EXTSTAT bits are set.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESK_MDU</name>
+       <description>AES Key Transfer. This bit is set to 1 when AES MDU Key has been transferred from the TRNG to the battery backed AES key register. This bit can only be reset by a BOR.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>incomplete</name>
+         <description>Key has not been transferred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>Key has been transferred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESK_NVSRAM</name>
+       <description>NVSRAM 256-bit AES Key Cleared. This field is set to 1 by hardware if the NVSRAM AES key is zero. This field resets to 1 on a POR.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nonzero</name>
+         <description>Key is non-zero.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>zero</name>
+         <description>Key is zero.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESK_SPIXF</name>
+       <description>SPIXF 128-Bit AES Key Cleared. This field is set to 1 by hardware if the SPIXR 128-bit AES key is zero. This field resets to 1 on a POR.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nonzero</name>
+         <description>Key is non-zero.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>zero</name>
+         <description>Key is zero.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESK_SPIXR</name>
+       <description>SPIXR 128-Bit AES Key Cleared. This field is set to 1 by hardware if the SPIXR 128-bit AES key is zero. This field resets to 1 on a POR.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nonzero</name>
+         <description>Key is non-zero.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>zero</name>
+         <description>Key is zero.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT0</name>
+       <description>External Sensor 0 Detect.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT1</name>
+       <description>External Sensor 1 Detect.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT2</name>
+       <description>External Sensor 2 Detect.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT3</name>
+       <description>External Sensor 3 Detect.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT4</name>
+       <description>External Sensor 4 Detect.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT5</name>
+       <description>External Sensor 5 Detect.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DLRTC</name>
+     <description>DRS Log RTC Value. This register contains the 32 bit value in the RTC second register when the last DRS event occurred.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-only</access>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>DLRTC</name>
+       <description>DRS Log RTC Value. This register contains the 32 bit value in the RTC second register when the last DRS event occured.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEUCFG</name>
+     <description>MEU Configuration</description>
+     <addressOffset>0x24</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>ENC_REG0</name>
+       <description> NVSRAM Encryption Enable Region 0. Setting this field to 1 enables encryption using the MEU of region 0 of the NVSRAM.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>plaintext</name>
+         <description>Plain text.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>encrypted</name>
+         <description>Encrypted.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ENC_REG1</name>
+       <description> NVSRAM Encryption Enable Region 1. Setting this field to 1 enables encryption using the MEU of region 1 of the NVSRAM.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>plaintext</name>
+         <description>Plain text.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>encrypted</name>
+         <description>Encrypted.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ENC_REG2</name>
+       <description> NVSRAM Encryption Enable Region 2. Setting this field to 1 enables encryption using the MEU of region 2 of the NVSRAM.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>plaintext</name>
+         <description>Plain text.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>encrypted</name>
+         <description>Encrypted.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ENC_REG3</name>
+       <description> NVSRAM Encryption Enable Region 3. Setting this field to 1 enables encryption using the MEU of region 3 of the NVSRAM.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>plaintext</name>
+         <description>Plain text.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>encrypted</name>
+         <description>Encrypted.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ENC_REG4</name>
+       <description> NVSRAM Encryption Enable Region 4. Setting this field to 1 enables encryption using the MEU of region 4 of the NVSRAM.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>plaintext</name>
+         <description>Plain text.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>encrypted</name>
+         <description>Encrypted.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ENC_REG5</name>
+       <description> NVSRAM Encryption Enable Region 5. Setting this field to 1 enables encryption using the MEU of region 5 of the NVSRAM.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>plaintext</name>
+         <description>Plain text.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>encrypted</name>
+         <description>Encrypted.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ENC_REG6</name>
+       <description> NVSRAM Encryption Enable Region 6. Setting this field to 1 enables encryption using the MEU of region 6 of the NVSRAM.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>plaintext</name>
+         <description>Plain text.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>encrypted</name>
+         <description>Encrypted.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ENC_REG7</name>
+       <description> NVSRAM Encryption Enable Region 7. Setting this field to 1 enables encryption using the MEU of region 7 of the NVSRAM.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>plaintext</name>
+         <description>Plain text.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>encrypted</name>
+         <description>Encrypted.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECST</name>
+     <description>Security Monitor Status Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>EXTSRS</name>
+       <description>External Sensor Control Register Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INTSRS</name>
+       <description>Internal Sensor Control Register Status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SECALRS</name>
+       <description>Security Alarm Register Status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MEUCFG</name>
+       <description>MEU Configuration Register Status.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SDBE</name>
+     <description>Security Monitor Self Destruct Byte.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>DBYTE</name>
+       <description>Self Destruct Byte</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SBDEN</name>
+       <description>Self-Destruct Byte Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SMON The Security Monitor block used to monitor system threat conditions.-->
+  <peripheral>
+   <name>SPIXR</name>
+   <description>SPIXR peripheral.</description>
+   <baseAddress>0x4003A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>DATA32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>DATA16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>DATA32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>DATA8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>DATA32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SPIEN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MMEN</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSIO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,
+						Slave Select 0 can be input in Master mode. This bit has no
+						effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is
+								self clearing when transactions are done. If
+								a transaction completes, and the TX FIFO
+								is empty, the Master halts, if a transaction
+								completes, and the TX FIFO is not empty,
+								the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Slave Select Control.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>deassert</name>
+         <description>SPI de-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>assert</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are
+						selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3</name>
+         <description>SS3 is selected.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS4</name>
+         <description>SS4 is selected.</description>
+         <value>0x10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS5</name>
+         <description>SS5 is selected.</description>
+         <value>0x20</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS6</name>
+         <description>SS6 is selected.</description>
+         <value>0x40</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS7</name>
+         <description>SS7 is selected.</description>
+         <value>0x80</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL3</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCLK_FB_INV</name>
+       <description>Invert SCLK Feedback in Master Mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>NON_INV</name>
+         <description>SCLK is not inverted to Line Receiver.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INV</name>
+         <description>SCLK is inverted to Line Receiver.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin(s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSPOL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3_high</name>
+         <description>SS3 active high.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS4_high</name>
+         <description>SS4 active high.</description>
+         <value>0x10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS5_high</name>
+         <description>SS5 active high.</description>
+         <value>0x20</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS6_high</name>
+         <description>SS6 active high.</description>
+         <value>0x40</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS7_high</name>
+         <description>SS7 active high.</description>
+         <value>0x80</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SS_TIME</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SSACT1</name>
+       <description>Slave Select Action delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSACT2</name>
+       <description>Slave Select Action delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSINACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BRG_CTRL</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LOW</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCALE</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_FIFO_LEVEL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for
+						threshold status. When TX FIFO has fewer than this many bytes, the
+						associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CLEAR</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write
+						pointers. This should be done when FIFO is not being accessed on the SPI side.
+					</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CNT</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_DMA_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_LEVEL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for
+						threshold status. When RX FIFO has more than this many bytes, the
+						associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CLEAR</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write
+						pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFIO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CNT</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RX_DMA_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data
+						to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data
+						from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_FL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts,
+						cleared when last bit of last character is acted upon and Slave Select
+						de-assertion would occur. In Slave mode, set when Slave Select is
+						asserted, cleared when Slave Select is de-asserted. Not used in Timer mode.
+					</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>XMEM_CTRL</name>
+     <description>Register to control external memory.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RD_CMD</name>
+       <description>Read command.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>WR_CMD</name>
+       <description>Write command.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>DUMMY_CLK</name>
+       <description>Dummy clocks.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>XMEM_EN</name>
+       <description>XMEM enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXR SPIXR peripheral.-->
+  <peripheral>
+   <name>SPIXFC</name>
+   <description>SPI XiP Flash Configuration Controller</description>
+   <baseAddress>0x40027000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPIXFC</name>
+    <description>SPIXFC IRQ</description>
+    <value>38</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CFG</name>
+     <description>Configuration Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>SSEL</name>
+       <description>Slaves Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Slave_0</name>
+         <description>Slave 0 is selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Slave_1</name>
+         <description>Slave 1 is selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description>Defines SPI Mode, Only valid values are 0 and 3.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SPIX_Mode_0</name>
+         <description>SPIX Mode 0. CLK Polarity = 0, CLK Phase = 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SPIX_Mode_3</name>
+         <description>SPIX Mode 3. CLK Polarity = 1, CLK Phase = 1.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PAGE_SIZE</name>
+       <description>Page Size.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>4_bytes</name>
+         <description>4 bytes.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_bytes</name>
+         <description>8 bytes.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_bytes</name>
+         <description>16 bytes.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>32_bytes</name>
+         <description>32 bytes.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI_CLK</name>
+       <description>SCLK High Clocks. Number of system clocks that SCLK will be high when SCLK pulses are generated. 0 Correspond to 16 system clocks and, all other values defines the number of system clock taht SCLK will be held high.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16_SCLK</name>
+         <description>16 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LO_CLK</name>
+       <description>SCLK low Clocks. Number of system clocks that SCLK will be low when SCLK pulses are generated. 0 correspond to 16 system clocks and, all other values defines the number of system clock taht SCLK will be held low.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16_SCLK</name>
+         <description>16 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSACT</name>
+       <description>Slaves Select Activate Timing.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_CLKS</name>
+         <description>0 sytem clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_CLKS</name>
+         <description>2 sytem clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_CLKS</name>
+         <description>4 sytem clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_CLKS</name>
+         <description>8 sytem clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSIACT</name>
+       <description>Slaves Select Inactive Timing.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>4_CLKS</name>
+         <description>4 sytem clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_CLKS</name>
+         <description>6 sytem clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_CLKS</name>
+         <description>8 sytem clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_CLKS</name>
+         <description>12 sytem clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IOSMPL</name>
+       <description>Sample Delay</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SS_POL</name>
+     <description>SPIX Controller Slave Select Polarity Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>SSPOL_0</name>
+       <description>Slave Select Polarity.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lo</name>
+         <description>Active Low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hi</name>
+         <description>Active High.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GEN_CTRL</name>
+     <description>SPIX Controller General Controller Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ENABLE</name>
+       <description>SPI Master enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable SPI Master, putting a reset state.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable SPI Master for processing transactions.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transaction FIFO Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis_txfifo</name>
+         <description>Disable Transaction FIFO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en_txfifo</name>
+         <description>Enable Transaction FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Result FIFO Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis_rxfifo</name>
+         <description>Disable Result FIFO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en_rxfifo</name>
+         <description>Enable Result FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BBMODE</name>
+       <description>Bit-Bang Mode.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Bit-Bang Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Bit-Bang Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSDR</name>
+       <description>This bits reflects the state of the currently selected slave select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output0</name>
+         <description>Selected Slave select output = 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>output1</name>
+         <description>Selected Slave select output = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLK_DR</name>
+       <description>SSCLK Drive and State.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SCLK_0</name>
+         <description>SCLK is 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SCLK_1</name>
+         <description>SCLK is 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDIO_DATA_IN</name>
+       <description>SDIO Input Data Value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BB_DATA</name>
+       <description>No description available.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BB_DATA_OUT_EN</name>
+       <description>Bit Bang SDIO Output Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SIMPLE</name>
+       <description>Simple Mode Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SIMPLE_RX</name>
+       <description>Simple Receive Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SIMPLE_SS</name>
+       <description>Simple Mode Slave Select.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCLK_FB</name>
+       <description>Enable SCLK Feedback Mode.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLK_FB_INVERT</name>
+       <description>SCK Invert.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO_CTRL</name>
+     <description>SPIX Controller FIFO Control and Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>TX_FIFO_AE_LVL</name>
+       <description>Transaction FIFO Almost Empty Level.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_CNT</name>
+       <description>Transaction FIFO Used.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_AF_LVL</name>
+       <description>Results FIFO Almost Full Level.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_CNT</name>
+       <description>Result FIFO Used.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SP_CTRL</name>
+     <description>SPIX Controller Special Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>SAMPL</name>
+       <description>Setting this bit to a 1 enables the ability to drive SDIO outputs prior to the assertion of Slave Select. This bit must
+                                                                         only be set when the SPIXF bus is idle and the transaction FIFO is empty. This bit is automatically cleared by hardware after the
+                                                                         next slave select assertion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SDIO_OUT</name>
+       <description>SDIO Output Value Sample Mode</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>SDIO_OUT_EN</name>
+       <description>SDIO Output Enable Sample Mode</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>SCLKINH3</name>
+       <description>SCLK Inhibit Mode3. In SPI Mode 3, some SPI flash read timing diagrams show the last SCLK going low prior to de-assertion. The default is to support this additional falling edge of clock. When this bit is set and the device is in SPI Mode 3, the SPI clock is held high while Slave Select is de-asserted. This is to support some SPI flash write timing diagrams.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Allow trailing SCLK low pulse prior to Slave Select de-assertion.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Inhibit trailing SCLK low pulse prior to Slave Select de-assertion.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>SPIX Controller Interrupt Status Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>TX_STALLED</name>
+       <description>Transaction Stalled Interrupt Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Normal FIFO Transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Stalled FIFO Transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_STALLED</name>
+       <description>Results Stalled Interrupt Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Normal FIFO Operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Stalled FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_READY</name>
+       <description>Transaction Ready Interrupt Status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>FIFO Transaction not ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>FIFO Transaction ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_DONE</name>
+       <description>Results Done Interrupt Status.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Results FIFO ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Results FIFO Not ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_AE</name>
+       <description>Transaction FIFO Almost Empty Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Transaction FIFO not Almost Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Transaction FIFO Almost Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_AF</name>
+       <description>Results FIFO Almost Full Flag.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Results FIFO level below the Almost Full level.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Results FIFO level at Almost Full level.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>SPIX Controller Interrupt Enable Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>TX_STALLED</name>
+       <description>Transaction Stalled Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Disable Transaction Stalled Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Enable Transaction Stalled Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_STALLED</name>
+       <description>Results Stalled Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Disable Results Stalled Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Enable Results Stalled Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_READY</name>
+       <description>Transaction Ready Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Disable FIFO Transaction Ready Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Enable FIFO Transaction Ready Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_DONE</name>
+       <description>Results Done Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Disable Results Done Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Enable Results Done Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_AE</name>
+       <description>Transaction FIFO Almost Empty Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Disable Transaction FIFO Almost Empty Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Enable Transaction FIFO Almost Empty Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_AF</name>
+       <description>Results FIFO Almost Full Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Disable Results FIFO Almost Full Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Enable Results FIFO Almost Full Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXFC SPI XiP Flash Configuration Controller-->
+  <peripheral>
+   <name>SPIXFC_FIFO</name>
+   <description>SPI XiP Master Controller FIFO.</description>
+   <baseAddress>0x400BC000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>TX_8</name>
+     <description>SPI TX FIFO 8-Bit Write</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <dataType>uint8_t</dataType>
+    </register>
+    <register>
+     <name>TX_16</name>
+     <description>SPI TX FIFO 16-Bit Write</description>
+     <alternateRegister>TX_8</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <dataType>uint16_t</dataType>
+    </register>
+    <register>
+     <name>TX_32</name>
+     <description>SPI TX FIFO 32-Bit Write</description>
+     <alternateRegister>TX_8</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <dataType>uint32_t</dataType>
+    </register>
+    <register>
+     <name>RX_8</name>
+     <description>SPI RX FIFO 8-Bit Access</description>
+     <addressOffset>0x04</addressOffset>
+     <size>8</size>
+     <dataType>uint8_t</dataType>
+    </register>
+    <register>
+     <name>RX_16</name>
+     <description>SPI RX FIFO 16-Bit Access</description>
+     <alternateRegister>RX_8</alternateRegister>
+     <addressOffset>0x04</addressOffset>
+     <size>16</size>
+     <dataType>uint16_t</dataType>
+    </register>
+    <register>
+     <name>RX_32</name>
+     <description>SPI RX FIFO 32-Bit Access</description>
+     <alternateRegister>RX_8</alternateRegister>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+     <dataType>uint32_t</dataType>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXFC_FIFO SPI XiP Master Controller FIFO.-->
+  <peripheral>
+   <name>SPIXFM</name>
+   <description>SPIXF Master</description>
+   <baseAddress>0x40026000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CFG</name>
+     <description>SPIX Configuration Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Defines SPI Mode, Only valid values are 0 and 3.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SCLK_HI_SAMPLE_RISING</name>
+         <description>Description not available.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SCLK_LO_SAMPLE_FAILLING</name>
+         <description>Description not available.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSPOL</name>
+       <description>Slave Select Polarity.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ACTIVE_HIGH</name>
+         <description>Slave Select is Active High.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ACTIVE_LOW</name>
+         <description>Slave Select is Active Low.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEL</name>
+       <description>Slave Select. Only valid value is zero.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>LO_CLK</name>
+       <description>Number of system clocks that SCLK will be low when SCLK pulses are generated.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>HI_CLK</name>
+       <description>Number of system clocks that SCLK will be high when SCLK pulses are generated.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>SSACT</name>
+       <description>Slave Select Active Timing.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>off</name>
+         <description>0 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_2_mod_clk</name>
+         <description>2 System clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_4_mod_clk</name>
+         <description>4 System clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_8_mod_clk</name>
+         <description>8 System clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSIACT</name>
+       <description>Slave Select Inactive Timing.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>for_1_mod_clk</name>
+         <description>1 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_3_mod_clk</name>
+         <description>3 System clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_5_mod_clk</name>
+         <description>5 System clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_9_mod_clk</name>
+         <description>9 System clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FETCH_CTRL</name>
+     <description>SPIX Fetch Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>CMDVAL</name>
+       <description>Command Value sent to target to initiate fetching from SPI flash.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>CMD_WIDTH</name>
+       <description>Command Width. Number of data I/O used to send commands.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Single</name>
+         <description>Single SDIO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual_IO</name>
+         <description>Dual SDIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad_IO</name>
+         <description>Quad SDIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Invalid</name>
+         <description>Invalid.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_WIDTH</name>
+       <description>Address Width. Number of data I/O used to send address, and mode/dummy clocks.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Single</name>
+         <description>Single SDIO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual_IO</name>
+         <description>Dual SDIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad_IO</name>
+         <description>Quad SDIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Invalid</name>
+         <description>Invalid.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>Data Width. Number of data I/O used to receive data.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Single</name>
+         <description>Single SDIO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual_IO</name>
+         <description>Dual SDIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad_IO</name>
+         <description>Quad SDIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Invalid</name>
+         <description>Invalid.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FOUR_BYTE_ADDR</name>
+       <description>Four Byte Address Mode. Enables 4-byte Flash Address Mode.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>3</name>
+         <description>3 Byte Address Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4</name>
+         <description>4 Byte Address Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MODE_CTRL</name>
+     <description>SPIX Mode Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>MDCLK</name>
+       <description>Mode Clocks. Number of SPI clocks needed during mode/dummy phase of fetch.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>NO_CMD</name>
+       <description>No Command Mode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>always</name>
+         <description>Send read command every time SPI transaction is initiated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>once</name>
+         <description>Send read command only once. NO read command in subsequent SPI transactions.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE_SEND</name>
+       <description>Mode Send.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MODE_DATA</name>
+     <description>SPIX Mode Data Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Mode Data. Specifies the data to send with the Dummy/Mode clocks.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>OUT_EN</name>
+       <description>Mode Output Enable. Output enable state for each corresponding data bit in MD_DATA. 0: output enable off, I/O is tristate and 1: Output enable on, I/O is driving MD_DATA.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FB_CTRL</name>
+     <description>SPIX Feedback Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>FB_EN</name>
+       <description>Enable SCLK feedback mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable SCLK feedback mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable SCLK feedback mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INVERT_EN</name>
+       <description>Invert SCLK in feedback mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Invert SCLK feedback mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Invert SCLK feedback mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IO_CTRL</name>
+     <description>SPIX IO Control Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>SCLK_DS</name>
+       <description>SCLK drive Strength. This bit controls the drive strength on the SCLK pin.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Low</name>
+         <description>Low drive strength.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>High</name>
+         <description>High drive strength.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_DS</name>
+       <description>Slave Select Drive Strength. This bit controls the drive strength on the dedicated slave select pin.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Low</name>
+         <description>Low drive strength.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>High</name>
+         <description>High drive strength.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDIO_DS</name>
+       <description>SDIO Drive Strength. This bit controls the drive strength of all SDIO pins.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Low</name>
+         <description>Low drive strength.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>High</name>
+         <description>High drive strength.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PU_PD_CTRL</name>
+       <description>IO Pullup/Pulldown Control. These bits control the pullups and pulldowns associated with all SPI XiP SDIO pins.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>tri_state</name>
+         <description>Tristate.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pull_Up</name>
+         <description>Pull-Up.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pull_down</name>
+         <description>Pull-Down.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SEC_CTRL</name>
+     <description>SPIX Memory Security Control Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>DEC_EN</name>
+       <description>Decryption Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable decryption of SPIX data.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable decryption of SPIX data.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTH_DISABLE</name>
+       <description>Integrity Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Integrity checking enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Integrity checking disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUS_IDLE</name>
+     <description>Bus Idle</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>BUSIDLE</name>
+       <description>A 16-bit timer will be triggered for each external access. The timer will be
+                                         restarted if another access is performed before the timer expires. When the
+                                             timer expires, slave select will be deactivated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTHOFFSET</name>
+     <description>Auth Offset</description>
+     <addressOffset>0x28</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXFM SPIXF Master-->
+  <peripheral>
+   <name>SPI</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x40046000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>16</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>DATA32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>QSPIFIFO</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>DATA16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>DATA32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>QSPIFIFO</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>DATA8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>DATA32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>QSPIFIFO</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MASTER</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Start Select Control. Used in Master mode to control the behavior of the Slave Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DEASSERT</name>
+         <description>SPI De-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ASSERT</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3</name>
+         <description>SS3 is selected.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Rising_Edge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Falling_Edge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin(s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_POL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3_high</name>
+         <description>SS3 active high.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SS_TIME</name>
+     <description>Register for controlling SPI peripheral/Slave Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PRE</name>
+       <description>Slave Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POST</name>
+       <description>Slave Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_CFG</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCALE</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_FIFO_LEVEL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CLEAR</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write
+            pointers. This should be done when FIFO is not being accessed on the SPI side.
+          .</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CNT</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DMA_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_LEVEL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CLEAR</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CNT</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_DMA_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_FL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPI SPI peripheral.-->
+  <peripheral derivedFrom="SPI">
+   <name>SPI1</name>
+   <description>SPI peripheral. 1</description>
+   <baseAddress>0x40047000</baseAddress>
+   <interrupt>
+    <name>SPI1</name>
+    <description>SPI1 IRQ</description>
+    <value>17</value>
+   </interrupt>
+  </peripheral>
+<!--SPI1 SPI peripheral. 1-->
+  <peripheral derivedFrom="SPI">
+   <name>SPI2</name>
+   <description>SPI peripheral. 2</description>
+   <baseAddress>0x40048000</baseAddress>
+   <interrupt>
+    <name>SPI2</name>
+    <description>SPI2 IRQ</description>
+    <value>18</value>
+   </interrupt>
+  </peripheral>
+<!--SPI2 SPI peripheral. 2-->
+  <peripheral>
+   <name>TMR0</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting.</description>
+   <groupName>Timers</groupName>
+   <baseAddress>0x40010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR0</name>
+    <description>TMR0 IRQ</description>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Count.  This register stores the current timer count.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000001</resetValue>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Compare.  This register stores the compare value, which is used to set the maximum count value to initiate a reload of the timer to 0x0001.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x0000FFFF</resetValue>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>PWM.  This register stores the value that is compared to the current timer count.</description>
+     <addressOffset>0x08</addressOffset>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Clear Interrupt. Writing a value (0 or 1) to a bit in this register clears the associated interrupt.</description>
+     <addressOffset>0x0C</addressOffset>
+     <modifiedWriteValues>oneToClear</modifiedWriteValues>
+     <fields>
+      <field>
+       <name>IRQ</name>
+       <description>Clear Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CN</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>TMODE</name>
+       <description>Timer Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>oneShot</name>
+         <description>One Shot Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Continuous Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>counter</name>
+         <description>Counter Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pwm</name>
+         <description>PWM Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>capture</name>
+         <description>Capture Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>compare</name>
+         <description>Compare Mode.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>gated</name>
+         <description>Gated Mode.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>captureCompare</name>
+         <description>Capture/Compare Mode.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES</name>
+       <description>Prescaler.  Set the Timer's prescaler value. The prescaler divides the PCLK input to the timer and sets the Timer's Count Clock, F_CNT_CLK = PCLK (HZ) /prescaler. The Timer's prescaler setting is a 4-bit value with pres3:pres[2:0].</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TPOL</name>
+       <description>Timer input/output polarity bit.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TEN</name>
+       <description>Timer Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES3</name>
+       <description>MSB of prescaler value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC</name>
+       <description>Timer PWM Synchronization Mode Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NOLHPOL</name>
+       <description>Timer PWM output 0A polarity bit.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NOLLPOL</name>
+       <description>Timer PWM output 0A' polarity bit.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PWMCKBD</name>
+       <description>Timer PWM output 0A Mode Disable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>NOLLCMP</name>
+       <description>Non-overlapping Low Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A and next rising edge of PWM output 0A'.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>NOLHCMP</name>
+       <description>Non-overlapping High Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A' and next rising edge of PWM output 0A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TMR0 32-bit reloadable timer that can be used for timing and event counting.-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR1</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 1</description>
+   <baseAddress>0x40011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+<!--TMR1 32-bit reloadable timer that can be used for timing and event counting. 1-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR2</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 2</description>
+   <baseAddress>0x40012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+<!--TMR2 32-bit reloadable timer that can be used for timing and event counting. 2-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR3</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 3</description>
+   <baseAddress>0x40013000</baseAddress>
+   <interrupt>
+    <name>TMR3</name>
+    <description>TMR3 IRQ</description>
+    <value>8</value>
+   </interrupt>
+  </peripheral>
+<!--TMR3 32-bit reloadable timer that can be used for timing and event counting. 3-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR4</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 4</description>
+   <baseAddress>0x40014000</baseAddress>
+   <interrupt>
+    <name>TMR4</name>
+    <description>TMR4 IRQ</description>
+    <value>9</value>
+   </interrupt>
+  </peripheral>
+<!--TMR4 32-bit reloadable timer that can be used for timing and event counting. 4-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR5</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 5</description>
+   <baseAddress>0x40015000</baseAddress>
+   <interrupt>
+    <name>TMR5</name>
+    <description>TMR5 IRQ</description>
+    <value>10</value>
+   </interrupt>
+  </peripheral>
+<!--TMR5 32-bit reloadable timer that can be used for timing and event counting. 5-->
+  <peripheral>
+   <name>TRNG</name>
+   <description>Random Number Generator.</description>
+   <baseAddress>0x4004D000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TRNG</name>
+    <description>TRNG interrupt.</description>
+    <value>4</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>TRNG Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000003</resetValue>
+     <fields>
+      <field>
+       <name>ODHT</name>
+       <description>On Demand Health Test.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RND_IE</name>
+       <description>To enable IRQ generation when a new 32-bit Random number is ready.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HEALTH_EN</name>
+       <description>Health Test Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AESKG_USR</name>
+       <description>User block AES Key Gen.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AESKG_SYS</name>
+       <description>System block AES Key Gen.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>Wipe Key.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RDY</name>
+       <description>32-bit random data is ready to read from TRNG_DATA register. Reading TRNG_DATA when RND_RDY=0 will return all 0's. IRQ is generated when RND_RDY=1 if TRNG_CN.RND_IRQ_EN=1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ODHT</name>
+       <description>On demand health test.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HT</name>
+       <description>Health test status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRCFAIL</name>
+       <description>Source Fail.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AESKGD</name>
+       <description>AES Key Gen Status.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LD_CNT</name>
+       <description>Load Count.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data. The content of this register is valid only when RNG_IS =1. When TNRG is disabled, read returns 0x0000 0000.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRNG Random Number Generator.-->
+  <peripheral>
+   <name>UART0</name>
+   <description>UART</description>
+   <baseAddress>0x40042000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>UART0</name>
+    <description>UART0 IRQ</description>
+    <value>14</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ENABLE</name>
+       <description>UART enabled, to enable UART block, it is used to drive a gated clock in order to save power consumption when UART is not used. FIFOs are flushed when UART is disabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>UART disabled. FIFOs are flushed. Clock is gated off for power savings. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>UART enabled. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PARITY_EN</name>
+       <description>Enable/disable Parity bit (9th character).</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Parity </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Parity enabled as 9th bit</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PARITY</name>
+       <description>When PARITY_EN=1, selects odd, even, Mark or Space parity.
+                Mark parity = always 1;
+
+                Space parity = always 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Even</name>
+         <description>Even parity selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ODD</name>
+         <description>Odd parity selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>MARK</name>
+         <description>Mark parity selected.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SPACE</name>
+         <description>Space parity selected.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PARMD</name>
+       <description>Selects parity based on 1s or 0s count (when PARITY_EN=1).</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1</name>
+         <description>Parity calculation is based on number of 1s in frame.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>0</name>
+         <description>Parity calculation is based on number of 0s in frame.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Flushes the TX FIFO buffer.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Flushes the RX FIFO buffer.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BITACC</name>
+       <description>If set, bit accuracy is selected, in this case the bit duration is the same for all the bits with the optimal accuracy. But the frame duration can have a significant deviation from the expected baudrate.If clear, frame accuracy is selected, therefore bits can have different duration in order to guarantee the minimum frame deviation.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>FRAME</name>
+         <description>Frame accuracy.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BIT</name>
+         <description>Bit accuracy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CHAR_SIZE</name>
+       <description>Selects UART character size.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5</name>
+         <description>5 bits.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6</name>
+         <description>6 bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7</name>
+         <description>7 bits.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8</name>
+         <description>8 bits.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPBITS</name>
+       <description>Selects the number of stop bits that will be generated.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1</name>
+         <description>1 stop bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_5</name>
+         <description>1.5 stop bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLOW_CTRL</name>
+       <description>Enables/disables hardware flow control.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW Flow Control with RTS/CTS enabled</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW Flow Control disabled</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLOW_POL</name>
+       <description>RTS/CTS polarity.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0</name>
+         <description>RTS/CTS asserted is logic 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1</name>
+         <description>RTS/CTS asserted is logic 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NULL_MODEM</name>
+       <description>NULL Modem Support (RTS/CTS and TXD/RXD swap).</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Direct convention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Null Modem Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>Break control bit. It causes a break condition to be transmitted to receiving UART.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Break characters are not generated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Break characters are sent (all the bits are at '0' including start/parity/stop).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKSEL</name>
+       <description>Baud Rate Clock Source Select.  Selects the baud rate clock.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SYSTEM</name>
+         <description>System clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate 7.3727MHz internal clock.  Useful in low power modes when the system clock is slow.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_TO</name>
+       <description>RX Time Out. RX time out interrupt will occur after RXTO Uart
+                       characters if RX-FIFO is not empty and RX FIFO has not been read.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>THRESH_CTRL</name>
+     <description>Threshold Control register.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>RX_FIFO_THRESH</name>
+       <description>RX FIFO Threshold Level.When the RX FIFO reaches this many bytes or higher, UARTn_INFTL.rx_fifo_level is set.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_THRESH</name>
+       <description>TX FIFO Threshold Level. When the TX FIFO reaches this many bytes or higher, UARTn_INTFL.tx_fifo_level is set.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RTS_FIFO_THRESH</name>
+       <description>RTS threshold control. When the RX FIFO reaches this many bytes or higher, the RTS output signal is deasserted, informing the transmitting UART to stop sending data to this UART.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TX_BUSY</name>
+       <description>Read-only flag indicating the UART transmit status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_BUSY</name>
+       <description>Read-only flag indicating the UARTreceiver status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>PARITY</name>
+       <description>9th Received bit state. This bit identifies the state of the 9th bit of received data. Only available for UART_CTRL.SIZE[1:0]=3.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>Received BREAK status. BREAKS is cleared when UART_STAT register is read. Received data input is held in spacing (logic 0) state for longer than a full word transmission time (that is, the total time of Start bit + data bits + Parity + Stop bits).</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_EMPTY</name>
+       <description>Read-only flag indicating the RX FIFO state.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Read-only flag indicating the RX FIFO state.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Read-only flag indicating the TX FIFO state.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>Read-only flag indicating the TX FIFO state.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_FIFO_CNT</name>
+       <description>Indicates the number of bytes currently in the RX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_FIFO_CNT</name>
+       <description>Indicates the number of bytes currently in the TX FIFO.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>RX_FRAME_ERROR</name>
+       <description>Enable for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PARITY_ERROR</name>
+       <description>Enable for RX Parity Error interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_CHANGE</name>
+       <description>Enable for CTS signal change interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OVERRUN</name>
+       <description>Enable for RX FIFO OVerrun interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_THRESH</name>
+       <description>Enable for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_ALMOST_EMPTY</name>
+       <description>Enable for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_THRESH</name>
+       <description>Enable for interrupt when TX FIFO reaches the number of bytes configured by the TXTHD field.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>Enable for received BREAK character interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_TIMEOUT</name>
+       <description>Enable for RX Timeout Interrupt. Trigger if there is no RX communication during n UART characters (n=UART_CN.RXTO).</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LAST_BREAK</name>
+       <description>Enable for Last break character interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Interrupt Status Flags.</description>
+     <addressOffset>0x10</addressOffset>
+     <size>32</size>
+     <modifiedWriteValues>oneToClear</modifiedWriteValues>
+     <fields>
+      <field>
+       <name>FRAME</name>
+       <description>FLAG for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PARITY</name>
+       <description>FLAG for RX Parity Error interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_CHANGE</name>
+       <description>FLAG for CTS signal change interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OVERRUN</name>
+       <description>FLAG for RX FIFO Overrun interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_THRESH</name>
+       <description>FLAG for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_ALMOST_EMPTY</name>
+       <description>FLAG for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_THRESH</name>
+       <description>FLAG for interrupt when TX FIFO reaches the number of bytes configured by the TXTHD field.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>FLAG for received BREAK character interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_TIMEOUT</name>
+       <description>FLAG for RX Timeout Interrupt. Trigger if there is no RX communication during n UART characters (n=UART_CN.RXTO).</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LAST_BREAK</name>
+       <description>FLAG for Last break character interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BAUD0</name>
+     <description>Baud rate register. Integer portion.</description>
+     <addressOffset>0x14</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>IBAUD</name>
+       <description>Integer portion of baud rate divisor value. IBAUD = InputClock / (factor * Baud Rate Frequency).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>FACTOR</name>
+       <description>FACTOR must be chosen to have IDIV&gt;
+                0. factor used in calculation = 128 &gt;
+                &gt;
+                FACTOR.
+      </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>128</name>
+         <description>Baud Factor 128</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>64</name>
+         <description>Baud Factor 64</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>32</name>
+         <description>Baud Factor 32</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16</name>
+         <description>Baud Factor 16</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BAUD1</name>
+     <description>Baud rate register. Decimal Setting.</description>
+     <addressOffset>0x18</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DBAUD</name>
+       <description>Decimal portion of baud rate divisor value. DIV = InputClock/ (factor*Baud Rate Frequency). DDIV= (DIV-IDIV) *128.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Data buffer.</description>
+     <addressOffset>0x1C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>FIFO</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration.</description>
+     <addressOffset>0x20</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>TXDMA_EN</name>
+       <description>TX DMA channel enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>DMA is disabled </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>DMA is enabled </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXDMA_EN</name>
+       <description>RX DMA channel enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>DMA is disabled </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>DMA is enabled </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXDMA_START</name>
+       <description>Receive DMA Start.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXDMA_AUTO_TO</name>
+       <description>Receive DMA Timeout Start.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXDMA_LEVEL</name>
+       <description>TX threshold for DMA transmission.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RXDMA_LEVEL</name>
+       <description>RX threshold for DMA transmission.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TX_FIFO</name>
+     <description>Transmit FIFO Status register.</description>
+     <addressOffset>0x24</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Reading from this field returns the next character available at the output of the TX FIFO (if one is available, otherwise 00h is returned).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--UART0 UART-->
+  <peripheral derivedFrom="UART0">
+   <name>UART1</name>
+   <description>UART 1</description>
+   <baseAddress>0x40043000</baseAddress>
+   <interrupt>
+    <name>UART1</name>
+    <description>UART1 IRQ</description>
+    <value>15</value>
+   </interrupt>
+  </peripheral>
+<!--UART1 UART 1-->
+  <peripheral derivedFrom="UART0">
+   <name>UART2</name>
+   <description>UART 2</description>
+   <baseAddress>0x40044000</baseAddress>
+   <interrupt>
+    <name>UART2</name>
+    <description>UART2 IRQ</description>
+    <value>34</value>
+   </interrupt>
+  </peripheral>
+<!--UART2 UART 2-->
+  <peripheral derivedFrom="UART0">
+   <name>UART3</name>
+   <description>UART 3</description>
+   <baseAddress>0x40045000</baseAddress>
+   <interrupt>
+    <name>UART3</name>
+    <description>UART3 IRQ</description>
+    <value>88</value>
+   </interrupt>
+  </peripheral>
+<!--UART3 UART 3-->
+  <peripheral derivedFrom="UART0">
+   <name>UART4</name>
+   <description>UART 4</description>
+   <baseAddress>0x40023000</baseAddress>
+   <interrupt>
+    <name>UART4</name>
+    <description>UART4 IRQ</description>
+    <value>89</value>
+   </interrupt>
+  </peripheral>
+<!--UART4 UART 4-->
+  <peripheral derivedFrom="UART0">
+   <name>UART5</name>
+   <description>UART 5</description>
+   <baseAddress>0x40024000</baseAddress>
+   <interrupt>
+    <name>UART5</name>
+    <description>UART5 IRQ</description>
+    <value>90</value>
+   </interrupt>
+  </peripheral>
+<!--UART5 UART 5-->
+  <peripheral>
+   <name>USBHS</name>
+   <description>USB 2.0 High-speed Controller.</description>
+   <baseAddress>0x400B1000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>USB</name>
+    <value>2</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FADDR</name>
+     <description>Function address register.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <resetMask>0x00</resetMask>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Function address for this controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>UPDATE</name>
+       <description>Set when ADDR is written, cleared when new address takes effect.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>POWER</name>
+     <description>Power management register.</description>
+     <addressOffset>0x01</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>EN_SUSPENDM</name>
+       <description>Enable SUSPENDM signal.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SUSPEND</name>
+       <description>Suspend mode detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESUME</name>
+       <description>Generate resume signaling.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESET</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS_MODE</name>
+       <description>High-speed mode detected.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS_ENABLE</name>
+       <description>High-speed mode enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SOFTCONN</name>
+       <description>Softconn.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ISO_UPDATE</name>
+       <description>Wait for SOF during Isochronous xfers.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRIN</name>
+     <description>Interrupt register for EP0 and IN EP1-15.</description>
+     <addressOffset>0x02</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_IN_INT</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP14_IN_INT</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP13_IN_INT</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP12_IN_INT</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP11_IN_INT</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP10_IN_INT</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP9_IN_INT</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP8_IN_INT</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP7_IN_INT</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP6_IN_INT</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP5_IN_INT</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP4_IN_INT</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP3_IN_INT</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP2_IN_INT</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP1_IN_INT</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP0_IN_INT</name>
+       <description>Endpoint 0 interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTROUT</name>
+     <description>Interrupt register for OUT EP 1-15.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_OUT_INT</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP14_OUT_INT</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP13_OUT_INT</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP12_OUT_INT</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP11_OUT_INT</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP10_OUT_INT</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP9_OUT_INT</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP8_OUT_INT</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP7_OUT_INT</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP6_OUT_INT</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP5_OUT_INT</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP4_OUT_INT</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP3_OUT_INT</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP2_OUT_INT</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP1_OUT_INT</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRINEN</name>
+     <description>Interrupt enable for EP 0 and IN EP 1-15.</description>
+     <addressOffset>0x06</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_IN_INT_EN</name>
+       <description>Endpoint 15 interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP14_IN_INT_EN</name>
+       <description>Endpoint 14 interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP13_IN_INT_EN</name>
+       <description>Endpoint 13 interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP12_IN_INT_EN</name>
+       <description>Endpoint 12 interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP11_IN_INT_EN</name>
+       <description>Endpoint 11 interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP10_IN_INT_EN</name>
+       <description>Endpoint 10 interrupt enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP9_IN_INT_EN</name>
+       <description>Endpoint 9 interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP8_IN_INT_EN</name>
+       <description>Endpoint 8 interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP7_IN_INT_EN</name>
+       <description>Endpoint 7 interrupt enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP6_IN_INT_EN</name>
+       <description>Endpoint 6 interrupt enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP5_IN_INT_EN</name>
+       <description>Endpoint 5 interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP4_IN_INT_EN</name>
+       <description>Endpoint 4 interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP3_IN_INT_EN</name>
+       <description>Endpoint 3 interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP2_IN_INT_EN</name>
+       <description>Endpoint 2 interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP1_IN_INT_EN</name>
+       <description>Endpoint 1 interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP0_INT_EN</name>
+       <description>Endpoint 0 interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTROUTEN</name>
+     <description>Interrupt enable for OUT EP 1-15.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_OUT_INT_EN</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP14_OUT_INT_EN</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP13_OUT_INT_EN</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP12_OUT_INT_EN</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP11_OUT_INT_EN</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP10_OUT_INT_EN</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP9_OUT_INT_EN</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP8_OUT_INT_EN</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP7_OUT_INT_EN</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP6_OUT_INT_EN</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP5_OUT_INT_EN</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP4_OUT_INT_EN</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP3_OUT_INT_EN</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP2_OUT_INT_EN</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP1_OUT_INT_EN</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRUSB</name>
+     <description>Interrupt register for common USB interrupts.</description>
+     <addressOffset>0x0A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SOF_INT</name>
+       <description>Start of Frame.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESET_INT</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESUME_INT</name>
+       <description>Resume detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SUSPEND_INT</name>
+       <description>Suspend detected.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRUSBEN</name>
+     <description>Interrupt enable for common USB interrupts.</description>
+     <addressOffset>0x0B</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SOF_INT_EN</name>
+       <description>Start of Frame.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESET_INT_EN</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESUME_INT_EN</name>
+       <description>Resume detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SUSPEND_INT_EN</name>
+       <description>Suspend detected.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FRAME</name>
+     <description>Frame number.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>FRAMENUM</name>
+       <description>Read the last received frame number, that is the 11-bit frame number received in the SOF packet.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INDEX</name>
+     <description>Index for banked registers.</description>
+     <addressOffset>0x0E</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>INDEX</name>
+       <description>Index Register Access Selector. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TESTMODE</name>
+     <description>USB 2.0 test mode enable register.</description>
+     <addressOffset>0x0F</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>FORCE_FS</name>
+       <description>Force USB to Full-speed after reset.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FORCE_HS</name>
+       <description>Force USB to High-speed after reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_PKT</name>
+       <description>Transmit fixed test packet.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_K</name>
+       <description>Force USB to continuous K state.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_J</name>
+       <description>Force USB to continuous J state.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_SE0_NAK</name>
+       <description>Respond to any valid IN token with NAK.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INMAXP</name>
+     <description>Maximum packet size for INx endpoint (x == INDEX).</description>
+     <addressOffset>0x10</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>MAXPACKETSIZE</name>
+       <description>Maximum Packet Size in a Single Transaction. That is the maximum packet size in bytes, that is transmitted for each microframe. The maximum value is 1024, subject to the limitations of the endpoint type set in USB 2.0 Specification, Chapter 9</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+      <field>
+       <name>NUMPACKMINUS1</name>
+       <description>Number of Split Packets - 1. Defines the maximum number of packets minus 1 that a USB payload can be split into. THis must be an exact multiple of maxpacketsize. Only applicable for HS High-Bandwidth isochronous endpoints and Bulk endpoints. Ignored in all other cases. </description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CSR0</name>
+     <description>Control status register for EP 0 (when INDEX == 0).</description>
+     <addressOffset>0x12</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SERV_SETUP_END</name>
+       <description>Clear EP0 Setup End Bit. Write a 1 to clear the setupend bit. Automatically cleared after being set </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SERV_OUTPKTRDY</name>
+       <description>Clear EP0 Out Packet Ready Bit. Write a 1 to clear the outpktrdy bit. Automatically cleared after being set.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SEND_STALL</name>
+       <description>Send EP0 STALL Handshake. Write a 1 to this bit to terminate the current control transaction by sneding a STALL handshake. Automatically cleared after being set. </description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SETUP_END</name>
+       <description>Read Setup End Status. Automatically set when a contorl transaction ends before the dataend bit has been set by fimrware. An interrupt is generated when this bit is set. Write 1 to servicedsetupend to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_END</name>
+       <description>Control Transaction Data End. Write a 1 to this bit after firmware completes any of the following three transactions: 1. set inpktrdy = 1 for the last data packet. 2. Set inpktrdy =1 for a zero-length data packet. 3. Clear outpktrdy = 0 after unloading the last data packet. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENT_STALL</name>
+       <description> Read EP0 STALL Handshake Sent Status Automatically set when a STALL handshake is transmitted. Write a 0 to clear. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPKTRDY</name>
+       <description>EP0 IN Packet Ready 1: Write a 1 after writing a data packet to the IN FIFO. Automatically cleared when the data packet is transmitted. An interrupt is generated when this bit is cleared. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPKTRDY</name>
+       <description>EP0 OUT Packet Ready Status Automatically set when a data packet is received in the OUT FIFO. An interrupt is generated when this bit is set. Write a 1 to the servicedoutpktrdy bit (above) to clear after the packet is unloaded from the OUT FIFO. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INCSRL</name>
+     <description>Control status lower register for INx endpoint (x == INDEX).</description>
+     <alternateRegister>CSR0</alternateRegister>
+     <addressOffset>0x12</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>INCOMPTX</name>
+       <description>Read Incomplete Split Transfer Error Status High-bandwidth isochronous transfers: Automatically set when a payload is split into multiple packets but insufficient IN tokens were received to send all packets. The current packets is flushed from the IN FIFO. Write 0 to clear.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLRDATATOG</name>
+       <description>Write 1 to clear IN endpoint data-toggle to 0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENTSTALL</name>
+       <description>Read STALL Handshake Sent Status Automatically set when a STALL handshake is transmitted, at which time the IN FIFO is flushed, and inpktrdy is cleared. Write 0 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENDSTALL</name>
+       <description>Send STALL Handshake.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>terminate</name>
+         <description>Terminate STALL handhsake</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Respond to an IN token with a STALL handshake</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSHFIFO</name>
+       <description>Flush Next Packet from IN FIFO. Write 1 to clear</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>UNDERRUN</name>
+       <description>Read IN FIFO Underrun Error Status Isochronous Mode: Automatically set if the IN FIFO is empty. Write 0 to clear</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFONOTEMPTY</name>
+       <description>Read FIFO Not Empty Status. Automatically set when there is at least one packet in the IN FIFO. Write a 0 to clear. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPKTRDY</name>
+       <description>IN Packet Ready. Write a 1 to clear </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INCSRU</name>
+     <description>Control status upper register for INx endpoint (x == INDEX).</description>
+     <addressOffset>0x13</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>AUTOSET</name>
+       <description>Auto Set inpktrdy. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>set</name>
+         <description>USBHS_INCSRL_inpktrdy must be set by firmware.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>auto</name>
+         <description>USBHS_INCSRL_inpktrdy is automatically set. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ISO</name>
+       <description>Isochronous Transfer Enable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>interrupt</name>
+         <description>Enable IN Bulk and IN interrupt transfers.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>isochronous</name>
+         <description>Enable IN Isochronous transfers. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description> Endpoint Direction Mode.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>out</name>
+         <description>Endpoint direction is OUT.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>in</name>
+         <description>Endpoint direction is IN. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FRCDATATOG</name>
+       <description> Force In Data - Toggle</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>received</name>
+         <description>Toggle data-toglge only when an ACK is received.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dontcare</name>
+         <description>Toggle data-toggle regardless of ACK. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPKTBUFDIS</name>
+       <description> Double Packet Buffering Disable </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Double packet buffering.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Double Packet Buffering.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTMAXP</name>
+     <description>Maximum packet size for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x14</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>NUMPACKMINUS1</name>
+       <description>Number of Split Packets -1. Defines the maximum number of packets - 1 that a usb payload is combined into. The value must be exact multiple of maxpacketsize. </description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>MAXPACKETSIZE</name>
+       <description>Maximum Packet in a Single Transaction. This is the maximum packet size, in bytes, that is transmitted for each microframe. The maximum value is 1024, subject to the limitations for the endpoint type set in USB2.0 spesification, chapter 9.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCSRL</name>
+     <description>Control status lower register for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x16</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>CLRDATATOG</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENTSTALL</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENDSTALL</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FLUSHFIFO</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DATAERROR</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>OVERRUN</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFOFULL</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>OUTPKTRDY</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCSRU</name>
+     <description>Control status upper register for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x17</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>AUTOCLEAR</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ISO</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DISNYET</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DPKTBUFDIS</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INCOMPRX</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>COUNT0</name>
+     <description>Number of received bytes in EP 0 FIFO (INDEX == 0).</description>
+     <addressOffset>0x18</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>COUNT0</name>
+       <description>Read Number of Data Bytes in the Endpoint 0 FIFO. Returns the number of data bytes in the endpoint 0 FIFO. This value changes as contents of the FIFO change. The value is only valued when USBHS_OUTSCRL_outpktrdy = 1 </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCOUNT</name>
+     <description>Number of received bytes in OUT EPx FIFO (x == INDEX).</description>
+     <alternateRegister>COUNT0</alternateRegister>
+     <addressOffset>0x18</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>OUTCOUNT</name>
+       <description>Read Number of Data Bytes in OUT FIFO. Returns the number of data bytes in the packet that are read next in the OUT FIFO. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>13</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO0</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO0</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO1</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO1</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO2</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO2</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO3</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x2c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO3</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO4</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO4</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO5</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO5</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO6</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO6</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO7</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x3c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO7</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO8</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO8</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO9</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO9</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO10</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO10</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO11</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x4c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO11</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO12</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO12</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO13</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO13</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO14</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO14</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO15</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x5c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO15</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HWVERS</name>
+     <description>HWVERS</description>
+     <addressOffset>0x6c</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>USBHS_HWVERS</name>
+       <description>USBHS Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EPINFO</name>
+     <description>Endpoint hardware information.</description>
+     <addressOffset>0x78</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>OUTENDPOINTS</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>INTENDPOINTS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RAMINFO</name>
+     <description>RAM width information.</description>
+     <addressOffset>0x79</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RAMBITS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SOFTRESET</name>
+     <description>Software reset register.</description>
+     <addressOffset>0x7A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RSTXS</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RSTS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTUCH</name>
+     <description>Chirp timeout timer setting.</description>
+     <addressOffset>0x80</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>C_T_UCH</name>
+       <description>HS Chirp Timeout Clock Cycles. This configures the chirp timeout used by this device to negotiate a HS connection with a FS Host. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTHSRTN</name>
+     <description>Sets delay between HS resume to UTM normal operating mode.</description>
+     <addressOffset>0x82</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>C_T_HSTRN</name>
+       <description>High Speed Resume Delay Clock Cycles. This configures the delay from when the RESUME state on the bus ends, the when the USBHS resumes normal operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_USB_REG_00</name>
+     <description>MXM_USB_REG_00</description>
+     <addressOffset>0x400</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_UTMI_RESET</name>
+     <description>M31_PHY_UTMI_RESET</description>
+     <addressOffset>0x404</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_UTMI_VCONTROL</name>
+     <description>M31_PHY_UTMI_VCONTROL</description>
+     <addressOffset>0x408</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CLK_EN</name>
+     <description>M31_PHY_CLK_EN</description>
+     <addressOffset>0x40C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_PONRST</name>
+     <description>M31_PHY_PONRST</description>
+     <addressOffset>0x410</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_NONCRY_RSTB</name>
+     <description>M31_PHY_NONCRY_RSTB</description>
+     <addressOffset>0x414</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_NONCRY_EN</name>
+     <description>M31_PHY_NONCRY_EN</description>
+     <addressOffset>0x418</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_EN</name>
+     <description>M31_PHY_U2_COMPLIANCE_EN</description>
+     <addressOffset>0x420</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_DAC_ADJ</name>
+     <description>M31_PHY_U2_COMPLIANCE_DAC_ADJ</description>
+     <addressOffset>0x424</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_DAC_ADJ_EN</name>
+     <description>M31_PHY_U2_COMPLIANCE_DAC_ADJ_EN</description>
+     <addressOffset>0x428</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CLK_RDY</name>
+     <description>M31_PHY_CLK_RDY</description>
+     <addressOffset>0x42C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_PLL_EN</name>
+     <description>M31_PHY_PLL_EN</description>
+     <addressOffset>0x430</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_BIST_OK</name>
+     <description>M31_PHY_BIST_OK</description>
+     <addressOffset>0x434</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DATA_OE</name>
+     <description>M31_PHY_DATA_OE</description>
+     <addressOffset>0x438</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_OSCOUTEN</name>
+     <description>M31_PHY_OSCOUTEN</description>
+     <addressOffset>0x43C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_LPM_ALIVE</name>
+     <description>M31_PHY_LPM_ALIVE</description>
+     <addressOffset>0x440</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_HS_BIST_MODE</name>
+     <description>M31_PHY_HS_BIST_MODE</description>
+     <addressOffset>0x444</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CORECLKIN</name>
+     <description>M31_PHY_CORECLKIN</description>
+     <addressOffset>0x448</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XTLSEL</name>
+     <description>M31_PHY_XTLSEL</description>
+     <addressOffset>0x44C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_LS_EN</name>
+     <description>M31_PHY_LS_EN</description>
+     <addressOffset>0x450</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DEBUG_SEL</name>
+     <description>M31_PHY_DEBUG_SEL</description>
+     <addressOffset>0x454</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DEBUG_OUT</name>
+     <description>M31_PHY_DEBUG_OUT</description>
+     <addressOffset>0x458</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_OUTCLKSEL</name>
+     <description>M31_PHY_OUTCLKSEL</description>
+     <addressOffset>0x45C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_31_0</name>
+     <description>M31_PHY_XCFGI_31_0</description>
+     <addressOffset>0x460</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_63_32</name>
+     <description>M31_PHY_XCFGI_63_32</description>
+     <addressOffset>0x464</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_95_64</name>
+     <description>M31_PHY_XCFGI_95_64</description>
+     <addressOffset>0x468</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_127_96</name>
+     <description>M31_PHY_XCFGI_127_96</description>
+     <addressOffset>0x46C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_137_128</name>
+     <description>M31_PHY_XCFGI_137_128</description>
+     <addressOffset>0x470</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_HS_COARSE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_HS_COARSE_TUNE_NUM</description>
+     <addressOffset>0x474</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_HS_FINE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_HS_FINE_TUNE_NUM</description>
+     <addressOffset>0x478</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_FS_COARSE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_FS_COARSE_TUNE_NUM</description>
+     <addressOffset>0x47C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_FS_FINE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_FS_FINE_TUNE_NUM</description>
+     <addressOffset>0x480</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_LOCK_RANGE_MAX</name>
+     <description>M31_PHY_XCFG_LOCK_RANGE_MAX</description>
+     <addressOffset>0x484</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_LOCK_RANGE_MIN</name>
+     <description>M31_PHY_XCFGI_LOCK_RANGE_MIN</description>
+     <addressOffset>0x488</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_OB_RSEL</name>
+     <description>M31_PHY_XCFG_OB_RSEL</description>
+     <addressOffset>0x48C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_OC_RSEL</name>
+     <description>M31_PHY_XCFG_OC_RSEL</description>
+     <addressOffset>0x490</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGO</name>
+     <description>M31_PHY_XCFGO</description>
+     <addressOffset>0x494</addressOffset>
+    </register>
+    <register>
+     <name>MXM_INT</name>
+     <description>USB Added Maxim Interrupt Flag Register.</description>
+     <addressOffset>0x498</addressOffset>
+     <fields>
+      <field>
+       <name>VBUS</name>
+       <description>VBUS</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOVBUS</name>
+       <description>NOVBUS</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_INT_EN</name>
+     <description>USB Added Maxim Interrupt Enable Register.</description>
+     <addressOffset>0x49C</addressOffset>
+     <fields>
+      <field>
+       <name>VBUS</name>
+       <description>VBUS</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOVBUS</name>
+       <description>NOVBUS</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_SUSPEND</name>
+     <description>USB Added Maxim Suspend Register.</description>
+     <addressOffset>0x4A0</addressOffset>
+     <fields>
+      <field>
+       <name>SEL</name>
+       <description>Suspend register</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_REG_A4</name>
+     <description>USB Added Maxim Power Status Register</description>
+     <addressOffset>0x4A4</addressOffset>
+     <fields>
+      <field>
+       <name>VRST_VDDB_N_A</name>
+       <description>VRST_VDDB_N_A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--USBHS USB 2.0 High-speed Controller.-->
+  <peripheral>
+   <name>WDT0</name>
+   <description>Watchdog Timer 0</description>
+   <baseAddress>0x40003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WDT0</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x7FFFF000</resetMask>
+     <fields>
+      <field>
+       <name>INT_PERIOD</name>
+       <description>Watchdog Interrupt Period. The watchdog timer will assert an interrupt, if enabled, if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_PERIOD</name>
+       <description>Watchdog Reset Period. The watchdog timer will assert a reset, if enabled, if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_EN</name>
+       <description>Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_FLAG</name>
+       <description>Watchdog Timer Interrupt Flag.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EN</name>
+       <description>Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EN</name>
+       <description>Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_FLAG</name>
+       <description>Watchdog Timer Reset Flag.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>WDT_RST</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WDT0 Watchdog Timer 0-->
+  <peripheral derivedFrom="WDT0">
+   <name>WDT1</name>
+   <description>Watchdog Timer 0 1</description>
+   <baseAddress>0x40003400</baseAddress>
+   <interrupt>
+    <name>WDT1</name>
+    <description>WDT1 IRQ</description>
+    <value>57</value>
+   </interrupt>
+  </peripheral>
+<!--WDT1 Watchdog Timer 0 1-->
+  <peripheral>
+   <name>SKBD</name>
+   <description>Secure Keyboard</description>
+   <baseAddress>0x40032000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Secure_Keypad</name>
+    <description>Secure Keypad interrupt</description>
+    <value>19</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CR0</name>
+     <description>Input Output Select Bits.  Each bit of IOSEL selects the pin direction for the corresponding KBDIO pin.  If IOSEL[0] = 1, KBDIO0 is an output.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>KBDIO_0</name>
+       <description>Input Output Select for KBDIO0 pin.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Input</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Output</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CR1</name>
+     <description>Control Register 1</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>AUTOEN</name>
+       <description>Automatic Keyboard Scan Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="AUTOEN">
+       <name>CLEAR</name>
+       <description>Auto Clear Bit</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTNB</name>
+       <description>Output Number. Number of KBDIO pins selected as outputs. NOTE:
+                                                                                                                                                                     Output pins must be allocated contiguously starting with KBDIO0 and continuing through to KBDIO7.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>DBTM</name>
+       <description>Debounce Time. Number of milliseconds a keypress event must be active before it is considered actual. NOTE:
+                                                                                                                                                                     Debounce time values based on system running from an external 12MHz clock source with PLL0 enabled.  Other external crystal values will cause the debounce time to scale linearly.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>time4ms</name>
+         <description>4.1 ms</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>time5ms</name>
+         <description>5.3 ms</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>time6ms</name>
+         <description>6.5 ms</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>time7ms</name>
+         <description>7.6 ms</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>time8ms</name>
+         <description>8.8 ms</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>time10ms</name>
+         <description>10.0 ms</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>time11ms</name>
+         <description>11.2 ms</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>time12ms</name>
+         <description>12.3 ms</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SR</name>
+     <description>Status Register</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>Busy bit. This bit is set by hardware when the automatic keyboard scan is enabled and running.  This bit is clear at all other times.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IER</name>
+     <description>Interrupt Enable Register</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>PUSHIE</name>
+       <description>Push Event Enable Bit. When set, this bit enables an interrupt to be generated on a key push event.  Automatic keyboard scan must be enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="PUSHIE">
+       <name>RELEASEIE</name>
+       <description>Release Event Enable Bit. When set, this bit enables an interrupt to be generated on a key release event.  Automatic keyboard scan must be enabled.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="PUSHIE">
+       <name>OVERIE</name>
+       <description>Overrun Event Enable Bit. When set, this bit enables an interrupt to be generated on an overrun event.  Automatic keyboard scan must be enabled.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ISR</name>
+     <description>Interrupt Status Register</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>PUSHIS</name>
+       <description>Push Interrupt Flag. This bit is set by hardware when a key has been pushed.  If the interrupt is enabled for this flag, a system interrupt will be fired.  If the interrupt enable is not set, the flag will be set, but no interrupt will fire.  This bit must be cleared by software.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="PUSHIS">
+       <name>RELEASEIS</name>
+       <description>Release Interrupt Flag. This bit is set by hardware when a key has been released.  If the interrupt is enabled for this flag, a system interrupt will be fired.  If the interrupt enable is not set, the flag will be set, but no interrupt will fire.  This bit must be cleared by software.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="PUSHIS">
+       <name>OVERIS</name>
+       <description>Overrun Event Enable Bit. This bit is set by hardware when an overrun event has occurred.  If the interrupt is enabled for this flag, a system interrupt will be fired.  If the interrupt enable is not set, the flag will be set, but no interrupt will fire.  This bit must be cleared by software.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>EVENT[%s]</name>
+     <description>Key Register</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00000C00</resetValue>
+     <fields>
+      <field>
+       <name>IOIN</name>
+       <description>IO Input. Input pin of key event.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>IOOUT</name>
+       <description>IO Output. Output pin of key event.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>PUSH</name>
+       <description>If set to 1 the key has been released.  If set to 0 the key has been pushed.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pushed</name>
+         <description>Pushed</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>released</name>
+         <description>Released</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>If set to 1 this register has been read.  If set to 0 the key register has not been read since its last change.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notRead</name>
+         <description>This register has not been read since its last change.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>This register has been read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NEXT</name>
+       <description>If set to 1 one of the next key registers (x+1 to 3) contains a key event.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>none</name>
+         <description>No more key register contain a key event.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>more</name>
+         <description>Other key registers contain a key event.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SKBD Secure Keyboard-->
+ </peripherals>
+</device>

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32572/Include/max32572.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32572/Include/max32572.svd
@@ -1,0 +1,18935 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max32572</name>
+ <series>ARMCM4</series>
+ <version>1.0</version>
+ <description>MAX32572 32-bit ARM Cortex-M4 microcontroller, 1024KB of flash, 760KB of system RAM, 128KB of Boot ROM.</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>ADC</name>
+   <description>10-bit Analog to Digital Converter</description>
+   <baseAddress>0x40034000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>ADC</name>
+    <description>ADC IRQ</description>
+    <value>20</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>ADC Control</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Start ADC Conversion</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PWR</name>
+       <description>ADC Power Up</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>REBUF_PWR</name>
+       <description>ADC Reference Buffer Power Up</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CHGPUMP_PWR</name>
+       <description>ADC Charge Pump Power Up</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>REF_SCALE</name>
+       <description>ADC Reference Scale</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SCALE</name>
+       <description>ADC Scale</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLK_EN</name>
+       <description>ADC Clock Enable</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_SEL</name>
+       <description>ADC Channel Select</description>
+       <bitRange>[16:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AIN0</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN1</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN2</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN3</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN4</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN5</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN6</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN7</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VcoreA</name>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VcoreB</name>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vrxout</name>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vtxout</name>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VddA</name>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VddB</name>
+         <description>VddB/4</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vddio</name>
+         <description>Vddio/4</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vddioh</name>
+         <description>Vddioh/4</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VregI</name>
+         <description>VregI/4</description>
+         <value>16</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DIVSEL</name>
+       <description>Scales the external inputs, all inputs are scaled the same</description>
+       <bitRange>[18:17]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV3</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ALIGN</name>
+       <description>ADC Data Alignment Select</description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>ADC Status</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ACTIVE</name>
+       <description>ADC Conversion In Progress</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>AFE_PWR_UP_ACTIVE</name>
+       <description>AFE Power Up Delay Active</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>OVERFLOW</name>
+       <description>ADC Overflow</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>ADC Output Data</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>ADC Converted Sample Data Output</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>ADC Interrupt Control Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONE_IE</name>
+       <description>ADC Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>REF_READY_IE</name>
+       <description>ADC Reference Ready Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>HI_LIMIT_IE</name>
+       <description>ADC Hi Limit Monitor Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>LO_LIMIT_IE</name>
+       <description>ADC Lo Limit Monitor Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OVERFLOW_IE</name>
+       <description>ADC Overflow Interrupt Enable</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DONE_IF</name>
+       <description>ADC Done Interrupt Flag</description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>REF_READY_IF</name>
+       <description>ADC Reference Ready Interrupt Flag</description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>HI_LIMIT_IF</name>
+       <description>ADC Hi Limit Monitor Interrupt Flag</description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>LO_LIMIT_IF</name>
+       <description>ADC Lo Limit Monitor Interrupt Flag</description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>OVERFLOW_IF</name>
+       <description>ADC Overflow Interrupt Flag</description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>PENDING</name>
+       <description>ADC Interrupt Pending Status</description>
+       <bitRange>[22:22]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>LIMIT[%s]</name>
+     <description>ADC Limit</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CH_LO_LIMIT</name>
+       <description>Low Limit Threshold</description>
+       <bitRange>[9:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_HI_LIMIT</name>
+       <description>High Limit Threshold</description>
+       <bitRange>[21:12]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_SEL</name>
+       <description>ADC Channel Select</description>
+       <bitRange>[27:24]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_LO_LIMIT_EN</name>
+       <description>Low Limit Monitoring Enable</description>
+       <bitRange>[28:28]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_HI_LIMIT_EN</name>
+       <description>High Limit Monitoring Enable</description>
+       <bitRange>[29:29]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DECCNT</name>
+     <description>ADC Decimation Count.</description>
+     <addressOffset>0x0020</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DELAY</name>
+       <description>Delay.</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ADC 10-bit Analog to Digital Converter-->
+  <peripheral>
+   <name>AESKEYS</name>
+   <description>AES Key Registers.</description>
+   <baseAddress>0x40005000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>MEU[%s]</name>
+     <description>AES-256 SRAM Encryption Key (MEU).</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>XIP[%s]</name>
+     <description>AES-128 QSPI Code Key (MEMPROT XIP).</description>
+     <addressOffset>0x20</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+    </register>
+   </registers>
+  </peripheral>
+<!--AESKEYS AES Key Registers.-->
+  <peripheral>
+   <name>MSRADC</name>
+   <description>Magnetic Strip Reader - 9 bit ADC</description>
+   <baseAddress>0x4002B000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>ADC9</name>
+    <description>ADC IRQ</description>
+    <value>22</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>ADC Control</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>ADC Clock Divider.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ACHSEL</name>
+       <description>A Channel ADC Input Pin Selection.</description>
+       <bitRange>[10:8]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>invalid</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CH1_IN</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CH2_IN</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CH3_IN</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ACHSEL">
+       <name>BCHSEL</name>
+       <description>B Channel ADC Input Pin Selection.</description>
+       <bitRange>[13:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field derivedFrom="ACHSEL">
+       <name>CCHSEL</name>
+       <description>C Channel ADC Input Pin Selection.</description>
+       <bitRange>[16:14]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field derivedFrom="ACHSEL">
+       <name>DCHSEL</name>
+       <description>D Channel ADC Input Pin Selection.</description>
+       <bitRange>[19:17]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field derivedFrom="ACHSEL">
+       <name>ECHSEL</name>
+       <description>E Channel ADC Input Pin Selection.</description>
+       <bitRange>[22:20]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field derivedFrom="ACHSEL">
+       <name>FCHSEL</name>
+       <description>F Channel ADC Input Pin Selection.</description>
+       <bitRange>[25:23]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field derivedFrom="ACHSEL">
+       <name>GCHSEL</name>
+       <description>G Channel ADC Input Pin Selection.</description>
+       <bitRange>[28:26]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field derivedFrom="ACHSEL">
+       <name>HCHSEL</name>
+       <description>H Channel ADC Input Pin Selection.</description>
+       <bitRange>[31:29]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMD</name>
+     <description>MSRADC Command</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RST</name>
+       <description>ADC Reset.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SNGLSMPL</name>
+       <description>Single Sample Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CONTSMPL</name>
+       <description>Continuous Sample Mode Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ROTLIMIT</name>
+       <description>Rotation Limit.</description>
+       <bitRange>[6:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1_channel</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_channels</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_channels</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_channels</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5_channels</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_channels</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7_channels</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_channels</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKSEL</name>
+       <description>Clock Select.</description>
+       <bitRange>[10:8]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>3_samples</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5_samples</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_samples</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_samples</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_samples</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>32_samples</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>64_samples</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>128_samples</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>ADC FIFO</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SAMPLE</name>
+       <description>ADC Converted Sample Data Output</description>
+       <bitRange>[8:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>INPUT</name>
+       <description>ADC Sample Pin</description>
+       <bitRange>[11:9]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>invalid</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CH1_IN</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CH2_IN</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CH3_IN</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CH4_IN</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CH5_IN</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CH6_IN</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CH7_IN</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INCOMPLETE</name>
+       <description>ADC Incomplete.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>ADC Interrupt Enable Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SET_FIFOLVL</name>
+       <description>Set FIFO Interrupt Level.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>at_least_1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>at_least_2</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>at_least_3</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>at_least_4</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>at_least_5</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>at_least_6</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>at_least_7</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>at_least_8</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>at_least_9</name>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>at_least_10</name>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>at_least_11</name>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>at_least_12</name>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>at_least_13</name>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>at_least_14</name>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>at_least_15</name>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>at_least_16</name>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMAREQ</name>
+       <description>DMA Request Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_OV</name>
+       <description>FIFO Overflow Interrupt Enable.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_UN</name>
+       <description>FIFO Underflow Interrupt Enable.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_LVL</name>
+       <description>FIFO Level Interrupt Enable.</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>GLOBAL</name>
+       <description>ADC Global Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>ADC Interrupt Flag Register.</description>
+     <access>read-write</access>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>FIFOCNT</name>
+       <description>FIFO Count.</description>
+       <bitRange>[5:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>FIFO_FULL_ST</name>
+       <description>FIFO Full Status.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>FIFO_EM_ST</name>
+       <description>FIFO Empty Status.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>FIFO_OV</name>
+       <description>FIFO Overflow Status.</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>FIFO_UN</name>
+       <description>FIFO Underflow Status.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>FIFO_LVL</name>
+       <description>FIFO Level Status.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>GLOBAL</name>
+       <description>ADC Global Interrupt Flag.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--MSRADC Magnetic Strip Reader - 9 bit ADC-->
+  <peripheral>
+   <name>FCR</name>
+   <description>Function Control Register.</description>
+   <baseAddress>0x40000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>FCTRL0</name>
+     <description>Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>USBCLKSEL</name>
+       <description>USB External Core Clock Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>sys</name>
+         <description>Generated clock from system clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dig</name>
+         <description>Digital clock from a GPIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0DGEN0</name>
+       <description>I2C0 SDA Glitch Filter Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0DGEN1</name>
+       <description>I2C0 SCL Glitch Filter Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN0</name>
+       <description>I2C1 SDA Glitch Filter Enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN1</name>
+       <description>I2C1 SCL Glitch Filter Enable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FCTRL1</name>
+     <description>Register 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>AC_EN</name>
+       <description>Auto-calibration Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AC_RUN</name>
+       <description>Autocalibration Run.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOAD</name>
+       <description>Load Trim.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INV_GAIN</name>
+       <description>Invert Gain.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ATOMIC</name>
+       <description>Atomic mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MU</name>
+       <description>MU value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>AC_TRIM</name>
+       <description>150MHz HFIO Auto Calibration Trim</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FCTRL3</name>
+     <description>Register 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONECNT</name>
+       <description>Auto-calibration Done Counter Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>URVBOOTADDR</name>
+     <description>Register 4.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BOOTADDR</name>
+       <description>RISCV Boot Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>URVCTRL</name>
+     <description>Register 5.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SLEEP_REQ</name>
+       <description>Sleep Request to RISCV.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SLEEP_ACK</name>
+       <description>Acknowledgement of Sleep Request for RISCV.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GP</name>
+     <description>General Purpose Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>GP</name>
+       <description>General Purpose.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIMCTRL</name>
+     <description>MSR ADC Trim Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MSR_R1</name>
+       <description>MSR R1</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0K</name>
+         <description>0kOhm</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1P2K</name>
+         <description>1.2kOhm</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2P4K</name>
+         <description>2.4kOhm</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4P8K</name>
+         <description>4.8kOhm</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MSR_R2</name>
+       <description>MSR R2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>OPEN</name>
+         <description>Open drain.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3K</name>
+         <description>3kOhm</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6K</name>
+         <description>6kOhm</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12K</name>
+         <description>12kOhm</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>24K</name>
+         <description>24kOhm</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ERFOKS</name>
+     <description>ERFO Kick Start Register.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CTRL</name>
+       <description>Kick Start Control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FCR Function Control Register.-->
+  <peripheral>
+   <name>TRIMSIR</name>
+   <description>Trim System Initilazation Registers</description>
+   <baseAddress>0x40005400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>BBSIR2</name>
+     <description>System Init. Configuration Register 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>BBSIR3</name>
+     <description>System Init. Configuration Register 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRIMSIR Trim System Initilazation Registers-->
+  <peripheral>
+   <name>MCR</name>
+   <description>Misc Control.</description>
+   <baseAddress>0x40006C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>PDOWN</name>
+     <description>PDOWN Drive Strength</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>PDOWNDS</name>
+       <description>PDOWN Drive Strength</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>PDOWNVS</name>
+       <description>PDOWN Voltage Select</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Misc Power State Control Register</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>VDDCSW</name>
+       <description>Controls switching of VCORE</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>USBSWEN_N</name>
+       <description>USB Switch Control</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>off</name>
+         <description>USB SW off in LP modes</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>on</name>
+         <description>USB SW On</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>P1M</name>
+       <description>Enable the Reset Pad Pull Up Resistors</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1m</name>
+         <description>1MOhm Pullup</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>25k</name>
+         <description>25kOhm Pullup.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>rstn_voltage_sel</name>
+       <description>Error! Description not Found!</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ERTCO_PD</name>
+       <description>32kHz Crystal Oscillator Power Down.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>32kHz Crystal Oscillator Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Reset Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RTC</name>
+       <description>Real Time Cock Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RTCTRIM</name>
+     <description>RTC Trim Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>TRIM_X1</name>
+       <description>RTC Trim X1</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TRIM_X2</name>
+       <description>RTC TRIM X2</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LDOCTRL</name>
+     <description>LDO Control Register.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>0P9V_EN</name>
+       <description>LDO 0.9V Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWRMONST</name>
+     <description>Power Monitor Statuses Register.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>PORZ_VLOSS</name>
+       <description>Sticky bit indicating power on status of core power domains.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PORZ_VBAT</name>
+       <description>Sticky bit indicating power on status of the battery.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PORZ_VRTC</name>
+       <description>Sticky bit indicating power on status of the RTC.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PORZ_VDDC</name>
+       <description>Sticky bit indicating power on status of VCORE.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PORZ_VDDA</name>
+       <description>Sticky bit indicating power on status of VDDA.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PORZ_VDDB</name>
+       <description>Sticky bit indicating power on status of VDDB.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RSTZ_VDDC</name>
+       <description>Sticky bit indicating reset condition on VCORE.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RSTZ_VDDA</name>
+       <description>Sticky bit indicating reset condition on VDDA.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RSTZ_VDDB</name>
+       <description>Sticky bit indicating reset condition on VDDB.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RSTZ_VDDIO</name>
+       <description>Sticky bit indicating reset condition on VDDIO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RSTZ_VDDIOH</name>
+       <description>Sticky bit indicating reset condition on VDDIOH.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RSTZ_VRTC</name>
+       <description>Sticky bit indicating reset condition on RTC.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RSTZ_LDO_0P9V</name>
+       <description>Non-sticky bit indicating reset condition on 0.9V USB supply.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RSTZ_VDDCA</name>
+       <description>Non-sticky bit indicating reset condition on VCORE in Analog supply.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RSTZ_VCOREHV</name>
+       <description>Non-sticky bit indicating high voltage reset condition on VCORE supply.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RSTZ_VDDIOHV</name>
+       <description>Non-sticky bit indicating high voltage reset condition on VDDIO supply.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RSTZ_VDDIOHHV</name>
+       <description>Non-sticky bit indicating high voltage reset condition on VDDIOH supply.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--MCR Misc Control.-->
+  <peripheral>
+   <name>CTB</name>
+   <description>The Cryptographic Toolbox is a combination of cryptographic engines and a secure cryptographic accelerator (SCA) used to provide advanced cryptographic security.</description>
+   <baseAddress>0x40001000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Crypto_Engine</name>
+    <description>Crypto Engine interrupt.</description>
+    <value>27</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Crypto Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0xC0000000</resetValue>
+     <fields>
+      <field>
+       <name>RST</name>
+       <description>Reset. This bit is used to reset the crypto accelerator.  All crypto internal states and related registers are reset to their default reset values. Control register such as CRYPTO_CTRL, CIPHER_CTRL, HASH_CTRL, CRC_CTRL, MAA_CTRL (with the exception of the STC bit), HASH_MSG_SZ_[3:0] and MAA_MAWS will retain their values. This bit will automatically clear itself after one cycle.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_write</name>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>Starts reset operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INTR</name>
+       <description>Interrupt Enable. Generates an interrupt when done or error set.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRC</name>
+       <description>Source Select.  This bit selects the hash function and CRC generator input source.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inputFIFO</name>
+         <description>Input FIFO</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputFIFO</name>
+         <description>Output FIFO</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="INTR">
+       <name>BSO</name>
+       <description>Byte Swap Output. Note. No byte swap will occur if there is not a full word.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="INTR">
+       <name>BSI</name>
+       <description>Byte Swap Input. Note. No byte swap will occur if there is not a full word.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="INTR">
+       <name>WAIT_EN</name>
+       <description>Wait Pin Enable. This can be used to hold off the crypto DMA until an external memory is ready. This is useful for transferring pages from NAND flash which may take several microseconds to become ready.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WAIT_POL</name>
+       <description>Wait Pin Polarity. When the wait pin is enabled, this bit selects its active state.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRSRC</name>
+       <description>Write FIFO Source Select. This field determines where data written to the write FIFO comes from. When data is written to the write FIFO, it is always written out the DMA. To decrypt or encrypt data, the write FIFO source should be set to the cipher output. To implement memcpy() or memset() functions, or to fill memory with random data, the write FIFO source should be set to the read FIFO. When calculating a HASH or CMAC, the write FIFO should be disabled.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>none</name>
+         <description>None.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cipherOutput</name>
+         <description>Cipher Output.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>readFIFO</name>
+         <description>Read FIFO.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDSRC</name>
+       <description>Read FIFO Source Select. This field selects the source of the read FIFO. Typically, it is set to use the DMA. To implement a memset() function, the read FIFO DMA should be disabled. To fill memory with random data or to hash random numbers, the read FIFO source should be set to the random number generator.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dmaDisabled</name>
+         <description>DMA Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dmaOrApb</name>
+         <description>DMA Or APB.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rng</name>
+         <description>RNG.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLAG_MODE</name>
+       <description>Done Flag Mode. This bit configures the access behavior of the individual CRYPTO_CTRL Done flags (CRYPTO_CTRL[27:24]). This bit is cleared only on reset to limit upkeep, i.e. once set, it will remain set until a reset occurs.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unres_wr</name>
+         <description>Unrestricted write (0 or 1) of CRYPTO_CTRL[27:24] flags.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>res_wr</name>
+         <description>Access to CRYPTO_CTRL[27:24] are write 1 to clear/write 0 no effect.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMADNEMSK</name>
+       <description>DMA Done Flag Mask. This bit masks the DMA_DONE flag from being used to generate the CRYPTO_CTRL.DONE flag, and this disables a DMA_DONE condition from generating and interrupt. The DMA_DONE flag itself is unaffected and still may be monitored. This allows more optimal interrupt-driven crypto operations using DMA.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_used</name>
+         <description>DMA_DONE not used in setting CRYPTO_CTRL.DONE bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>used</name>
+         <description>DMA_DONE used in setting CRYPTO_CTRL.DONE bit.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMA_DONE</name>
+       <description>DMA Done. DMA write/read operation is complete. This bit must be cleared before starting a DMA operation.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notDone</name>
+         <description>Not Done.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>done</name>
+         <description>Done.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>GLS_DONE</name>
+       <description>Galois Done. FIFO is full and CRC or Hamming Code Generator is enabled. This bit must be cleared before starting a CRC operation Note that DMA_DONE must be polled instead of this bit to determine the end of DMA operation during the utilization of Hamming Code Generator.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>HSH_DONE</name>
+       <description>Hash Done. SHA operation is complete. This bit must be cleared before starting a HASH operation.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>CPH_DONE</name>
+       <description>Cipher Done. Either AES or DES encryption/decryption operation is complete. This bit must be cleared before starting a cipher operation.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERR</name>
+       <description>AHB Bus Error. This bit is set when the DMA encounters a bus error during a read or write operation. Once this bit is set, the DMA will stop. This bit can only be cleared by resetting the crypto block.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Ready. Crypto block ready for more data.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>DONE</name>
+       <description>Done. One or more cryptographic calculations complete (logical OR of done flags).</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CIPHER_CTRL</name>
+     <description>Cipher Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ENC</name>
+       <description>Encrypt. Select encryption or decryption of input data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>encrypt</name>
+         <description>Encrypt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>decrypt</name>
+         <description>Decrypt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEY</name>
+       <description>Load Key from crypto DMA. This bit is automatically cleared by hardware after the DMA has completed loading the key. When the DMA operation is done, it sets the appropriate crypto DMA Done flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRC</name>
+       <description>Source of Random key.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>cipherKey</name>
+         <description>User cipher key (0x4000_1060).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>regFile</name>
+         <description>Key from battery-backed register file (0x4000_5000 to 0x4000_501F).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>qspiKey_regFile</name>
+         <description>Key from battery-backed register file (0x4000_5020 to 0x4000_502F).</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CIPHER</name>
+       <description>Cipher Operation Select.  Symmetric Block Cipher algorithm selection or memory operation.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes128</name>
+         <description>AES 128.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes192</name>
+         <description>AES 192.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes256</name>
+         <description>AES 256.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>des</name>
+         <description>DES.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>tdes</name>
+         <description>Triple DES.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description>Mode Select. Mode of operation for block cipher or memory operation. DES/TDES cannot be used in CFB, OFB or CTR modes.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ECB</name>
+         <description>ECB Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CBC</name>
+         <description>CBC Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CFB</name>
+         <description>CFB (AES only).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>OFB</name>
+         <description>OFB (AES only).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CTR</name>
+         <description>CTR (AES only).</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HVC</name>
+       <description>H Vector Computation.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DTYPE</name>
+       <description>GCM/CCM data type.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CCMM</name>
+       <description>CCM M Parameter.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CCML</name>
+       <description>CCM L Parameter.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HASH_CTRL</name>
+     <description>HASH Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>INIT</name>
+       <description>Initialize. Initializes hash registers with standard constants.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>XOR</name>
+       <description>XOR data with IV from cipher block. Useful when calculating HMAC to XOR the input pad and output pad.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HASH</name>
+       <description>Hash function selection.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha1</name>
+         <description>SHA-1.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha224</name>
+         <description>SHA 224.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha256</name>
+         <description>SHA 256.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha384</name>
+         <description>SHA 384.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha512</name>
+         <description>SHA 512.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LAST</name>
+       <description>Last Message Bit. This bit shall be set along with the HASH_MSG_SZ register prior to hashing the last 512 or 1024-bit block of the message data. It will allow automatic preprocessing of the last message padding, which includes the trailing bit 1, followed by the respective number of zero bits for the last block size and finally the message length represented in bytes. The bit will be automatically cleared at the same time the HASH DONE is set, designating the completion of the last message hash.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEffect</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>lastMsgData</name>
+         <description>Last Message Data.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_CTRL</name>
+     <description>CRC Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>CRC</name>
+       <description>Cyclic Redundancy Check Enable. The CRC cannot be enabled if the PRNG is enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MSB</name>
+       <description>MSB select. This bit selects the order of calculating CRC on data.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lsbFirst</name>
+         <description>LSB First.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>msbFirst</name>
+         <description>MSB First.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CRC">
+       <name>PRNG</name>
+       <description>Pseudo Random Number Generator Enable. If entropy is disabled, this outputs one byte of pseudo random data per clock cycle. If entropy is enabled, data is output at a rate of one bit per clock cycle.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CRC">
+       <name>ENT</name>
+       <description>Entropy Enable. If the PRNG is enabled, this mixes the high frequency ring oscillator with the LFSR. If the PRNG is disabled, the raw entropy data is output at a rate of 1 bit per clock. This makes it possible to characterize the quality of the entropy source.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CRC">
+       <name>HAM</name>
+       <description>Hamming Code Enable. Enable hamming code calculation.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HRST</name>
+       <description>Hamming Reset. Reset Hamming code ECC generator for next block.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+       <enumeratedValues>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>Starts reset operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_SRC</name>
+     <description>Crypto DMA Source Address.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>DMA Source Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_DEST</name>
+     <description>Crypto DMA Destination Address.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>DMA Destination Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_CNT</name>
+     <description>Crypto DMA Byte Count.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>DMA Byte Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAA_CTRL</name>
+     <description>MAA Control Register.</description>
+     <addressOffset>0x1C</addressOffset>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DIN[%s]</name>
+     <description>Crypto Data Input. Data input can be written to this register instead of using the DMA. This register writes to the FIFO. This register occupies four successive words to allow the use of multi-store instructions. Words can be written to any location, they will be placed in the FIFO in the order they are written. The endian swap input control bit affects this register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Crypto Data Input. Input can be written to this register instead of using DMA.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DOUT[%s]</name>
+     <description>Crypto Data Output. Resulting data from cipher calculation. Data is placed in the lower words of these four registers depending on the algorithm. For block cipher modes, this register holds the result of most recent encryption or decryption operation. These registers are affected by the endian swap bits.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Crypto Data Output. Resulting data from cipher calculation. Data is placed in the lower words of these four registers depending on algorithm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_POLY</name>
+     <description>CRC Polynomial. The polynomial to be used for Galois Field calculations (CRC or LFSR) should be written to this register. This register is affected by the MSB control bit.</description>
+     <addressOffset>0x40</addressOffset>
+     <resetValue>0xEDB88320</resetValue>
+     <fields>
+      <field>
+       <name>POLY</name>
+       <description>CRC Polynomial. The polynomial to be used for Galois Field calculations (CRC or LFSR) should be written to this register. This register is affected by the MSB control bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_VAL</name>
+     <description>CRC Value. This is the state for the Galois Field. This register holds the result of a CRC calculation or the current state of the LFSR. This register is affected by the MSB control bit.</description>
+     <addressOffset>0x44</addressOffset>
+     <resetValue>0xFFFFFFFF</resetValue>
+     <fields>
+      <field>
+       <name>VAL</name>
+       <description>CRC Value. This is the state for the Galois Field. This register holds the result of a CRC calculation or the current state of LFSR. This register is affected by the MSB control bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_PRNG</name>
+     <description>CRC PRNG Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>PRNG</name>
+       <description>PRNG</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HAM_ECC</name>
+     <description>Hamming ECC Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>ECC</name>
+       <description>Hamming ECC Value. These bits are the even parity of their corresponding bit groups.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PAR</name>
+       <description>Parity. This is the parity of the entire array.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>even</name>
+         <description>Even.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>odd</name>
+         <description>Odd.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CIPHER_INIT[%s]</name>
+     <description>Initial Vector. For block cipher operations that use CBC, CFB, OFB, or CNTR modes, this register holds the initial value. This register is updated with each encryption or decryption operation. This register is affected by the endian swap bits.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>IVEC</name>
+       <description>Initial Vector. For block cipher operations that use CBC, CFB, OFB, or CNTR modes, this register holds the initial value. This register is updated with each encryption or decryption operation. This register is affected by the endian swap bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CIPHER_KEY[%s]</name>
+     <description>Cipher Key.  This register holds the key used for block cipher operations. The lower words are used for block ciphers that use shorter key lengths. This register is affected by the endian swap input control bits.</description>
+     <addressOffset>0x60</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>KEY</name>
+       <description>Cipher Key. This register holds the key used for block cipher operations. The lower words are used for block ciphers that use shorter kye lengths. This register is affected by the endian swap input control bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>16</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>HASH_DIGEST[%s]</name>
+     <description>This register holds the calculated hash value. This register is affected by the endian swap bits.</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>HASH</name>
+       <description>This register holds the calculated hash value. This register is affected by the endian swap bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>HASH_MSG_SZ[%s]</name>
+     <description>Message Size. This register holds the lowest 32-bit of message size in bytes.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>MSGSZ</name>
+       <description>Message Size. This register holds the lowest 32-bit of message size in bytes.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>AAD_LENGTH[%s]</name>
+     <description>AAD Length Registers.</description>
+     <addressOffset>0xD0</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>LENGTH</name>
+       <description>AAD length in bytes for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>PLD_LENGTH[%s]</name>
+     <description>PLD Length Registers.</description>
+     <addressOffset>0xD8</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>LENGTH</name>
+       <description>PLD length in bytes for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>TAGMIC[%s]</name>
+     <description>TAG/MIC Registers.</description>
+     <addressOffset>0xE0</addressOffset>
+     <fields>
+      <field>
+       <name>LENGTH</name>
+       <description>TAG/MIC output for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAA_MAWS</name>
+     <description>MAA Word Size Register.</description>
+     <addressOffset>0xF0</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>SIZE</name>
+       <description>MAA Word Size.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_CTRL0</name>
+     <description>SCA Control 0 Register.</description>
+     <addressOffset>0x700</addressOffset>
+     <fields>
+      <field>
+       <name>STC</name>
+       <description>Start Calculation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCAIE</name>
+       <description>SCA Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Abort Operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AFFJAC</name>
+       <description>Select Affine or Jacobi Coordinates.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERMEM</name>
+       <description>Erase Cryptographic Memory.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MANPARAM</name>
+       <description>ECC Parameter Source.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HWKEY</name>
+       <description>Hardware Key Select.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OPCODE</name>
+       <description>SCA Opcode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>MODADDR</name>
+       <description>MODULO Address Offset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>ECCSIZE</name>
+       <description>ECC Size.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_CTRL1</name>
+     <description>SCA Advanced Control Register.</description>
+     <addressOffset>0x704</addressOffset>
+     <fields>
+      <field>
+       <name>MAN</name>
+       <description>SCA Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>auto</name>
+         <description>Auto Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>manual</name>
+         <description>Manual Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTOCARRY</name>
+       <description>Automatically propagate the carry for the next operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PLUSONE</name>
+       <description>Enable Carry propagation for the next operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESSELECT</name>
+       <description>ALU Selection.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>NRNG</name>
+       <description>Enable NIST RNG.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARRYPOS</name>
+       <description>To set Carry location.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+      <field>
+       <name>CM_EN</name>
+       <description>Enable Countermeasure.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_STAT</name>
+     <description>SCA Status Register.</description>
+     <addressOffset>0x708</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SCA Busy.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCAIF</name>
+       <description>SCA Interrupt Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PVF1</name>
+       <description>Point 1 Verification Failed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PVF2</name>
+       <description>Point 2 Verification Failed.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FSMERR</name>
+       <description>FSM Transition Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>COMPERR</name>
+       <description>EC Computation Error.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MEMERR</name>
+       <description>SCA Memory Access Error.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARRY</name>
+       <description>Carry on ongoing operation.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GTE2I2</name>
+       <description>Modulo 2x Result.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ALUNEG1</name>
+       <description>ALU 2 SubSign of the subtraction result for ALU_2.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ALUNEG2</name>
+       <description>ALU 2 SubSign of the subtraction result for ALU_2.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PPX_ADDR</name>
+     <description>PPX Coordinate Data Pointer Register.</description>
+     <addressOffset>0x70C</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point P Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PPY_ADDR</name>
+     <description>PPY Coordinate Data Pointer Register.</description>
+     <addressOffset>0x710</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point P Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PPZ_ADDR</name>
+     <description>PPZ Coordinate Data Pointer Register.</description>
+     <addressOffset>0x714</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point P Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PQX_ADDR</name>
+     <description>PQX Coordinate Data Pointer Register.</description>
+     <addressOffset>0x718</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point Q Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PQY_ADDR</name>
+     <description>PQY Coordinate Data Pointer Register.</description>
+     <addressOffset>0x71C</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point Q Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PQZ_ADDR</name>
+     <description>PQZ Coordinate Data Pointer Register.</description>
+     <addressOffset>0x720</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point Q Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_RDSA_ADDR</name>
+     <description>SCA RDSA Address Register.</description>
+     <addressOffset>0x724</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>The starting address of the R portion for R, S ECDSA signature.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_RES_ADDR</name>
+     <description>SCA Result Address Register.</description>
+     <addressOffset>0x728</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Starting address of result storage.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_OP_BUFF_ADDR</name>
+     <description>SCA Operation Buffer Address Register.</description>
+     <addressOffset>0x72C</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Starting address of operation buffer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_MODDATA</name>
+     <description>SCA Modulo Data Input Register.</description>
+     <addressOffset>0x730</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Used to load the SCA modulo for modular operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_NRNG</name>
+     <description>SCA NIST RNG Address Register.</description>
+     <addressOffset>0x734</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Starting SRAM address where up to 32 words of NIST washed RNG data is stored.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_WASH</name>
+     <description>SCA Wash Register.</description>
+     <addressOffset>0x738</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Starting SRAM address where up to 1 word of random is stored for SRAM washing.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CTB The Cryptographic Toolbox is a combination of cryptographic engines and a secure cryptographic accelerator (SCA) used to provide advanced cryptographic security.-->
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0</name>
+    <value>28</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1</name>
+    <value>29</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA2</name>
+    <value>30</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA3</name>
+    <value>31</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA4</name>
+    <value>68</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA5</name>
+    <value>69</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA6</name>
+    <value>70</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA7</name>
+    <value>71</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA8</name>
+    <value>72</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA9</name>
+    <value>73</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA10</name>
+    <value>74</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA11</name>
+    <value>75</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA12</name>
+    <value>76</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA13</name>
+    <value>77</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA14</name>
+    <value>78</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA15</name>
+    <value>79</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>INTEN</name>
+     <description>DMA Interrupt Enable Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel 0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <description>Channel 1 Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <description>Channel 2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <description>Channel 3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH4</name>
+       <description>Channel 4 Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH5</name>
+       <description>Channel 5 Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH6</name>
+       <description>Channel 6 Interrupt Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH7</name>
+       <description>Channel 7 Interrupt Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH8</name>
+       <description>Channel 8 Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH9</name>
+       <description>Channel 9 Interrupt Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH10</name>
+       <description>Channel 10 Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH11</name>
+       <description>Channel 11 Interrupt Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH12</name>
+       <description>Channel 12 Interrupt Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH13</name>
+       <description>Channel 13 Interrupt Enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH14</name>
+       <description>Channel 14 Interrupt Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH15</name>
+       <description>Channel 15 Interrupt Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>DMA Interrupt Flag Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel Interrupt. To clear an interrupt, all active interrupt bits of the DMA_ST must be cleared. The interrupt bits are set only if their corresponding interrupt enable bits are set in DMA_CN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH8</name>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH9</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH10</name>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH11</name>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH12</name>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH13</name>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH14</name>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH15</name>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>16</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CTRL</name>
+      <description>DMA Channel Control Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>EN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQUEST</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0RX</name>
+          <description>SPI0 RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1RX</name>
+          <description>SPI1 RX</description>
+          <value>0x02</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0RX</name>
+          <description>UART0 RX</description>
+          <value>0x04</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1RX</name>
+          <description>UART1 RX</description>
+          <value>0x05</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SC0RX</name>
+          <description>SC0 RX</description>
+          <value>0x06</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0RX</name>
+          <description>I2C0 RX</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1RX</name>
+          <description>I2C1 RX</description>
+          <value>0x08</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>ADC</name>
+          <description>Analog-to-Digital Converter Channel</description>
+          <value>0x09</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>MSRADC</name>
+          <description>MSR 9 bit ADC.</description>
+          <value>0x0B</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2RX</name>
+          <description>UART2 RX</description>
+          <value>0x0E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI3RX</name>
+          <description>SPI3 RX</description>
+          <value>0x0F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP1</name>
+          <description>USB Endpoint 1 RX</description>
+          <value>0x11</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP2</name>
+          <description>USB Endpoint 2 RX</description>
+          <value>0x12</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP3</name>
+          <description>USB Endpoint 3 RX</description>
+          <value>0x13</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP4</name>
+          <description>USB Endpoint 4 RX</description>
+          <value>0x14</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP5</name>
+          <description>USB Endpoint 5 RX</description>
+          <value>0x15</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP6</name>
+          <description>USB Endpoint 6 RX</description>
+          <value>0x16</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP7</name>
+          <description>USB Endpoint 7 RX</description>
+          <value>0x17</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP8</name>
+          <description>USB Endpoint 8 RX</description>
+          <value>0x18</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP9</name>
+          <description>USB Endpoint 9 RX</description>
+          <value>0x19</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP10</name>
+          <description>USB Endpoint 10 RX</description>
+          <value>0x1A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP11</name>
+          <description>USB Endpoint 11 RX</description>
+          <value>0x1B</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3RX</name>
+          <description>UART3 RX</description>
+          <value>0x1C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0TX</name>
+          <description>SPI0 TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1TX</name>
+          <description>SPI1 TX</description>
+          <value>0x22</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0TX</name>
+          <description>UART0 TX</description>
+          <value>0x24</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1TX</name>
+          <description>UART1 TX</description>
+          <value>0x25</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SC0TX</name>
+          <description>SC0 TX</description>
+          <value>0x26</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0TX</name>
+          <description>I2C0 TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1TX</name>
+          <description>I2C1 TX</description>
+          <value>0x28</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2TX</name>
+          <description>UART2 TX</description>
+          <value>0x2E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI3TX</name>
+          <description>SPI3 TX</description>
+          <value>0x2F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP1</name>
+          <description>USB Endpoint 1 TX</description>
+          <value>0x31</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP2</name>
+          <description>USB Endpoint 2 TX</description>
+          <value>0x32</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP3</name>
+          <description>USB Endpoint 3 TX</description>
+          <value>0x33</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP4</name>
+          <description>USB Endpoint 4 TX</description>
+          <value>0x34</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP5</name>
+          <description>USB Endpoint 5 TX</description>
+          <value>0x35</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP6</name>
+          <description>USB Endpoint 6 TX</description>
+          <value>0x36</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP7</name>
+          <description>USB Endpoint 7 TX</description>
+          <value>0x37</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP8</name>
+          <description>USB Endpoint 8 TX</description>
+          <value>0x38</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP9</name>
+          <description>USB Endpoint 9 TX</description>
+          <value>0x39</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP10</name>
+          <description>USB Endpoint 10 TX</description>
+          <value>0x3A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP11</name>
+          <description>USB Endpoint 11 TX</description>
+          <value>0x3B</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3TX</name>
+          <description>UART3 TX</description>
+          <value>0x3C</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_WAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_PER</name>
+        <description>Timeout Period Select.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_CLKDIV</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BURST_SIZE</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>DIS_IE</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IE</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>STATUS</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>STATUS</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IF</name>
+        <description>Count-to-Zero (CTZ) Event Interrupt Flag</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>RLD_IF</name>
+        <description>Reload Event Interrupt Flag.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>TO_IF</name>
+        <description>Time-Out Event Interrupt Flag.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRCRLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DSTRLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNTRLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>EN</name>
+        <description>Reload Enable. This bit should be set after the address reload registers have been programmed. This bit is automatically cleared to 0 when reload occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+<!--DMA DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x40000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SYSCTRL</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>BSTAPEN</name>
+       <description>Boundary Scan TAP enable. When enabled, the JTAG port is conneted to the Boundary Scan TAP instead of the ARM ICE.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Boundary Scan TAP port disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Boundary Scan TAP port enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SBUSARB</name>
+       <description>System bus abritration scheme. These bits are used to select between Fixed-burst abritration and Round-Robin scheme. The Round-Robin scheme is selected by default. These bits are reset by the system reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>fix</name>
+         <description>Fixed Burst abritration.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>round</name>
+         <description>Round-robin scheme.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FPU_DIS</name>
+       <description>Cortex M4 Floating Point Disable This bit is used to disable the floating-point unit of the Cortex-M4.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SFCC_FLUSH</name>
+       <description>Code Cache Flush. This bit is used to flush the code caches and the instruction buffer of the Cortex-M4. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CHKRES1</name>
+       <description>Result of CPU1 ROM1 Checksum.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CCHK1</name>
+       <description>Compute CPU1 ROM1 Checksum</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CCHK0</name>
+       <description>Compute ROM0 Checksum. This bit is self-cleared when calculation is completed. Once set, software clearing this bit is ignored and the bit will remain set until the operation is completed.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SWD_DIS</name>
+       <description> Serial Wire Debug Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHKRES0</name>
+       <description>ROM Checksum Result. This bit is only valid when CHKRD=1.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pass</name>
+         <description>ROM Checksum Correct.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fail</name>
+         <description>ROM Checksum Fail.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA">
+       <name>WDT0</name>
+       <description>Watchdog Timer 0 Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO1</name>
+       <description>GPIO1 Reset. Setting this bit to 1 resets GPIO1 pins to their default states.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR0</name>
+       <description>Timer 0 Reset. Setting this bit to 1 resets Timer 0 blocks.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR1</name>
+       <description>Timer 1 Reset. Setting this bit to 1 resets Timer 1 blocks.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR2</name>
+       <description>Timer 2 Reset. Setting this bit to 1 resets Timer 2 blocks.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR3</name>
+       <description>Timer 3 Reset. Setting this bit to 1 resets Timer 3 blocks.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR4</name>
+       <description>Timer4 Reset. Setting this bit to 1 resets Timer 4 blocks.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR5</name>
+       <description>Timer5 Reset. Setting this bit to 1 resets Timer 5 blocks.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART0</name>
+       <description>UART 0 Reset. Setting this bit to 1 resets all UART 0 blocks.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART1</name>
+       <description>UART 1 Reset. Setting this bit to 1 resets all UART 1 blocks.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI0</name>
+       <description>SPI 0 Reset. Setting this bit to 1 resets all SPI 0 blocks.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI1</name>
+       <description>SPI 1 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>I2C0</name>
+       <description>I2C 0 Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>CRYPTO</name>
+       <description>Crypto Reset.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>USB</name>
+       <description>USB Reset.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TRNG</name>
+       <description>TRNG Reset.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>ADC</name>
+       <description>ADC Reset.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART2</name>
+       <description>UART2 Reset. Setting this bit to 1 resets all UART 2 blocks.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SOFT</name>
+       <description>Soft Reset. Setting this bit to 1 resets everything except the CPU and the watchdog timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>PERIPH</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SYS</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>PCLK_DIV</name>
+       <description>PCLK Divider.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_DIV</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the PLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_SEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ISO</name>
+         <description>The internal 60 MHz oscillator is used for the system clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERFO</name>
+         <description>The external 32 MHz input is used for the system clock.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INRO</name>
+         <description>8 kHz LIRC is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>The internal 100 MHz oscillator is used for the system clock.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBRO</name>
+         <description>The internal 7.3725 MHz oscillator is used for the system clock.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERTCO</name>
+         <description>External 32 kHz input is used for the system clock.</description>
+         <value>6</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRYPTOCLK_DIV</name>
+       <description>Cryptographic clock divider</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>non_div</name>
+         <description>The cryptographic accelerator clock is running in non-divided mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div</name>
+         <description>The cryptographic accelerator clock is running in divided mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_RDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IPO_DIV</name>
+       <description>IPO Divider.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_EN</name>
+       <description>27 MHz Crystal Oscillator Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERFO_EN">
+       <name>ISO_EN</name>
+       <description>60 MHz Internal Oscillator Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_EN">
+       <name>IPO_EN</name>
+       <description>100 MHz Clock Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_EN">
+       <name>IBRO_EN</name>
+       <description>7.3725 MHz Clock Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_VS</name>
+       <description>7.3725 MHz High Frequency Internal Reference Clock Voltage Select. This register bit is used to select the power supply to the IBRO.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Vcor</name>
+         <description>VCore Supply</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1V</name>
+         <description>Dedicated 1V regulated supply.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_RDY</name>
+       <description>32 MHz Oscillator Ready</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>ERTCO_RDY</name>
+       <description>32 kHz Crystal Oscillator Ready</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>ISO_RDY</name>
+       <description>60 MHz Oscillator Ready.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>IPO_RDY</name>
+       <description>100 MHz Clock Ready.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>IBRO_RDY</name>
+       <description>7.3725 MHz HIRC Ready.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>INRO_RDY</name>
+       <description>8 kHz Low Frequency Reference Clock Ready.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PM</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This two bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sleep</name>
+         <description>Sleep Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>DeepSleep Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>ShutDown Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>backup</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO_WE</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wake Up Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wake Up Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>RTC_WE</name>
+       <description>RTC Alarm Wake Up Enable. This bit enables RTC alarm as wakeup source. If enabled, the desired RTC alarm must be configured via the RTC control registers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>USB_WE</name>
+       <description>USB Wake Up Enable. This bit enables USB IRQ as wakeup source</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_PD</name>
+       <description>27 MHz power down. This bit selects the 27 MHz clock power state in DEEPSLEEP mode.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERFO_PD">
+       <name>ISO_PD</name>
+       <description>60 MHz power down. This bit selects the 60 MHz clock power state in DEEPSLEEP mode.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_PD">
+       <name>IPO_PD</name>
+       <description>100 MHz power down. This bit selects 100 MHz clock power state in DEEPSLEEP mode. </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_PD">
+       <name>IBRO_PD</name>
+       <description>7.3725 MHz power down. This bit selects 7.3725 MHz clock power state in DEEPSLEEP mode. </description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_BP</name>
+       <description>27MHz Oscillator Bypass.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIV</name>
+     <description>Peripheral Clock Divider.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>SKBDFRQ</name>
+       <description>GCR Frequency Indicator for Secure Keyboard.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>ADCFRQ</name>
+       <description>ADC clock Frequency. These bits define the ADC clock frequency. fADC = fPCLK / (ADCFRQ)</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>AONCLKDIV</name>
+       <description>AON Clock Divider. These bits define the AON Domain Clock Divider.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div4</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0</name>
+       <description>GPIO0 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>GPIO1</name>
+       <description>GPIO1 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>USB</name>
+       <description>USB Clock Disable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>DMA</name>
+       <description>DMA Clock Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI0</name>
+       <description>SPI 0 Clock Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI1</name>
+       <description>SPI 1 Clock Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART0</name>
+       <description>UART 0 Clock Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART1</name>
+       <description>UART 1 Clock Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C0</name>
+       <description>I2C 0 Clock Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>CRYPTO</name>
+       <description>Crypto Clock Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR0</name>
+       <description>Timer 0 Clock Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR1</name>
+       <description>Timer 1 Clock Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR2</name>
+       <description>Timer 2 Clock Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR3</name>
+       <description>Timer 3 Clock Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR4</name>
+       <description>Timer 4 Clock Disable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR5</name>
+       <description>Timer 5 Clock Disable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SKBD</name>
+       <description>Secure Keypad Clock Disable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>ADC</name>
+       <description>ADC Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>HTMR0</name>
+       <description>High Speed Timer 0 Clock Disable.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>HTMR1</name>
+       <description>High Speed Timer 1 Clock Disable.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C1</name>
+       <description>I2C 1 Clock Disable.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>PT</name>
+       <description>Pluse Train Clock Disable.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPIXIP</name>
+       <description>SPI XIP Clock Disable.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPIXIPC</name>
+       <description>SPI XIPC Clock Disable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCTRL</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 2.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>RAM4_WS</name>
+       <description>System RAM4 WS Select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM5_WS</name>
+       <description>System RAM5 WS Select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM6_WS</name>
+       <description>System RAM6 WS Select.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROM1_WS</name>
+       <description>ROM1 WS Select.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM0LS_EN</name>
+       <description>System RAM 0 Light Sleep Mode.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM1LS_EN</name>
+       <description>System RAM 1 Light Sleep Mode.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM2LS_EN</name>
+       <description>System RAM 2 Light Sleep Mode.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM3LS_EN</name>
+       <description>System RAM 3 Light Sleep Mode.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM4LS_EN</name>
+       <description>System RAM 4 Light Sleep Mode.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM5LS_EN</name>
+       <description>System RAM 5 Light Sleep Mode.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM6LS_EN</name>
+       <description>System RAM 6 Light Sleep Mode.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>ICCXIPLS_EN</name>
+       <description>ICACHE-XIP RAM Light Sleep Mode.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>CRYPTOLS_EN</name>
+       <description>MEU RAM Light Sleep Mode.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>USBLS_EN</name>
+       <description>USB FIFO Light Sleep Mode.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>ROM0LS_EN</name>
+       <description>ROM0 Light Sleep Mode.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>ROM1LS_EN</name>
+       <description>ROM1 Light Sleep Mode.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>MAALS_EN</name>
+       <description>MAA Light Sleep Mode.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMZ</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM Block 0 Zeroization.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM1</name>
+       <description>System RAM Block 1 Zeroization.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM2</name>
+       <description>System RAM Block 2 Zeroization.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM3</name>
+       <description>System RAM Block 3 Zeroization.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM4</name>
+       <description>System RAM Block 4 Zeroization.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM5</name>
+       <description>System RAM Block 5 Zeroization.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM6</name>
+       <description>System RAM Block 6 Zeroization.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICCXIP</name>
+       <description>Internal ICC XIP Data and Tag RAM Zeroization.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>CRYPTO</name>
+       <description>MEU Memory Zeroization.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>USBFIFO</name>
+       <description>USB FIFO Zeroization.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCCLKCTRL</name>
+     <description>Smart Card Clock Control.</description>
+     <addressOffset>0x34</addressOffset>
+     <resetValue>0x00000000</resetValue>
+     <fields>
+      <field>
+       <name>SC0CLK_DIV</name>
+       <description>Smart Card0 Clock Divider</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>SC1CLK_DIV</name>
+       <description>Smart Card1 Clock Divider</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSST</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICELOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CODEINTERR</name>
+       <description>Code Integrity Error Flag. This bit indicates a code integrity error has occured in XiP interface. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>norm</name>
+         <description>Normal Operating Condition.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>code</name>
+         <description>Code Integrity Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCMEMF</name>
+       <description>System Cache Memory Fault Flag. This bit indicates a memory fault has occured in the System Cache while receiving data from the Hyperbus Interface.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>norm</name>
+         <description>Normal Operating Condition.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>memory</name>
+         <description>Memory Fault.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>I2C1</name>
+       <description>I2C1 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>PT</name>
+       <description>PT Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPIXIP</name>
+       <description>SPI XIPF Reset.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPIXIPM</name>
+       <description>SPI XIP Master Reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>WDT1</name>
+       <description>WDT1 Reset.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPI3</name>
+       <description>SPI3 Reset.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AC</name>
+       <description>Auto-Cal Reset.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SEMA</name>
+       <description>Semaphore Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>UART3</name>
+       <description>UART3 Reset.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SKBD</name>
+       <description>SKBD Reset.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>MSRADC</name>
+       <description>MSRADC Reset.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SC0</name>
+       <description>SC0 Reset.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SC1</name>
+       <description>SC1 Reset.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>HTMR0</name>
+       <description>HTIMER0 Reset.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>HTMR1</name>
+       <description>HTIMER1 Reset.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>CPU1</name>
+       <description>CPU1 Reset.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>UART2</name>
+       <description>UART2 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="UART2">
+       <name>TRNG</name>
+       <description>TRNG Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>OTP</name>
+       <description>OTP Clock Disable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>WDT0</name>
+       <description>Watchdog 0 Clock Disable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>WDT1</name>
+       <description>Watchdog 1 Clock Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SEMA</name>
+       <description>Semaphore Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SPI3</name>
+       <description>SPI3 Clock Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>UART3</name>
+       <description>UART3 Clock Disable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>MSRADC</name>
+       <description>MSRADC Clock Disable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SC0</name>
+       <description>SC0 Clock Disable.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SC1</name>
+       <description>SC1 Clock Disable.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>CPU1</name>
+       <description>CPU1 Clock Disable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVENTEN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Enable RXEV pin event. When this bit is set, RXEV event from the CPU is output to GPIO1.9.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO1.9.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REVISION</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSIE</name>
+     <description>System Status Interrupt Enable Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEUNLOCK</name>
+       <description>ARM ICE Unlock Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ICEUNLOCK">
+       <name>CIE</name>
+       <description>Code Integrity Error Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ICEUNLOCK">
+       <name>SCMF</name>
+       <description>System Cache Memory Fault Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPOCNT</name>
+     <description>IPO Warmup Count Register.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>WMUPCNT</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCR Global Control Registers.-->
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x40008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN0</name>
+     <description>GPIO Function Enable Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_SET</name>
+     <description>GPIO Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_OUT bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTMODE</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTPOL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INEN</name>
+     <description>GPIO Input Enable</description>
+     <addressOffset>0x30</addressOffset>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DUALEDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL0</name>
+     <description>GPIO Input Mode Config 0. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>The two bits in GPIO_PADCTRL0 and GPIO_PADCTRL1 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL1</name>
+     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>The two bits in GPIO_PADCTRL0 and GPIO_PADCTRL1 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_SET</name>
+     <description>GPIO Alternate Function Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_SET</name>
+     <description>GPIO Alternate Function 2 Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN2 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_CLR</name>
+     <description>GPIO Wake Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN2 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x7C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HYSEN</name>
+     <description>GPIO Input Hysteresis Enable.</description>
+     <addressOffset>0xA8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SRSEL</name>
+     <description>GPIO Slew Rate Enable Register.</description>
+     <addressOffset>0xAC</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>FAST</name>
+         <description>Fast Slew Rate selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SLOW</name>
+         <description>Slow Slew Rate selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS0</name>
+     <description>GPIO Drive Strength 0 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ld</name>
+         <description>GPIO port pin is in low-drive mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hd</name>
+         <description>GPIO port pin is in high-drive mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PSSEL</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VSSEL</name>
+     <description>GPIO Voltage Select.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GPIO0 Individual I/O for each GPIO-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO1</name>
+   <description>Individual I/O for each GPIO 1</description>
+   <baseAddress>0x40009000</baseAddress>
+   <interrupt>
+    <name>GPIO1</name>
+    <description>GPIO1 IRQ</description>
+    <value>25</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO1 Individual I/O for each GPIO 1-->
+  <peripheral>
+   <name>HTMR</name>
+   <description>High Speed Timer Module.</description>
+   <baseAddress>0x4001B000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0xFFF</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>HTimer</name>
+    <description>HTimer interrupt.</description>
+    <value>93</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>LNICNT</name>
+     <description>HTimer Long-Interval Counter. This register contains the 32 most significant bits of the counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>HTimer Long Interval Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SHICNT</name>
+     <description>HTimer Short Interval Counter. This counter ticks every t_htclk (16.48uS). HTIMER_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>HTimer Short Interval Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LNIALM</name>
+     <description>HTimer Long Interval Alarm Value Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>ALM</name>
+       <description>HTimer Long Interval Alarm. An Alarm is triggered when this value matches HTIMER_SEC[19:0]</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SHIALM</name>
+     <description>HTimer Short Interval Alarm Value Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>ALM</name>
+       <description>This register contains the reload value for the short interval alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>HTimer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>HTimer Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LONG_ALM_IE</name>
+       <description>Long Interval Alarm Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHORT_ALM_IE</name>
+       <description>Short Interval Alarm Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>HTimer Busy. This bit is set to 1 by hardware when changes to HTimer registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>HTimer Ready. This bit is set to 1 by hardware when the HTimer count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the HTimer count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY_IE</name>
+       <description>HTimer Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LONG_ALM_IF</name>
+       <description>Long Interval Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHORT_ALM_IF</name>
+       <description>Short Interval Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_EN</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical HTimer bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIM</name>
+     <description>HTimer Trim Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>HTimer Trim. This register contains the 2's complement value that specifies the trim resolution. Each increment or decrement of the bit adds or subtracts 1ppm at each 4KHz clock value, with a maximum correction of +/- 127ppm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VBAT_TMR</name>
+       <description>VBAT Timer Value. When HTimer is running off of VBAT, this field is incremented every 32 seconds.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>HTimer Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>FILTER_EN</name>
+       <description>Enable Filter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_SEL</name>
+       <description>IBIAS Select.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>2x</name>
+         <description>2x</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4x</name>
+         <description>4x</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HYST_EN</name>
+       <description>HTimer Hysteresis Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_EN</name>
+       <description>HTimer IBIAS Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYPASS</name>
+       <description>HTimer Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_32K</name>
+       <description>HTimer 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--HTMR High Speed Timer Module.-->
+  <peripheral derivedFrom="HTMR">
+   <name>HTMR1</name>
+   <description>High Speed Timer Module. 1</description>
+   <baseAddress>0x4001C000</baseAddress>
+   <interrupt>
+    <name>HTMR1</name>
+    <description>HTMR1 IRQ</description>
+    <value>94</value>
+   </interrupt>
+  </peripheral>
+<!--HTMR1 High Speed Timer Module. 1-->
+  <peripheral>
+   <name>I2C0</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>I2C</groupName>
+   <baseAddress>0x4001D000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2C0</name>
+    <description>I2C0 IRQ</description>
+    <value>13</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>I2C Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable I2C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable I2C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave_mode</name>
+         <description>Slave Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master_mode</name>
+         <description>Master Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_EN</name>
+       <description>General Call Address Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Ignore Gneral Call Address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Acknowledge general call address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_EN</name>
+       <description>Interactive Receive Mode.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interactive Receive Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interactive Receive Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_ACK</name>
+       <description>Data Acknowledge. This bit defines the acknowledge bit returned by the I2C receiver while IRXM = 1 HW forces ACK to 0 when IRXM = 0.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ack</name>
+         <description>return ACK (pulling SDA LOW).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>return NACK (leaving SDA HIGH).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_OUT</name>
+       <description>SCL Output. This bits control SCL output when SWOE =1.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_scl_low</name>
+         <description>Drive SCL low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_scl</name>
+         <description>Release SCL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDA_OUT</name>
+       <description>SDA Output. This bits control SDA output when SWOE = 1. </description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_sda_low</name>
+         <description>Drive SDA low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_sda</name>
+         <description>Release SDA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL</name>
+       <description>SCL status. This bit reflects the logic gate of SCL signal. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDA</name>
+       <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BB_EN</name>
+       <description>Software Output Enable.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>outputs_disable</name>
+         <description>I2C Outputs SCLO and SDAO disabled. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputs_enable</name>
+         <description>I2C Outputs SCLO and SDAO enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read. This bit reflects the R/W bit of an address match (AMI = 1) or general call match (GCI = 1). This bit is valid 3 cycles after the relevant interrupt bit is set.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKSTR_DIS</name>
+       <description>This bit will disable slave clock stretching when set.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Slave clock stretching enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Slave clock stretching disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ONE_MST_MODE</name>
+       <description>SCL Push-Pull Mode. This bit controls whether SCL is operated in a the I2C standard open-drain mode, or in a non-standard push-pull mode where the Hi-Z output isreplaced with Drive-1. The non-standard mode should only be used when operating as a master and communicating with slaves that are guaranteed to never drive SCL low. </description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Standard open-drain operation:
+					drive low for 0, Hi-Z for 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Non-standard push-pull operation:
+					drive low for 0, drive high for 1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HS_EN</name>
+       <description>High speed mode enable</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>Bus Status.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>I2C Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>I2C Bus Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>RX empty.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX Full.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX Empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>TX Full.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_BUSY</name>
+       <description>Clock Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_actively_driving_scl_clock</name>
+         <description>Device not actively driving SCL clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>actively_driving_scl_clock</name>
+         <description>Device operating as master and actively driving SCL clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL0</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <name>INT_FL0_Done</name>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Interactive Receive Interrupt.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave General Call Address Match Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave Address Match Interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Receive Threshold Interrupt. This bit is automaticcaly cleared when RX_FIFO is below the threshold level.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. RX_FIFO equal or more bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>Transmit Threshold Interrupt. This bit is automaticcaly cleared when TX_FIFO is above the threshold level.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP Interrupt.</description>
+       <bitRange>[6:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Address Acknowledge Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Arbritation error Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>timeout Error Interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Address NACK Error Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Data NACK Error Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Do Not Respond Error Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Start Error Interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Stop Error Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>Transmit Lock Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN0</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when DONE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Description not available.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when RX_MODE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave mode general call address match received input enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when GEN_CTRL_ADDR = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave mode incoming address match interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when ADDR_MATCH = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Above Treshold Level Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Below Treshold Level Interrupt Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Stop Interrupt Enable</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when STOP = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Received Address ACK from Slave Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Master Mode Arbitration Lost Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>Timeout Error Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Master Mode Address NACK Received Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Master Mode Data NACK Received Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Slave Mode Do Not Respond Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Out of Sequence START condition detected interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Out of Sequence STOP condition detected interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>TX FIFO Locked Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL1</name>
+     <description>Interrupt Status Register 1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt. When operating as a slave receiver, this bit is set when you reach the first data bit and the RX FIFO and shift register are both full.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt. When operating as a slave transmitter, this bit is set when you reach the first data bit and the TX FIFO is empty and the master is still asking for more data (i.e the master hasn't sent a NACK yet).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Status Flag.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN1</name>
+     <description>Interrupt Staus Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOLEN</name>
+     <description>FIFO Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RX_DEPTH</name>
+       <description>Receive FIFO Length.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DEPTH</name>
+       <description>Transmit FIFO Length.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL0</name>
+     <description>Receive Control Register 0.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>DNR</name>
+       <description>Do Not Respond.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Always respond to address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>not_respond_rx_fifo_empty</name>
+         <description>Do not respond to address match when RX_FIFO is not empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Receive FIFO Flush. This bit is automatically cleared to 0 after the operation. Setting this bit to 1 will affect RX_FIFO status.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush RX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_LVL</name>
+       <description>Receive FIFO Threshold. These bits define the RX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL1</name>
+     <description>Receive Control Register 1.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Receive Count Bits. These bits define the number of bytes to be received in a transaction, except for the case RXCNT = 0. RXCNT = 0 means 256 bytes to be received in a transaction.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Receive FIFO Count. These bits reflect the number of byte in the RX_FIFO. These bits are flushed when I2CEN = 0.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL0</name>
+     <description>Transmit Control Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_MODE</name>
+       <description>Transmit FIFO Preaload Mode. Setting this bit will allow for high speed application to preload the transmit FIFO prior to Slave Address Match.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TX_READY_MODE</name>
+       <description>Transmit FIFO Ready Manual Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW control of I2CTXRDY enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW control of I2CTXRDY disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO General Call Address Match Auto Flush Disable.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Write Auto Flush Disable.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Read Auto Flush Disable.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NACK_FLUSH_DIS</name>
+       <description>TX FIFO received NACK Auto Flush Disable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Transmit FIFO Flush. This bit is automatically cleared to 0 after the operation.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush TX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_VAL</name>
+       <description>Transmit FIFO Threshold. These bits define the TX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL1</name>
+     <description>Transmit Control Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_RDY</name>
+       <description>Transmit FIFO Preload Ready.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>LAST</name>
+       <description>Transmit Last.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Transmit FIFO Count. These bits reflect the number of bytes in the TX_FIFO.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MSTCTRL</name>
+     <description>Master Control Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Setting this bit to 1 will start a master transfer.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>RESTART</name>
+       <description>Setting this bit to 1 will generate a repeated START.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Setting this bit to 1 will generate a STOP condition.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>EX_ADDR_EN</name>
+       <description>Slave Extend Address Select.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CODE</name>
+       <description>Master Code.</description>
+       <bitRange>[10:8]</bitRange>
+      </field>
+      <field>
+       <name>IGN_ACK</name>
+       <description>Master Ignore Acknowledge.</description>
+       <bitRange>[12:12]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKLO</name>
+     <description>Clock Low Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock low. In master mode, these bits define the SCL low period. In slave mode, these bits define the time SCL will be held low after data is outputted.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKHI</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>HI</name>
+       <description>Clock High. In master mode, these bits define the SCL high period.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HSCLK</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock Low. This field sets the Hs-Mode clock low count. In Slave mode, this is the time SCL is held low after data is output on SDA.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Clock High. This field sets the Hs-Mode clock high count. In Slave mode, this is the time SCL is held high after data is output on SDA</description>
+       <bitRange>[15:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TIMEOUT</name>
+     <description>Timeout Register</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_TO_VAL</name>
+       <description>Timeout</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>SLAVE_MULTI[%s]</name>
+     <description>Slave Address Register.</description>
+     <alternateRegister>SLAVE0</alternateRegister>
+     <addressOffset>0x4C</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Slave Address.</description>
+       <bitRange>[9:0]</bitRange>
+      </field>
+      <field>
+       <name>DIS</name>
+       <description>Slave Disable.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>EXT_ADDR_EN</name>
+       <description>Extended Address Select.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLAVE0</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE1</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x50</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE2</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x54</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE3</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x58</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2C0 Inter-Integrated Circuit.-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C1</name>
+   <description>Inter-Integrated Circuit. 1</description>
+   <baseAddress>0x4001E000</baseAddress>
+   <interrupt>
+    <name>I2C1</name>
+    <description>I2C1 IRQ</description>
+    <value>36</value>
+   </interrupt>
+  </peripheral>
+<!--I2C1 Inter-Integrated Circuit. 1-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C2</name>
+   <description>Inter-Integrated Circuit. 2</description>
+   <baseAddress>0x4001F000</baseAddress>
+   <interrupt>
+    <name>I2C2</name>
+    <description>I2C2 IRQ</description>
+    <value>62</value>
+   </interrupt>
+  </peripheral>
+<!--I2C2 Inter-Integrated Circuit. 2-->
+  <peripheral>
+   <name>SFCC</name>
+   <description>SPIXF Cache Controller Registers</description>
+   <baseAddress>0x4002F000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>INFO</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SZ</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCH</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEM</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SFCC SPIXF Cache Controller Registers-->
+  <peripheral>
+   <name>OTP</name>
+   <description>One-Time Programmable (OTP) Memory Controller.</description>
+   <groupName>OTP</groupName>
+   <baseAddress>0x40041000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>OTP Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address of the OTP 32 bit value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read Operation. Setting this bit starts a read operation from the OTP.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no_op</name>
+         <description>No operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Initiate program operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRITE</name>
+       <description>Program Operation. Setting this bit starts a write operation from the OTP location specified in the ADDR field.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>OTP Clock Divide Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>PCLKDIV</name>
+       <description>Clock Divider. The input clock, PCLK, is divided for generating OTP timing signals.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <description>Divide by 2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <description>Divide by 4</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV8</name>
+         <description>Divide by 8</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV16</name>
+         <description>Divide by 16</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV32</name>
+         <description>Divide by 32</description>
+         <value>31</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SPWE</name>
+       <description>Smart PWE. If programmed value is 1, don't assert PWE.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PD</name>
+       <description>Power Down OTP. OTP controller will generate power up and down signals for control pins.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HCLKDIV</name>
+       <description>Clock Divider. The input clock, HCLK, is divided for generating OTP pwr on and down timing signals.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RDATA</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>OTP Read Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>OTP Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>OTP Busy Flag. This bit indicates whether the OTP controller is working a read or write operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FAIL</name>
+       <description>OTP Failed Flag. This bit indicates whether OTP programming has failed. OTP programming fails if the controller accesses a 32 bit location that has not been previously programmed.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNLOCK1</name>
+       <description>Unlock1 Flag. This bit indicates that 1st password was entered, and the user block is enabled for OTP programming.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNLOCK3</name>
+       <description>Unlock3 Flag. This bit indicates that 3 words unlock process is complete.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWR_RDY</name>
+       <description>OTP Power On Status.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WDATA</name>
+     <description>OTP Write Data Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Write Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACTRL0</name>
+     <description>Access Control for user block.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>ADATA</name>
+       <description>User Block Access Control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACTRL1</name>
+     <description>Access Control for sys and user block.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ADATA</name>
+       <description>System Info Block Access Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--OTP One-Time Programmable (OTP) Memory Controller.-->
+  <peripheral>
+   <name>PT</name>
+   <description>Pulse Train</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C020</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0010</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RATE_LENGTH</name>
+     <description>Pulse Train Configuration</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>rate_control</name>
+       <description>Pulse Train Enable and Rate Control. Set to 0 to disable the Pulse Train.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>27</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>mode</name>
+       <description>Pulse Train Output Mode/Train Length</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>32_BIT</name>
+         <description>Pulse train, 32 bit pattern.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SQUARE_WAVE</name>
+         <description>Square wave mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_BIT</name>
+         <description>Pulse train, 2 bit pattern.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_BIT</name>
+         <description>Pulse train, 3 bit pattern.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_BIT</name>
+         <description>Pulse train, 4 bit pattern.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5_BIT</name>
+         <description>Pulse train, 5 bit pattern.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_BIT</name>
+         <description>Pulse train, 6 bit pattern.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7_BIT</name>
+         <description>Pulse train, 7 bit pattern.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_BIT</name>
+         <description>Pulse train, 8 bit pattern.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9_BIT</name>
+         <description>Pulse train, 9 bit pattern.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_BIT</name>
+         <description>Pulse train, 10 bit pattern.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11_BIT</name>
+         <description>Pulse train, 11 bit pattern.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_BIT</name>
+         <description>Pulse train, 12 bit pattern.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13_BIT</name>
+         <description>Pulse train, 13 bit pattern.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14_BIT</name>
+         <description>Pulse train, 14 bit pattern.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15_BIT</name>
+         <description>Pulse train, 15 bit pattern.</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_BIT</name>
+         <description>Pulse train, 16 bit pattern.</description>
+         <value>16</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>17_BIT</name>
+         <description>Pulse train, 17 bit pattern.</description>
+         <value>17</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>18_BIT</name>
+         <description>Pulse train, 18 bit pattern.</description>
+         <value>18</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>19_BIT</name>
+         <description>Pulse train, 19 bit pattern.</description>
+         <value>19</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>20_BIT</name>
+         <description>Pulse train, 20 bit pattern.</description>
+         <value>20</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>21_BIT</name>
+         <description>Pulse train, 21 bit pattern.</description>
+         <value>21</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>22_BIT</name>
+         <description>Pulse train, 22 bit pattern.</description>
+         <value>22</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>23_BIT</name>
+         <description>Pulse train, 23 bit pattern.</description>
+         <value>23</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>24_BIT</name>
+         <description>Pulse train, 24 bit pattern.</description>
+         <value>24</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>25_BIT</name>
+         <description>Pulse train, 25 bit pattern.</description>
+         <value>25</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>26_BIT</name>
+         <description>Pulse train, 26 bit pattern.</description>
+         <value>26</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>27_BIT</name>
+         <description>Pulse train, 27 bit pattern.</description>
+         <value>27</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>28_BIT</name>
+         <description>Pulse train, 28 bit pattern.</description>
+         <value>28</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>29_BIT</name>
+         <description>Pulse train, 29 bit pattern.</description>
+         <value>29</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30_BIT</name>
+         <description>Pulse train, 30 bit pattern.</description>
+         <value>30</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>31_BIT</name>
+         <description>Pulse train, 31 bit pattern.</description>
+         <value>31</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRAIN</name>
+     <description>Write the repeating bit pattern that is shifted out, LSB first, when configured in Pulse Train mode. See PT_RATE_LENGTH.mode for setting the length.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>LOOP</name>
+     <description>Pulse Train Loop Count</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>count</name>
+       <description>Number of loops for this pulse train to repeat.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>delay</name>
+       <description>Delay between loops of the Pulse Train in PT Peripheral Clock cycles</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>12</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESTART</name>
+     <description> Pulse Train Auto-Restart Configuration.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt_x_select</name>
+       <description>Auto-Restart PT X Select</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_x_loop_exit</name>
+       <description>Enable Auto-Restart on PT X Loop Exit</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt_y_select</name>
+       <description>Auto-Restart PT Y Select</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_y_loop_exit</name>
+       <description>Enable Auto-Restart on PT Y Loop Exit</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PT Pulse Train-->
+  <peripheral derivedFrom="PT">
+   <name>PT1</name>
+   <description>Pulse Train 1</description>
+   <baseAddress>0x4003C030</baseAddress>
+  </peripheral>
+<!--PT1 Pulse Train 1-->
+  <peripheral derivedFrom="PT">
+   <name>PT2</name>
+   <description>Pulse Train 2</description>
+   <baseAddress>0x4003C040</baseAddress>
+  </peripheral>
+<!--PT2 Pulse Train 2-->
+  <peripheral derivedFrom="PT">
+   <name>PT3</name>
+   <description>Pulse Train 3</description>
+   <baseAddress>0x4003C050</baseAddress>
+  </peripheral>
+<!--PT3 Pulse Train 3-->
+  <peripheral derivedFrom="PT">
+   <name>PT4</name>
+   <description>Pulse Train 4</description>
+   <baseAddress>0x4003C060</baseAddress>
+  </peripheral>
+<!--PT4 Pulse Train 4-->
+  <peripheral derivedFrom="PT">
+   <name>PT5</name>
+   <description>Pulse Train 5</description>
+   <baseAddress>0x4003C070</baseAddress>
+  </peripheral>
+<!--PT5 Pulse Train 5-->
+  <peripheral derivedFrom="PT">
+   <name>PT6</name>
+   <description>Pulse Train 6</description>
+   <baseAddress>0x4003C080</baseAddress>
+  </peripheral>
+<!--PT6 Pulse Train 6-->
+  <peripheral derivedFrom="PT">
+   <name>PT7</name>
+   <description>Pulse Train 7</description>
+   <baseAddress>0x4003C090</baseAddress>
+  </peripheral>
+<!--PT7 Pulse Train 7-->
+  <peripheral derivedFrom="PT">
+   <name>PT8</name>
+   <description>Pulse Train 8</description>
+   <baseAddress />
+  </peripheral>
+<!--PT8 Pulse Train 8-->
+  <peripheral>
+   <name>PTG</name>
+   <description>Pulse Train Generation</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0020</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>PT</name>
+    <description>Pulse Train IRQ</description>
+    <value>59</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ENABLE</name>
+     <description>Global Enable/Disable Controls for All Pulse Trains</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Enable/Disable control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Enable/Disable control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Enable/Disable control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Enable/Disable control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Enable/Disable control for PT4</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Enable/Disable control for PT5</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Enable/Disable control for PT6</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Enable/Disable control for PT7</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESYNC</name>
+     <description>Global Resync (All Pulse Trains) Control</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Resync control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Resync control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Resync control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Resync control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Resync control for PT4</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Resync control for PT5</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Resync control for PT6</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Resync control for PT7</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STOP_INTFL</name>
+     <description>Pulse Train Stop Interrupt Flags</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Flag</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Flag</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Flag</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STOP_INTEN</name>
+     <description>Pulse Train Stop Interrupt Enable/Disable</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_EN</name>
+     <description>Pulse Train Global Safe Enable.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_DIS</name>
+     <description>Pulse Train Global Safe Disable.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTFL</name>
+     <description>Pulse Train Ready Interrupt Flags</description>
+     <addressOffset>0x0018</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Ready Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Ready Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Ready Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Ready Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Ready Interrupt Flag</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Ready Interrupt Flag</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Ready Interrupt Flag</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Ready Interrupt Flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTEN</name>
+     <description>Pulse Train Ready Interrupt Enable/Disable</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Ready Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Ready Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Ready Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Ready Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Ready Interrupt Enable/Disable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Ready Interrupt Enable/Disable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Ready Interrupt Enable/Disable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Ready Interrupt Enable/Disable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PTG Pulse Train Generation-->
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x40006800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>LPCTRL</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAMRET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>OVR</name>
+       <description>Operating Voltage Range</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1_1V</name>
+         <description>1.1V</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RETREG_EN</name>
+       <description>Retention Regulator Enable. This bit controls the retention regulator in BACKUP mode. </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FASTWK_EN</name>
+       <description>Fast Wake-Up Mode. This bit enables fast wake-up from DeepSleep mode. (5uS typical). </description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BGOFF</name>
+       <description>Bandgap OFF. This controls the System Bandgap in DeepSleep mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>Bandgap is always ON.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>Bandgap is OFF in DeepSleep mode (default).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREPOR_DIS</name>
+       <description>VCore Power-On Reset Monitor Disable. This bit controls the Power-On Reset monitor on VDDC supply in DeepSleep and BACKUP mode.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDIOHHVMON_DIS</name>
+       <description>VDDIOH High Voltage Monitor Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDIOHVMON_DIS</name>
+       <description>VDDIO High Voltage Monitor Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREHVMON_DIS</name>
+       <description>VCORE High Voltage Monitor Disable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREMON_DIS</name>
+       <description>Vcore Monitor Disable. This bit controls the power monitor on the VCore supply in all operating modes.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VRTCMON_DIS</name>
+       <description>VRTC Monitor Disable. This bit controls the power monitor on the Always-On Supply in all operating modes.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDAMON_DIS</name>
+       <description>VDDA Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDIOMON_DIS</name>
+       <description>VDDIO Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDIOHMON_DIS</name>
+       <description>VFDDIOH Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDBMON_DIS</name>
+       <description>VDDB Monitor Disable. This bit controls the Power-On Reset monitor on VDDB supply in all operating mods.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DEEPSLEEP_PDOUT_DIS</name>
+       <description>PDOWN out enable in DEEPSLEEP mode.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKFL0</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO0.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN0</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register derivedFrom="LPWKFL0">
+     <name>LPWKFL1</name>
+     <description>Low Power I/O Wakeup Status Register 1. This register indicates the low power wakeup status for GPIO1.</description>
+     <addressOffset>0x0C</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN1</name>
+     <description>Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup functionality for GPIO1.</description>
+     <addressOffset>0x10</addressOffset>
+    </register>
+    <register derivedFrom="LPWKFL0">
+     <name>LPWKFL2</name>
+     <description>Low Power I/O Wakeup Status Register 2. This register indicates the low power wakeup status for GPIO2.</description>
+     <addressOffset>0x14</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN2</name>
+     <description>Low Power I/O Wakeup Enable Register 2. This register enables low power wakeup functionality for GPIO2.</description>
+     <addressOffset>0x18</addressOffset>
+    </register>
+    <register derivedFrom="LPWKFL0">
+     <name>LPWKFL3</name>
+     <description>Low Power I/O Wakeup Status Register 3. This register indicates the low power wakeup status for GPIO3.</description>
+     <addressOffset>0x1C</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN3</name>
+     <description>Low Power I/O Wakeup Enable Register 3. This register enables low power wakeup functionality for GPIO3.</description>
+     <addressOffset>0x20</addressOffset>
+    </register>
+    <register>
+     <name>LPPWKFL</name>
+     <description>Low Power Peripheral Wakeup Status Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>USBLS</name>
+       <description>USB UTMI Linestate Detect Wakeup Flag (write one to clear). One or both of these bits will be set when the USB bus activity causes the linestate to change and the device to wake while USB wakeup is enabled using PMLUSBWKEN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>USBVBUS</name>
+       <description>USB VBUS Detect Wakeup Flag (write one to clear). This bit will be set when the USB power supply is powered on or powered off.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CPU1</name>
+       <description>CPU1 Detect Wakeup Flag (wite one to clear). This bit will be set when the SDMA IRQ transitions from low to high, or high to low.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BACKUP</name>
+       <description>Battery Back Wakeup Flag (write one to clear). This bit will be set when exiting Battery Backup Mode.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESET</name>
+       <description>Reset Detect Wakeup Flag (write one to clear). This bit will be set when the external reset causes wakeup</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DRS_EVT</name>
+       <description>Tamper Detext Status. Can only be cleared with a system reset.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWKEN</name>
+     <description>Low Power Peripheral Wakeup Enable Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>USBLS</name>
+       <description>USB UTMI Linestate Detect Wakeup Enable. These bits allow wakeup from the corresponding USB linestate signal (s) on transition (s) from low to high or high to low when PM.USBWKEN is set.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>USBVBUS</name>
+       <description>USB VBUS Detect Wakeup Enable. This bit allows wakeup from the USB power supply on or off status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CPU1</name>
+       <description>CPU1 Wakeup Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPMEMSD</name>
+     <description>Low Power Memory Shutdown Control.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM block 0 Shut Down.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>System RAM block 1 Shut Down.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>System RAM block 2 Shut Down.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>System RAM block 3 Shut Down.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM4</name>
+       <description>System RAM block 4 Shut Down.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM5</name>
+       <description>System RAM block 5 Shut Down.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM6</name>
+       <description>System RAM block 6 Shut Down.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICCXIP</name>
+       <description>XiP Instruction Cache RAM Shut Down.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRYPTO</name>
+       <description>MAA memory Shut Down.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USBFIFO</name>
+       <description>USB FIFO Shut Down.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROM0</name>
+       <description>ROM0 Shut Down.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MEUMEM</name>
+       <description>MEU memory Shut Down.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROM1</name>
+       <description>ROM1 Shut Down.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPVDDPD</name>
+     <description>Low Power VDD Domain Power Down Control.</description>
+     <addressOffset>0x44</addressOffset>
+    </register>
+    <register>
+     <name>GP0</name>
+     <description>General Purpose Register 0</description>
+     <addressOffset>0x48</addressOffset>
+    </register>
+    <register>
+     <name>GP1</name>
+     <description>General Purpose Register 1</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--PWRSEQ Power Sequencer / Low Power Control Register.-->
+  <peripheral>
+   <name>RTC</name>
+   <description>Real Time Clock and Alarm.</description>
+   <baseAddress>0x40006000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>RTC</name>
+    <description>RTC interrupt.</description>
+    <value>3</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC</name>
+       <description>Sub-Seconds Counter (12-bit).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TODA</name>
+     <description>Time-of-day Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-day Alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSECA</name>
+     <description>RTC sub-second alarm.  This register contains the reload value for the sub-second alarm.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>This register contains the reload value for the sub-second alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>RTC Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Real Time Clock Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM_IE</name>
+       <description>Alarm Time-of-Day Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM_IE</name>
+       <description>Alarm Sub-second Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>RTC Busy. This bit is set to 1 by hardware when changes to RTC registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>RTC Ready. This bit is set to 1 by hardware when the RTC count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the RTC count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY_IE</name>
+       <description>RTC Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM_IF</name>
+       <description>Time-of-Day Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM_IF</name>
+       <description>Sub-second Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_SEL</name>
+       <description>Frequency Output Selection. When SQE=1, these bits specify the output frequency on the SQW pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq1Hz</name>
+         <description>1 Hz (Compensated).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq512Hz</name>
+         <description>512 Hz (Compensated).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq4KHz</name>
+         <description>4 KHz.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clkDiv8</name>
+         <description>RTC Input Clock / 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_EN</name>
+       <description>Asynchronous Counter Read Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>sync</name>
+         <description>Synchronous.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>async</name>
+         <description>Asynchronous.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_EN</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical RTC bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ignore</name>
+         <description>Ignored.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>allow</name>
+         <description>Allowed.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIM</name>
+     <description>RTC Trim Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>RTC Trim. This register contains the 2's complement value that specifies the trim resolution. Each increment or decrement of the bit adds or subtracts 1ppm at each 4KHz clock value, with a maximum correction of +/- 127ppm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VBAT_TMR</name>
+       <description>VBAT Timer Value. When RTC is running off of VBAT, this field is incremented every 32 seconds.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>RTC Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>FILTER_EN</name>
+       <description>Enable Filter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_SEL</name>
+       <description>IBIAS Select.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>2x</name>
+         <description>2x</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4x</name>
+         <description>4x</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HYST_EN</name>
+       <description>RTC Hysteresis Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_EN</name>
+       <description>RTC IBIAS Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYPASS</name>
+       <description>RTC Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_32K</name>
+       <description>RTC 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--RTC Real Time Clock and Alarm.-->
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x40000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SISTAT</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>MAGIC</name>
+       <description>Magic Word Validation.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>magicNotSet</name>
+         <description>Magic word was not set (OTP has not been initialized properly).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>magicSet</name>
+         <description>Magic word was set (OTP contains valid settings).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRCERR</name>
+       <description>CRC Error Status.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No CRC errors occurred during the read of the OTP memory block.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>A CRC error occurred while reading the OTP. The address of the failure location in the OTP memory is stored in the ERRADDR register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SIADDR</name>
+     <description>Read-only field set by the SIB block if a CRC error occurs during the read of the OTP memory. Contains the failing address in OTP memory (when CRCERR equals 1).</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ERRADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FSTAT</name>
+     <description>funcstat register.</description>
+     <addressOffset>0x100</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>FPU</name>
+       <description>FPU Function.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USB</name>
+       <description>USB Device.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADC</name>
+       <description>10-bit Sigma Delta ADC.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SPIXIP</name>
+       <description>SPIXIPffunction.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADC9</name>
+       <description>ADC9 function.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SC</name>
+       <description>SC function.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NMI</name>
+       <description>NMI function.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFSTAT</name>
+     <description>Security Function </description>
+     <addressOffset>0x104</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SECBOOT</name>
+       <description>Secure Boot Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SERLOAD</name>
+       <description>Serial Load Disable function.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TRNG</name>
+       <description>TRNG function.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AES</name>
+       <description>AES function.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHA</name>
+       <description>SHA function.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SECMODE</name>
+       <description>Security Mode Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIR System Initialization Registers.-->
+  <peripheral>
+   <name>SMON</name>
+   <description>The Security Monitor block used to monitor system threat conditions.</description>
+   <baseAddress>0x40004000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>EXTSCTRL</name>
+     <description>External Sensor Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x3800FFC0</resetMask>
+     <fields>
+      <field>
+       <name>EXTS_EN0</name>
+       <description>External Sensor Enable for input/output pair 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN1</name>
+       <description>External Sensor Enable for input/output pair 1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN2</name>
+       <description>External Sensor Enable for input/output pair 2.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN3</name>
+       <description>External Sensor Enable for input/output pair 3.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN4</name>
+       <description>External Sensor Enable for input/output pair 4.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN5</name>
+       <description>External Sensor Enable for input/output pair 5.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTCNT</name>
+       <description>External Sensor Error Counter. These bits set the number of external sensor accepted mismatches that have to occur within a single bit period before an external sensor alarm is triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>EXTFRQ</name>
+       <description>External Sensor Frequency. These bits define the frequency at which the external sensors are clocked to/from the EXTS_IN and EXTS_OUT pair.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq2000Hz</name>
+         <description>Div 4 (2000Hz).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq1000Hz</name>
+         <description>Div 8 (1000Hz).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq500Hz</name>
+         <description>Div 16 (500Hz).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq250Hz</name>
+         <description>Div 32 (250Hz).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq125Hz</name>
+         <description>Div 64 (125Hz).</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq63Hz</name>
+         <description>Div 128 (63Hz).</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq31Hz</name>
+         <description>Div 256 (31Hz).</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RFU</name>
+         <description>Reserved. Do not use.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>Clock Divide.  These bits are used to divide the 8KHz input clock. The resulting divided clock is used for all logic within the Security Monitor Block. Note:
+                                                             If the input clock is divided with these bits, the error count threshold table and output frequency will be affected accordingly with the same divide factor.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1 (8000 Hz).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2 (4000 Hz).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4 (2000 Hz).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8 (1000 Hz).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16 (500 Hz).</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32 (250 Hz).</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64 (125 Hz).</description>
+         <value>6</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>Busy. This bit is set to 1 by hardware after EXTSCN register is written to. This bit is automatically cleared to 0 after this register information has been transferred to the security monitor domain.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Update in Progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock Register. Once locked, the EXTSCN register can no longer be modified.  Only a battery disconnect will clear this bit. VBAT powers this register.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTSCTRL</name>
+     <description>Internal Sensor Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x7F00FFF7</resetMask>
+     <fields>
+      <field>
+       <name>SHIELD_EN</name>
+       <description>Die Shield Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TEMP_EN</name>
+       <description>Temperature Sensor Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VBAT_EN</name>
+       <description>Battery Monitor Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DFD_EN</name>
+       <description>Digital Fault Dector Enable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DFD_NMI_EN</name>
+       <description>Digital Fault NMI Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAMPOUT_EN</name>
+       <description>Tamper Output Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LOTEMP_SEL</name>
+       <description>Low Temperature Detection Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>neg50C</name>
+         <description>-50 degrees C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>neg30C</name>
+         <description>-30 degrees C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HITEMP_SEL</name>
+       <description>High Temperature Detection Select.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VCORELO_EN</name>
+       <description>VCORE Undervoltage Detect Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREHI_EN</name>
+       <description>VCORE Overvoltage Detect Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDLO_EN</name>
+       <description>VDD Undervoltage Detect Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDHI_EN</name>
+       <description>VDD Overvoltage Detect Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VGL_EN</name>
+       <description>Voltage Glitch Detection Enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock Register. Once locked, the INTSCN register can no longer be modified.  Only a battery disconnect will clear this bit. VBAT powers this register.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECALM</name>
+     <description>Security Alarm Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000000</resetValue>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>DRS</name>
+       <description>Destructive Reset Trigger. Setting this bit will generate a DRS. This bit is self-cleared by hardware.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>Key Wipe Trigger. Set to 1 to initiate a wipe of the AES key register. It does not reset the part, or log a timestamp. AES and DES registers are not affected by this bit. This bit is automatically cleared to 0 after the keys have been wiped.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHIELD_FL</name>
+       <description>Die Shield Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOTEMP_FL</name>
+       <description>Low Temperature Detect.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HITEMP_FL</name>
+       <description>High Temperature Detect.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATLO_FL</name>
+       <description>Battery Undervoltage Detect.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATHI_FL</name>
+       <description>Battery Overvoltage Detect.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_FL</name>
+       <description>External Sensor Flag.   This bit is set to 1 when any of the EXTSTAT bits are set.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DFD_FL</name>
+       <description>Digital Fault Detector.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VMAINPF_FL</name>
+       <description>VMAIN Power Fail Flag.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREHI_FL</name>
+       <description>VCORE Overvoltage Detect Flag.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDHI_FL</name>
+       <description>VDD Overvoltage Flag.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VGL_FL</name>
+       <description>Voltage Glitch Detection Flag.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT0_FL</name>
+       <description>External Sensor 0 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT1_FL</name>
+       <description>External Sensor 1 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT2_FL</name>
+       <description>External Sensor 2 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT3_FL</name>
+       <description>External Sensor 3 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT4_FL</name>
+       <description>External Sensor 4 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT5_FL</name>
+       <description>External Sensor 5 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN0_FL</name>
+       <description>External Sensor 0 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN1_FL</name>
+       <description>External Sensor 1 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN2_FL</name>
+       <description>External Sensor 2 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN3_FL</name>
+       <description>External Sensor 3 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN4_FL</name>
+       <description>External Sensor 4 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN5_FL</name>
+       <description>External Sensor 5 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECDIAG</name>
+     <description>Security Diagnostic Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <resetValue>0x00000001</resetValue>
+     <resetMask>0xFFC0FE02</resetMask>
+     <fields>
+      <field>
+       <name>POR_FL</name>
+       <description>Power-On-Reset Flag. This bit is set once the power supply is conneted.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHIELD_FL</name>
+       <description>Die Shield Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOTEMP_FL</name>
+       <description>Low Temperature Detect.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HITEMP_FL</name>
+       <description>High Temperature Detect.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATLO_FL</name>
+       <description>Battery Undervoltage Detect.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATHI_FL</name>
+       <description>Battery Overvoltage Detect.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DYNS_FL</name>
+       <description>Dynamic Sensor Flag.  This bit is set to 1 when any of the EXTSTAT bits are set.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESKT_MEU</name>
+       <description>AES Key Transfer. This bit is set to 1 when the NVSRAM 256 bit AES key is generated by the TRNG and loaded to the AES KEY NVSRAM Encryption registers. This bit is reset by a POR or DRS.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>incomplete</name>
+         <description>Key has not been transferred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>Key has been transferred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESKT_MEMPROT_XIP</name>
+       <description>AES Key Transfer.  This bit is set to 1 when AES MDU Key has been transferred from the TRNG to the battery backed AES key register. This bit can only be reset by a BOR.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>incomplete</name>
+         <description>Key has not been transferred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>Key has been transferred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEY0_ZERO</name>
+       <description>Key0 Cleared.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>incomplete</name>
+         <description>Key has not been transferred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>Key has been transferred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEY1_ZERO</name>
+       <description>Key1 Cleared.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>incomplete</name>
+         <description>Key has not been transferred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>Key has been transferred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DFD_FL</name>
+       <description>Digital Fault Detector Flag.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS0_FL</name>
+       <description>External Sensor 0 Detect.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS1_FL</name>
+       <description>External Sensor 1 Detect.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS2_FL</name>
+       <description>External Sensor 2 Detect.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS3_FL</name>
+       <description>External Sensor 3 Detect.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS4_FL</name>
+       <description>External Sensor 4 Detect.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS5_FL</name>
+       <description>External Sensor 5 Detect.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DLRTC</name>
+     <description>DRS Log RTC Value. This register contains the 32 bit value in the RTC second register when the last DRS event occurred.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-only</access>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>DLRTC</name>
+       <description>DRS Log RTC Value. This register contains the 32 bit value in the RTC second register when the last DRS event occured.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEUCTRL</name>
+     <description>MEU Configuration</description>
+     <addressOffset>0x24</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>ENC_EN</name>
+       <description>Configuration plain/encrypted area of the backed NVSRAM.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECST</name>
+     <description>Security Monitor Status Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>EXTSCTRL</name>
+       <description>External Sensor Control Register Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INTSCTRL</name>
+       <description>Internal Sensor Control Register Status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SECALM</name>
+       <description>Security Alarm Register Status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MEUCTRL</name>
+       <description>Security Alarm Register Status.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SDBE</name>
+     <description>Security Monitor Self Destruct Byte.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>SDBYTE</name>
+       <description>Self Destruct Byte</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>SDBYTE_EN</name>
+       <description>Self-Destruct Byte Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SMON The Security Monitor block used to monitor system threat conditions.-->
+  <peripheral>
+   <name>SPIXFC</name>
+   <description>SPI XiP Flash Configuration Controller</description>
+   <baseAddress>0x40027000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPIXFC</name>
+    <description>SPIXFC IRQ</description>
+    <value>38</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0</name>
+     <description>Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>SSEL</name>
+       <description>Slaves Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Slave_0</name>
+         <description>Slave 0 is selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Slave_1</name>
+         <description>Slave 1 is selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire Mode.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description>Defines SPI Mode, Only valid values are 0 and 3.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SPI_Mode_0</name>
+         <description>SPIX Mode 0. CLK Polarity = 0, CLK Phase = 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SPI_Mode_3</name>
+         <description>SPIX Mode 3. CLK Polarity = 1, CLK Phase = 1.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PGSZ</name>
+       <description>Page Size.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>4_bytes</name>
+         <description>4 bytes.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_bytes</name>
+         <description>8 bytes.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_bytes</name>
+         <description>16 bytes.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>32_bytes</name>
+         <description>32 bytes.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HICLK</name>
+       <description>SCLK High Clocks. Number of system clocks that SCLK will be high when SCLK pulses are generated. 0 Correspond to 16 system clocks and, all other values defines the number of system clock taht SCLK will be held high.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16_SCLK</name>
+         <description>16 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCLK</name>
+       <description>SCLK low Clocks. Number of system clocks that SCLK will be low when SCLK pulses are generated. 0 correspond to 16 system clocks and, all other values defines the number of system clock taht SCLK will be held low.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16_SCLK</name>
+         <description>16 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSACT</name>
+       <description>Slaves Select Activate Timing.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_CLKS</name>
+         <description>0 sytem clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_CLKS</name>
+         <description>2 sytem clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_CLKS</name>
+         <description>4 sytem clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_CLKS</name>
+         <description>8 sytem clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSINACT</name>
+       <description>Slaves Select Inactive Timing.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>4_CLKS</name>
+         <description>4 sytem clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_CLKS</name>
+         <description>6 sytem clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_CLKS</name>
+         <description>8 sytem clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_CLKS</name>
+         <description>12 sytem clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IOSMPL</name>
+       <description>Sample Delay</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSPOL</name>
+     <description>SPIX Controller Slave Select Polarity Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>SSPOL</name>
+       <description>Slave Select Polarity.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lo</name>
+         <description>Active Low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hi</name>
+         <description>Active High.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FCPOL</name>
+       <description>FC Polarity.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lo</name>
+         <description>Active Low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hi</name>
+         <description>Active High.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>SPIX Controller General Controller Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Master enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable SPI Master, putting a reset state.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable SPI Master for processing transactions.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transaction FIFO Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis_txfifo</name>
+         <description>Disable Transaction FIFO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en_txfifo</name>
+         <description>Enable Transaction FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Result FIFO Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS_RXFIFO</name>
+         <description>Disable Result FIFO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EN_RXFIFO</name>
+         <description>Enable Result FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BB_EN</name>
+       <description>Bit-Bang Mode.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Bit-Bang Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Bit-Bang Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSDR</name>
+       <description>This bits reflects the state of the currently selected slave select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output0</name>
+         <description>Selected Slave select output = 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>output1</name>
+         <description>Selected Slave select output = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FCDR</name>
+       <description>This bits reflects the state of the selected FC.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCLKDR</name>
+       <description>SCLK Drive and State.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SCLK_0</name>
+         <description>SCLK is 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SCLK_1</name>
+         <description>SCLK is 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDIO_DATA_IN</name>
+       <description>SDIO Input Data Value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BB_DATA_OUT</name>
+       <description>Bit Bang SDIO Output.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BB_DATA_OUT_EN</name>
+       <description>Bit Bang SDIO Output Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SIMPLE_EN</name>
+       <description>Simple Mode Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SIMPLE_RX</name>
+       <description>Simple Receive Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SIMPLE_SS</name>
+       <description>Simple Mode Slave Select.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCLK_FB</name>
+       <description>Enable SCLK Feedback Mode.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>En</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLK_FB_INV</name>
+       <description>SCK Invert.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>SPIX Controller FIFO Control and Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>TX_AE_LVL</name>
+       <description>Transaction FIFO Almost Empty Level.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_CNT</name>
+       <description>Transaction FIFO Used.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_AF_LVL</name>
+       <description>Results FIFO Almost Full Level.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_CNT</name>
+       <description>Result FIFO Used.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL3</name>
+     <description>SPIX Controller Special Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>SAMPLE</name>
+       <description>Setting this bit to a 1 enables the ability to drive SDIO outputs prior to the assertion of Slave Select. This bit must
+                                                                         only be set when the SPIXF bus is idle and the transaction FIFO is empty. This bit is automatically cleared by hardware after the
+                                                                         next slave select assertion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MISO_FC_EN</name>
+       <description>MISO FC Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SDIO_OUT_VAL</name>
+       <description>SDIO Output Value Sample Mode</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>SDIO_OUT_EN</name>
+       <description>SDIO Output Enable Sample Mode</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>SCLKINH3</name>
+       <description>SCLK Inhibit Mode3. In SPI Mode 3, some SPI flash read timing diagrams show the last SCLK going low prior to de-assertion. The default is to support this additional falling edge of clock. When this bit is set and the device is in SPI Mode 3, the SPI clock is held high while Slave Select is de-asserted. This is to support some SPI flash write timing diagrams.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Allow trailing SCLK low pulse prior to Slave Select de-assertion.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Inhibit trailing SCLK low pulse prior to Slave Select de-assertion.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>SPIX Controller Interrupt Status Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>TX_STALLED</name>
+       <description>Transaction Stalled Interrupt Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Normal FIFO Transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Stalled FIFO Transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_STALLED</name>
+       <description>Results Stalled Interrupt Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Normal FIFO Operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Stalled FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_RDY</name>
+       <description>Transaction Ready Interrupt Status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>FIFO Transaction not ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>FIFO Transaction ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_DONE</name>
+       <description>Results Done Interrupt Status.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Results FIFO ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Results FIFO Not ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_AE</name>
+       <description>Transaction FIFO Almost Empty Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Transaction FIFO not Almost Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Transaction FIFO Almost Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_AF</name>
+       <description>Results FIFO Almost Full Flag.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Results FIFO level below the Almost Full level.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Results FIFO level at Almost Full level.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>SPIX Controller Interrupt Enable Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>TX_STALLED</name>
+       <description>Transaction Stalled Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable Transaction Stalled Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable Transaction Stalled Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_STALLED</name>
+       <description>Results Stalled Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable Results Stalled Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable Results Stalled Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_RDY</name>
+       <description>Transaction Ready Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable FIFO Transaction Ready Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable FIFO Transaction Ready Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_DONE</name>
+       <description>Results Done Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable Results Done Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable Results Done Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_AE</name>
+       <description>Transaction FIFO Almost Empty Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable Transaction FIFO Almost Empty Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable Transaction FIFO Almost Empty Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_AF</name>
+       <description>Results FIFO Almost Full Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable Results FIFO Almost Full Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable Results FIFO Almost Full Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HEADER</name>
+     <description>Simple Header</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>TX_BIDIR</name>
+       <description>TX Bdirectional Header.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>RX_ONLY</name>
+       <description>RX Only Header.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCTRL</name>
+     <description>Auto Control Register.</description>
+     <addressOffset>0x20</addressOffset>
+    </register>
+    <register>
+     <name>AUTOCMD</name>
+     <description>Auto Command Register.</description>
+     <addressOffset>0x24</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXFC SPI XiP Flash Configuration Controller-->
+  <peripheral>
+   <name>SPIXFC_FIFO</name>
+   <description>SPI XiP Master Controller FIFO.</description>
+   <baseAddress>0x400BC000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>TX_8</name>
+     <description>SPI TX FIFO 8-Bit Write</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <dataType>uint8_t</dataType>
+    </register>
+    <register>
+     <name>TX_16</name>
+     <description>SPI TX FIFO 16-Bit Write</description>
+     <alternateRegister>TX_8</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <dataType>uint16_t</dataType>
+    </register>
+    <register>
+     <name>TX_32</name>
+     <description>SPI TX FIFO 32-Bit Write</description>
+     <alternateRegister>TX_8</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <dataType>uint32_t</dataType>
+    </register>
+    <register>
+     <name>RX_8</name>
+     <description>SPI RX FIFO 8-Bit Access</description>
+     <addressOffset>0x04</addressOffset>
+     <size>8</size>
+     <dataType>uint8_t</dataType>
+    </register>
+    <register>
+     <name>RX_16</name>
+     <description>SPI RX FIFO 16-Bit Access</description>
+     <alternateRegister>RX_8</alternateRegister>
+     <addressOffset>0x04</addressOffset>
+     <size>16</size>
+     <dataType>uint16_t</dataType>
+    </register>
+    <register>
+     <name>RX_32</name>
+     <description>SPI RX FIFO 32-Bit Access</description>
+     <alternateRegister>RX_8</alternateRegister>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+     <dataType>uint32_t</dataType>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXFC_FIFO SPI XiP Master Controller FIFO.-->
+  <peripheral>
+   <name>SPIXFM</name>
+   <description>SPIXF Master</description>
+   <baseAddress>0x40026000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>SPIX Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Defines SPI Mode, Only valid values are 0 and 3.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SCLK_HI_SAMPLE_RISING</name>
+         <description>Description not available.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SCLK_LO_SAMPLE_FAILLING</name>
+         <description>Description not available.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSPOL</name>
+       <description>Slave Select Polarity.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ACTIVE_HIGH</name>
+         <description>Slave Select is Active High.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ACTIVE_LOW</name>
+         <description>Slave Select is Active Low.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEL</name>
+       <description>Slave Select. Only valid value is zero.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>LOCLK</name>
+       <description>Number of system clocks that SCLK will be low when SCLK pulses are generated.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>HICLK</name>
+       <description>Number of system clocks that SCLK will be high when SCLK pulses are generated.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>SSACT</name>
+       <description>Slave Select Active Timing.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>off</name>
+         <description>0 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_2_mod_clk</name>
+         <description>2 System clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_4_mod_clk</name>
+         <description>4 System clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_8_mod_clk</name>
+         <description>8 System clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSINACT</name>
+       <description>Slave Select Inactive Timing.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>for_1_mod_clk</name>
+         <description>1 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_3_mod_clk</name>
+         <description>3 System clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_5_mod_clk</name>
+         <description>5 System clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_9_mod_clk</name>
+         <description>9 System clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FETCHCTRL</name>
+     <description>SPIX Fetch Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>CMD_VAL</name>
+       <description>Command Value sent to target to initiate fetching from SPI flash.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>CMD_WDTH</name>
+       <description>Command Width. Number of data I/O used to send commands.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Single</name>
+         <description>Single SDIO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual_IO</name>
+         <description>Dual SDIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad_IO</name>
+         <description>Quad SDIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Invalid</name>
+         <description>Invalid.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_WDTH</name>
+       <description>Address Width. Number of data I/O used to send address, and mode/dummy clocks.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Single</name>
+         <description>Single SDIO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual_IO</name>
+         <description>Dual SDIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad_IO</name>
+         <description>Quad SDIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Invalid</name>
+         <description>Invalid.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WDTH</name>
+       <description>Data Width. Number of data I/O used to receive data.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Single</name>
+         <description>Single SDIO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual_IO</name>
+         <description>Dual SDIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad_IO</name>
+         <description>Quad SDIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Invalid</name>
+         <description>Invalid.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>4BADDR</name>
+       <description>Four Byte Address Mode. Enables 4-byte Flash Address Mode.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>3</name>
+         <description>3 Byte Address Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4</name>
+         <description>4 Byte Address Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MODECTRL</name>
+     <description>SPIX Mode Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>MDCLK</name>
+       <description>Mode Clocks. Number of SPI clocks needed during mode/dummy phase of fetch.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>NOCMD</name>
+       <description>No Command Mode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>always</name>
+         <description>Send read command every time SPI transaction is initiated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>once</name>
+         <description>Send read command only once. NO read command in subsequent SPI transactions.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXIT_NOCMD</name>
+       <description>Mode Send.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MODEDATA</name>
+     <description>SPIX Mode Data Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Mode Data. Specifies the data to send with the Dummy/Mode clocks.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>OUT_EN</name>
+       <description>Mode Output Enable. Output enable state for each corresponding data bit in MD_DATA. 0: output enable off, I/O is tristate and 1: Output enable on, I/O is driving MD_DATA.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FBCTRL</name>
+     <description>SPIX Feedback Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enable SCLK feedback mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable SCLK feedback mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable SCLK feedback mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INVERT</name>
+       <description>Invert SCLK in feedback mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Invert SCLK feedback mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Invert SCLK feedback mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IOCTRL</name>
+     <description>SPIX IO Control Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>SCLK_DS</name>
+       <description>SCLK drive Strength. This bit controls the drive strength on the SCLK pin.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Low</name>
+         <description>Low drive strength.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>High</name>
+         <description>High drive strength.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_DS</name>
+       <description>Slave Select Drive Strength. This bit controls the drive strength on the dedicated slave select pin.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Low</name>
+         <description>Low drive strength.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>High</name>
+         <description>High drive strength.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDIO_DS</name>
+       <description>SDIO Drive Strength. This bit controls the drive strength of all SDIO pins.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Low</name>
+         <description>Low drive strength.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>High</name>
+         <description>High drive strength.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PADCTRL</name>
+       <description>IO Pullup/Pulldown Control. These bits control the pullups and pulldowns associated with all SPI XiP SDIO pins.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>tri_state</name>
+         <description>Tristate.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pull_Up</name>
+         <description>Pull-Up.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pull_down</name>
+         <description>Pull-Down.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMSECCTRL</name>
+     <description>SPIX Memory Security Control Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>DEC_EN</name>
+       <description>Decryption Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable decryption of SPIX data.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable decryption of SPIX data.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTH_DIS</name>
+       <description>Integrity Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Integrity checking enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Integrity checking disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CNTOPT_EN</name>
+       <description>Enable counters optimization (when authentication is enabled).</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable counter optimization.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable counter optimization.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INTERL_DIS</name>
+       <description>Disable authenticity interleaving (when authentication is enabled)</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable interleaving of SPIX data.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable interleaving of SPIX data.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTHERR_FL</name>
+       <description>Authentication Error Flag Bit.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUSIDLE</name>
+     <description>Bus Idle</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>BUSIDLE</name>
+       <description>A 16-bit timer will be triggered for each external access. The timer will be
+                                         restarted if another access is performed before the timer expires. When the
+                                             timer expires, slave select will be deactivated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTHOFFSET</name>
+     <description>Auth Offset</description>
+     <addressOffset>0x28</addressOffset>
+    </register>
+    <register>
+     <name>BYPASS_MODE</name>
+     <description>Bypass Mode Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enable bypass.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FCLK_DELAY</name>
+       <description>FCLK Delay.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_NS</name>
+         <description>0ns</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>0P5_NS</name>
+         <description>0.5ns</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1P0_NS</name>
+         <description>1.0ns</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1P5_NS</name>
+         <description>1.5ns</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2P0_NS</name>
+         <description>2.0ns</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2P5_NS</name>
+         <description>2.5ns</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3P0_NS</name>
+         <description>3.0ns</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3P5_NS</name>
+         <description>3.0ns</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLK_DELAY</name>
+       <description>SCLK Delay.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_NS</name>
+         <description>0ns</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>0P5_NS</name>
+         <description>0.5ns</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1P0_NS</name>
+         <description>1.0ns</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1P5_NS</name>
+         <description>1.5ns</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2P0_NS</name>
+         <description>2.0ns</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2P5_NS</name>
+         <description>2.5ns</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3P0_NS</name>
+         <description>3.0ns</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3P5_NS</name>
+         <description>3.0ns</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXFM SPIXF Master-->
+  <peripheral>
+   <name>SPI</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x40046000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>16</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FIFO32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>FIFO16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>FIFO32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>FIFO8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>FIFO32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Start Select Control. Used in Master mode to control the behavior of the Slave Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DEASSERT</name>
+         <description>SPI De-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ASSERT</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_ACTIVE</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3</name>
+         <description>SS3 is selected.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Rising_Edge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Falling_Edge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLK_FB_INV</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1</name>
+         <description>1 bits per character.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2</name>
+         <description>2 bits per character.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3</name>
+         <description>3 bits per character.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4</name>
+         <description>4 bits per character.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5</name>
+         <description>5 bits per character.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6</name>
+         <description>6 bits per character.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7</name>
+         <description>7 bits per character.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8</name>
+         <description>8 bits per character.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9</name>
+         <description>9 bits per character.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10</name>
+         <description>10 bits per character.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11</name>
+         <description>11 bits per character.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12</name>
+         <description>12 bits per character.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13</name>
+         <description>13 bits per character.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14</name>
+         <description>14 bits per character.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15</name>
+         <description>15 bits per character.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin(s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSPOL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3_high</name>
+         <description>SS3 active high.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSTIME</name>
+     <description>Register for controlling SPI peripheral/Slave Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PRE</name>
+       <description>Slave Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POST</name>
+       <description>Slave Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write
+            pointers. This should be done when FIFO is not being accessed on the SPI side.
+          .</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPI SPI peripheral.-->
+  <peripheral derivedFrom="SPI">
+   <name>SPI1</name>
+   <description>SPI peripheral. 1</description>
+   <baseAddress>0x40047000</baseAddress>
+   <interrupt>
+    <name>SPI1</name>
+    <description>SPI1 IRQ</description>
+    <value>17</value>
+   </interrupt>
+  </peripheral>
+<!--SPI1 SPI peripheral. 1-->
+  <peripheral derivedFrom="SPI">
+   <name>SPI2</name>
+   <description>SPI peripheral. 2</description>
+   <baseAddress>0x400BE000</baseAddress>
+   <interrupt>
+    <name>SPI2</name>
+    <description>SPI2 IRQ</description>
+    <value>56</value>
+   </interrupt>
+  </peripheral>
+<!--SPI2 SPI peripheral. 2-->
+  <peripheral>
+   <name>TMR0</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting.</description>
+   <groupName>Timers</groupName>
+   <baseAddress>0x40010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR0</name>
+    <description>TMR0 IRQ</description>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Count.  This register stores the current timer count.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Count.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Compare.  This register stores the compare value, which is used to set the maximum count value to initiate a reload of the timer to 0x0001.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x0000FFFF</resetValue>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>Compare.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>PWM.  This register stores the value that is compared to the current timer count.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>PWM</name>
+       <description>PWM</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Clear Interrupt. Writing a value (0 or 1) to a bit in this register clears the associated interrupt.</description>
+     <addressOffset>0x0C</addressOffset>
+     <modifiedWriteValues>oneToClear</modifiedWriteValues>
+     <fields>
+      <field>
+       <name>IRQ</name>
+       <description>Clear Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Timer Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>oneShot</name>
+         <description>One Shot Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Continuous Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>counter</name>
+         <description>Counter Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pwm</name>
+         <description>PWM Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>capture</name>
+         <description>Capture Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>compare</name>
+         <description>Compare Mode.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>gated</name>
+         <description>Gated Mode.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>captureCompare</name>
+         <description>Capture/Compare Mode.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>Prescaler.  Set the Timer's prescaler value. The prescaler divides the PCLK input to the timer and sets the Timer's Count Clock, F_CNT_CLK = PCLK (HZ) /prescaler. The Timer's prescaler setting is a 4-bit value with pres3:pres[2:0].</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL</name>
+       <description>Timer input/output polarity bit.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Timer Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV3</name>
+       <description>MSB of prescaler value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC</name>
+       <description>Timer PWM Synchronization Mode Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NOLHPOL</name>
+       <description>Timer PWM output 0A polarity bit.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NOLLPOL</name>
+       <description>Timer PWM output 0A' polarity bit.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PWMCKBD</name>
+       <description>Timer PWM output 0A Mode Disable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Non-overlapping Low Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A and next rising edge of PWM output 0A'.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Non-overlapping High Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A' and next rising edge of PWM output 0A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TMR0 32-bit reloadable timer that can be used for timing and event counting.-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR1</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 1</description>
+   <baseAddress>0x40011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+<!--TMR1 32-bit reloadable timer that can be used for timing and event counting. 1-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR2</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 2</description>
+   <baseAddress>0x40012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+<!--TMR2 32-bit reloadable timer that can be used for timing and event counting. 2-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR3</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 3</description>
+   <baseAddress>0x40013000</baseAddress>
+   <interrupt>
+    <name>TMR3</name>
+    <description>TMR3 IRQ</description>
+    <value>8</value>
+   </interrupt>
+  </peripheral>
+<!--TMR3 32-bit reloadable timer that can be used for timing and event counting. 3-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR4</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 4</description>
+   <baseAddress>0x40014000</baseAddress>
+   <interrupt>
+    <name>TMR4</name>
+    <description>TMR4 IRQ</description>
+    <value>9</value>
+   </interrupt>
+  </peripheral>
+<!--TMR4 32-bit reloadable timer that can be used for timing and event counting. 4-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR5</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 5</description>
+   <baseAddress>0x40015000</baseAddress>
+   <interrupt>
+    <name>TMR5</name>
+    <description>TMR5 IRQ</description>
+    <value>10</value>
+   </interrupt>
+  </peripheral>
+<!--TMR5 32-bit reloadable timer that can be used for timing and event counting. 5-->
+  <peripheral>
+   <name>TRNG</name>
+   <description>Random Number Generator.</description>
+   <baseAddress>0x4004D000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TRNG</name>
+    <description>TRNG interrupt.</description>
+    <value>4</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>TRNG Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000003</resetValue>
+     <fields>
+      <field>
+       <name>OD_HEALTH</name>
+       <description>Start On-Demand health test.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RND_IE</name>
+       <description>To enable IRQ generation when a new 32-bit Random number is ready.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HEALTH_IE</name>
+       <description>Enable IRQ generation when a health test fails.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MEU_KEYGEN</name>
+       <description>If set to 1, the TRNG generates the 256-bit AES MEU keys.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>XIP_KEYGEN</name>
+       <description>If set to 1, the TRNG generates the 128-bit QSPI (XIP) keys.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OD_ROMON</name>
+       <description>Start ring oscillator monitor on demand test.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OD_EE</name>
+       <description>Start entropy estimator on demand test.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMON_EE_FOE</name>
+       <description>Ring Oscillator Monitors and Entropy Estimator Freeze on Error.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMON_EE_FOD</name>
+       <description>Ring Oscillator Monitors and Entropy Estimator Freeze on Done.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EBLS</name>
+       <description>Entropy Bit Load Select.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>To wipe the Battery Backed key.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GET_TERO_CNT</name>
+       <description>Get Tero Count.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EE_DONE_IE</name>
+       <description>Entropy Estimator Done Interrupt Enable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMON_DIS</name>
+       <description>Ring Oscillator Disable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>RO_0</name>
+         <description>Ring Oscillator 0.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RO_1</name>
+         <description>Ring Oscillator 1.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RO_2</name>
+         <description>Ring Oscillator 2.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>RDY</name>
+       <description>32-bit random data is ready to read from TRNG_DATA register. Reading TRNG_DATA when RND_RDY=0 will return all 0's. IRQ is generated when RND_RDY=1 if TRNG_CN.RND_IRQ_EN=1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Busy</name>
+         <description>TRNG Busy</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Ready</name>
+         <description>32 bit random data is ready</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OD_HEALTH</name>
+       <description>On-Demand health test status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HEALTH</name>
+       <description>Health test status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRCFAIL</name>
+       <description>Entropy source has failed.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AES_KEYGEN</name>
+       <description>AESKGD.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OD_ROMON</name>
+       <description>On demand ring oscillator test status.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OD_EE</name>
+       <description>On demand entropy estimator status.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PP_ERR</name>
+       <description>Post process error.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMON_0_ERR</name>
+       <description>Ring Oscillator 0 Monitor Error.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMON_1_ERR</name>
+       <description>Ring Oscillator 1 Monitor Error.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMON_2_ERR</name>
+       <description>Ring Oscillator 2 Monitor Error.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EE_ERR_THR</name>
+       <description>Entropy Estimator Threshold Error.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EE_ERR_OOB</name>
+       <description>Entropy Estimator Out of Bounds Error..</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EE_ERR_LOCK</name>
+       <description>Entropy Estimator Lock Error.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TERO_CNT_RDY</name>
+       <description>TERO Count Ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RC_ERR</name>
+       <description>Repetition Count Error.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AP_ERR</name>
+       <description>Adaptive Proportion Error.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_DONE</name>
+       <description>Data register has been loaded with at least 32 new entropy bits.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_NIST_DONE</name>
+       <description>Data NIST register has been loaded with at least 32 new entropy bits.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HEALTH_DONE</name>
+       <description>Health Test Done.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMON_DONE</name>
+       <description>Ring Oscillator Monitor Test Done.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EE_DONE</name>
+       <description>Entropy Estimator Test Done.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data. The content of this register is valid only when RNG_IS =1. When TNRG is disabled, read returns 0x0000 0000.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA_NIST</name>
+     <description>Data NIST Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Ring Oscillator 1 Monitor Last Ring Oscillator Count.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRNG Random Number Generator.-->
+  <peripheral>
+   <name>UART</name>
+   <description>UART Low Power Registers</description>
+   <baseAddress>0x40042000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control register</description>
+     <addressOffset>0x0000</addressOffset>
+     <fields>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>This field specifies the depth of receive FIFO for interrupt generation (value 0 and &gt; 16 are ignored) </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EN</name>
+       <description>Parity Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EO</name>
+       <description>when PAREN=1 selects odd or even parity odd is 1 even is 0</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_MD</name>
+       <description>Selects parity based on 1s or 0s count (when PAREN=1) </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_DIS</name>
+       <description>CTS Sampling Disable </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Flushes the TX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Flushes the RX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHAR_SIZE</name>
+       <description>Selects UART character size</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5bits</name>
+         <description>5 bits</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6bits</name>
+         <description>6 bits</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7bits</name>
+         <description>7 bits</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8bits</name>
+         <description>8 bits</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPBITS</name>
+       <description>Selects the number of stop bits that will be generated</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HFC_EN</name>
+       <description>Enables/disables hardware flow control</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RTSDC</name>
+       <description>Hardware Flow Control RTS Mode</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKEN</name>
+       <description>Baud clock enable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKSRC</name>
+       <description>To select the UART clock source for the UART engine (except APB registers). Secondary clock (used for baud rate generator) can be asynchronous from APB clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Peripheral_Clock</name>
+         <description>apb clock</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>External_Clock</name>
+         <description>Clock 1</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK2</name>
+         <description>Clock 2</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK3</name>
+         <description>Clock 3</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPFE_EN</name>
+       <description>Data/Parity bit frame error detection enable</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKRDY</name>
+       <description>Baud clock Ready read only bit</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UCAGM</name>
+       <description>UART Clock Auto Gating mode</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FDM</name>
+       <description>Fractional Division Mode</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DESM</name>
+       <description>RX Dual Edge Sampling Mode</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TX_BUSY</name>
+       <description>Read-only flag indicating the UART transmit status</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_BUSY</name>
+       <description>Read-only flag indicating the UART receiver status</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Indicates the number of bytes currently in the RX FIFO (0-RX FIFO_ELTS) </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Indicates the number of bytes currently in the TX FIFO (0-TX FIFO_ELTS) </description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable control register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Enable Interrupt For RX Frame Error</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Enable Interrupt For RX Parity Error</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Enable Interrupt For CTS signal change Error</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Enable Interrupt For RX FIFO Overrun Error</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Enable Interrupt For RX FIFO reaches the number of bytes configured by RXTHD</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Enable Interrupt For TX FIFO has only one byte remaining.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Enable Interrupt For TX FIFO has half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Interrupt status flags Control register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Flag for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Flag for RX Parity Error interrupt</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Flag for CTS signal change interrupt (hardware flow control disabled) </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Flag for RX FIFO Overrun interrupt</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Flag for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Flag for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Flag for interrupt when TX FIFO is half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Clock Divider register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Baud rate divisor value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSR</name>
+     <description>Over Sampling Rate register</description>
+     <addressOffset>0x0014</addressOffset>
+     <fields>
+      <field>
+       <name>OSR</name>
+       <description>OSR</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXPEEK</name>
+     <description>TX FIFO Output Peek register</description>
+     <addressOffset>0x0018</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read TX FIFO next data. Reading from this field does not affect the contents of TX FIFO. Note that the parity bit is available from this field.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PNR</name>
+     <description> Pin register</description>
+     <addressOffset>0x001C</addressOffset>
+     <fields>
+      <field>
+       <name>CTS</name>
+       <description>Current sampled value of CTS IO</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RTS</name>
+       <description>This bit controls the value to apply on the RTS IO. If set to 1, the RTS IO is set to high level. If set to 0, the RTS IO is set to low level.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Read/Write register</description>
+     <addressOffset>0x0020</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Parity error flag for next byte to be read from FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration register</description>
+     <addressOffset>0x0030</addressOffset>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger If the TX FIFO level is less than this value, then the TX FIFO DMA interface will send a signal to system DMA to notify that TX FIFO is ready to receive data from memory.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX DMA channel enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Rx FIFO Level DMA Trigger If the RX FIFO level is greater than this value, then the RX FIFO DMA interface will send a signal to the system DMA to notify that RX FIFO has characters to transfer to memory.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX DMA channel enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wake up enable Control register</description>
+     <addressOffset>0x0034</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Enable for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Enable for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Enable for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wake up Flags register</description>
+     <addressOffset>0x0038</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Flag for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Flag for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Flag for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--UART UART Low Power Registers-->
+  <peripheral derivedFrom="UART">
+   <name>UART1</name>
+   <description>UART Low Power Registers 1</description>
+   <baseAddress>0x40043000</baseAddress>
+  </peripheral>
+<!--UART1 UART Low Power Registers 1-->
+  <peripheral derivedFrom="UART">
+   <name>UART2</name>
+   <description>UART Low Power Registers 2</description>
+   <baseAddress>0x40044000</baseAddress>
+  </peripheral>
+<!--UART2 UART Low Power Registers 2-->
+  <peripheral derivedFrom="UART">
+   <name>UART3</name>
+   <description>UART Low Power Registers 3</description>
+   <baseAddress>0x40045000</baseAddress>
+  </peripheral>
+<!--UART3 UART Low Power Registers 3-->
+  <peripheral>
+   <name>USBHS</name>
+   <description>USB 2.0 High-speed Controller.</description>
+   <baseAddress>0x400B1000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>USB</name>
+    <value>2</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FADDR</name>
+     <description>Function address register.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <resetMask>0x00</resetMask>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Function address for this controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>UPDATE</name>
+       <description>Set when ADDR is written, cleared when new address takes effect.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>POWER</name>
+     <description>Power management register.</description>
+     <addressOffset>0x01</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>EN_SUSPENDM</name>
+       <description>Enable SUSPENDM signal.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SUSPEND</name>
+       <description>Suspend mode detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESUME</name>
+       <description>Generate resume signaling.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESET</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS_MODE</name>
+       <description>High-speed mode detected.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS_ENABLE</name>
+       <description>High-speed mode enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SOFTCONN</name>
+       <description>Softconn.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ISO_UPDATE</name>
+       <description>Wait for SOF during Isochronous xfers.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRIN</name>
+     <description>Interrupt register for EP0 and IN EP1-15.</description>
+     <addressOffset>0x02</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_IN_INT</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP14_IN_INT</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP13_IN_INT</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP12_IN_INT</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP11_IN_INT</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP10_IN_INT</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP9_IN_INT</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP8_IN_INT</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP7_IN_INT</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP6_IN_INT</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP5_IN_INT</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP4_IN_INT</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP3_IN_INT</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP2_IN_INT</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP1_IN_INT</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP0_IN_INT</name>
+       <description>Endpoint 0 interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTROUT</name>
+     <description>Interrupt register for OUT EP 1-15.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_OUT_INT</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP14_OUT_INT</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP13_OUT_INT</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP12_OUT_INT</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP11_OUT_INT</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP10_OUT_INT</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP9_OUT_INT</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP8_OUT_INT</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP7_OUT_INT</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP6_OUT_INT</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP5_OUT_INT</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP4_OUT_INT</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP3_OUT_INT</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP2_OUT_INT</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP1_OUT_INT</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRINEN</name>
+     <description>Interrupt enable for EP 0 and IN EP 1-15.</description>
+     <addressOffset>0x06</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_IN_INT_EN</name>
+       <description>Endpoint 15 interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP14_IN_INT_EN</name>
+       <description>Endpoint 14 interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP13_IN_INT_EN</name>
+       <description>Endpoint 13 interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP12_IN_INT_EN</name>
+       <description>Endpoint 12 interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP11_IN_INT_EN</name>
+       <description>Endpoint 11 interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP10_IN_INT_EN</name>
+       <description>Endpoint 10 interrupt enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP9_IN_INT_EN</name>
+       <description>Endpoint 9 interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP8_IN_INT_EN</name>
+       <description>Endpoint 8 interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP7_IN_INT_EN</name>
+       <description>Endpoint 7 interrupt enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP6_IN_INT_EN</name>
+       <description>Endpoint 6 interrupt enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP5_IN_INT_EN</name>
+       <description>Endpoint 5 interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP4_IN_INT_EN</name>
+       <description>Endpoint 4 interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP3_IN_INT_EN</name>
+       <description>Endpoint 3 interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP2_IN_INT_EN</name>
+       <description>Endpoint 2 interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP1_IN_INT_EN</name>
+       <description>Endpoint 1 interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP0_INT_EN</name>
+       <description>Endpoint 0 interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTROUTEN</name>
+     <description>Interrupt enable for OUT EP 1-15.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_OUT_INT_EN</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP14_OUT_INT_EN</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP13_OUT_INT_EN</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP12_OUT_INT_EN</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP11_OUT_INT_EN</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP10_OUT_INT_EN</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP9_OUT_INT_EN</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP8_OUT_INT_EN</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP7_OUT_INT_EN</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP6_OUT_INT_EN</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP5_OUT_INT_EN</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP4_OUT_INT_EN</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP3_OUT_INT_EN</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP2_OUT_INT_EN</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP1_OUT_INT_EN</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRUSB</name>
+     <description>Interrupt register for common USB interrupts.</description>
+     <addressOffset>0x0A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SOF_INT</name>
+       <description>Start of Frame.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESET_INT</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESUME_INT</name>
+       <description>Resume detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SUSPEND_INT</name>
+       <description>Suspend detected.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRUSBEN</name>
+     <description>Interrupt enable for common USB interrupts.</description>
+     <addressOffset>0x0B</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SOF_INT_EN</name>
+       <description>Start of Frame.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESET_INT_EN</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESUME_INT_EN</name>
+       <description>Resume detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SUSPEND_INT_EN</name>
+       <description>Suspend detected.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FRAME</name>
+     <description>Frame number.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>FRAMENUM</name>
+       <description>Read the last received frame number, that is the 11-bit frame number received in the SOF packet.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INDEX</name>
+     <description>Index for banked registers.</description>
+     <addressOffset>0x0E</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>INDEX</name>
+       <description>Index Register Access Selector. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TESTMODE</name>
+     <description>USB 2.0 test mode enable register.</description>
+     <addressOffset>0x0F</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>FORCE_FS</name>
+       <description>Force USB to Full-speed after reset.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FORCE_HS</name>
+       <description>Force USB to High-speed after reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_PKT</name>
+       <description>Transmit fixed test packet.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_K</name>
+       <description>Force USB to continuous K state.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_J</name>
+       <description>Force USB to continuous J state.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_SE0_NAK</name>
+       <description>Respond to any valid IN token with NAK.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INMAXP</name>
+     <description>Maximum packet size for INx endpoint (x == INDEX).</description>
+     <addressOffset>0x10</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>MAXPACKETSIZE</name>
+       <description>Maximum Packet Size in a Single Transaction. That is the maximum packet size in bytes, that is transmitted for each microframe. The maximum value is 1024, subject to the limitations of the endpoint type set in USB 2.0 Specification, Chapter 9</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+      <field>
+       <name>NUMPACKMINUS1</name>
+       <description>Number of Split Packets - 1. Defines the maximum number of packets minus 1 that a USB payload can be split into. THis must be an exact multiple of maxpacketsize. Only applicable for HS High-Bandwidth isochronous endpoints and Bulk endpoints. Ignored in all other cases. </description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CSR0</name>
+     <description>Control status register for EP 0 (when INDEX == 0).</description>
+     <addressOffset>0x12</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SERV_SETUP_END</name>
+       <description>Clear EP0 Setup End Bit. Write a 1 to clear the setupend bit. Automatically cleared after being set </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SERV_OUTPKTRDY</name>
+       <description>Clear EP0 Out Packet Ready Bit. Write a 1 to clear the outpktrdy bit. Automatically cleared after being set.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SEND_STALL</name>
+       <description>Send EP0 STALL Handshake. Write a 1 to this bit to terminate the current control transaction by sneding a STALL handshake. Automatically cleared after being set. </description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SETUP_END</name>
+       <description>Read Setup End Status. Automatically set when a contorl transaction ends before the dataend bit has been set by fimrware. An interrupt is generated when this bit is set. Write 1 to servicedsetupend to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_END</name>
+       <description>Control Transaction Data End. Write a 1 to this bit after firmware completes any of the following three transactions: 1. set inpktrdy = 1 for the last data packet. 2. Set inpktrdy =1 for a zero-length data packet. 3. Clear outpktrdy = 0 after unloading the last data packet. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENT_STALL</name>
+       <description> Read EP0 STALL Handshake Sent Status Automatically set when a STALL handshake is transmitted. Write a 0 to clear. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPKTRDY</name>
+       <description>EP0 IN Packet Ready 1: Write a 1 after writing a data packet to the IN FIFO. Automatically cleared when the data packet is transmitted. An interrupt is generated when this bit is cleared. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPKTRDY</name>
+       <description>EP0 OUT Packet Ready Status Automatically set when a data packet is received in the OUT FIFO. An interrupt is generated when this bit is set. Write a 1 to the servicedoutpktrdy bit (above) to clear after the packet is unloaded from the OUT FIFO. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INCSRL</name>
+     <description>Control status lower register for INx endpoint (x == INDEX).</description>
+     <alternateRegister>CSR0</alternateRegister>
+     <addressOffset>0x12</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>INCOMPTX</name>
+       <description>Read Incomplete Split Transfer Error Status High-bandwidth isochronous transfers: Automatically set when a payload is split into multiple packets but insufficient IN tokens were received to send all packets. The current packets is flushed from the IN FIFO. Write 0 to clear.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLRDATATOG</name>
+       <description>Write 1 to clear IN endpoint data-toggle to 0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENTSTALL</name>
+       <description>Read STALL Handshake Sent Status Automatically set when a STALL handshake is transmitted, at which time the IN FIFO is flushed, and inpktrdy is cleared. Write 0 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENDSTALL</name>
+       <description>Send STALL Handshake.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>terminate</name>
+         <description>Terminate STALL handhsake</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Respond to an IN token with a STALL handshake</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSHFIFO</name>
+       <description>Flush Next Packet from IN FIFO. Write 1 to clear</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>UNDERRUN</name>
+       <description>Read IN FIFO Underrun Error Status Isochronous Mode: Automatically set if the IN FIFO is empty. Write 0 to clear</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFONOTEMPTY</name>
+       <description>Read FIFO Not Empty Status. Automatically set when there is at least one packet in the IN FIFO. Write a 0 to clear. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPKTRDY</name>
+       <description>IN Packet Ready. Write a 1 to clear </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INCSRU</name>
+     <description>Control status upper register for INx endpoint (x == INDEX).</description>
+     <addressOffset>0x13</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>AUTOSET</name>
+       <description>Auto Set inpktrdy. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>set</name>
+         <description>USBHS_INCSRL_inpktrdy must be set by firmware.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>auto</name>
+         <description>USBHS_INCSRL_inpktrdy is automatically set. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ISO</name>
+       <description>Isochronous Transfer Enable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>interrupt</name>
+         <description>Enable IN Bulk and IN interrupt transfers.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>isochronous</name>
+         <description>Enable IN Isochronous transfers. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description> Endpoint Direction Mode.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>out</name>
+         <description>Endpoint direction is OUT.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>in</name>
+         <description>Endpoint direction is IN. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FRCDATATOG</name>
+       <description> Force In Data - Toggle</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>received</name>
+         <description>Toggle data-toglge only when an ACK is received.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dontcare</name>
+         <description>Toggle data-toggle regardless of ACK. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPKTBUFDIS</name>
+       <description> Double Packet Buffering Disable </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Double packet buffering.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Double Packet Buffering.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTMAXP</name>
+     <description>Maximum packet size for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x14</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>NUMPACKMINUS1</name>
+       <description>Number of Split Packets -1. Defines the maximum number of packets - 1 that a usb payload is combined into. The value must be exact multiple of maxpacketsize. </description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>MAXPACKETSIZE</name>
+       <description>Maximum Packet in a Single Transaction. This is the maximum packet size, in bytes, that is transmitted for each microframe. The maximum value is 1024, subject to the limitations for the endpoint type set in USB2.0 spesification, chapter 9.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCSRL</name>
+     <description>Control status lower register for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x16</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>CLRDATATOG</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENTSTALL</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENDSTALL</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FLUSHFIFO</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DATAERROR</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>OVERRUN</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFOFULL</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>OUTPKTRDY</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCSRU</name>
+     <description>Control status upper register for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x17</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>AUTOCLEAR</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ISO</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DISNYET</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DPKTBUFDIS</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INCOMPRX</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>COUNT0</name>
+     <description>Number of received bytes in EP 0 FIFO (INDEX == 0).</description>
+     <addressOffset>0x18</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>COUNT0</name>
+       <description>Read Number of Data Bytes in the Endpoint 0 FIFO. Returns the number of data bytes in the endpoint 0 FIFO. This value changes as contents of the FIFO change. The value is only valued when USBHS_OUTSCRL_outpktrdy = 1 </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCOUNT</name>
+     <description>Number of received bytes in OUT EPx FIFO (x == INDEX).</description>
+     <alternateRegister>COUNT0</alternateRegister>
+     <addressOffset>0x18</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>OUTCOUNT</name>
+       <description>Read Number of Data Bytes in OUT FIFO. Returns the number of data bytes in the packet that are read next in the OUT FIFO. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>13</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO0</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO0</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO1</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO1</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO2</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO2</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO3</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x2c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO3</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO4</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO4</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO5</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO5</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO6</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO6</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO7</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x3c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO7</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO8</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO8</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO9</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO9</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO10</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO10</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO11</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x4c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO11</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO12</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO12</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO13</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO13</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO14</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO14</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO15</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x5c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO15</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HWVERS</name>
+     <description>HWVERS</description>
+     <addressOffset>0x6c</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>USBHS_HWVERS</name>
+       <description>USBHS Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EPINFO</name>
+     <description>Endpoint hardware information.</description>
+     <addressOffset>0x78</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>OUTENDPOINTS</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>INTENDPOINTS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RAMINFO</name>
+     <description>RAM width information.</description>
+     <addressOffset>0x79</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RAMBITS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SOFTRESET</name>
+     <description>Software reset register.</description>
+     <addressOffset>0x7A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RSTXS</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RSTS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTUCH</name>
+     <description>Chirp timeout timer setting.</description>
+     <addressOffset>0x80</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>C_T_UCH</name>
+       <description>HS Chirp Timeout Clock Cycles. This configures the chirp timeout used by this device to negotiate a HS connection with a FS Host. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTHSRTN</name>
+     <description>Sets delay between HS resume to UTM normal operating mode.</description>
+     <addressOffset>0x82</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>C_T_HSTRN</name>
+       <description>High Speed Resume Delay Clock Cycles. This configures the delay from when the RESUME state on the bus ends, the when the USBHS resumes normal operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_USB_REG_00</name>
+     <description>MXM_USB_REG_00</description>
+     <addressOffset>0x400</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_UTMI_RESET</name>
+     <description>M31_PHY_UTMI_RESET</description>
+     <addressOffset>0x404</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_UTMI_VCONTROL</name>
+     <description>M31_PHY_UTMI_VCONTROL</description>
+     <addressOffset>0x408</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CLK_EN</name>
+     <description>M31_PHY_CLK_EN</description>
+     <addressOffset>0x40C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_PONRST</name>
+     <description>M31_PHY_PONRST</description>
+     <addressOffset>0x410</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_NONCRY_RSTB</name>
+     <description>M31_PHY_NONCRY_RSTB</description>
+     <addressOffset>0x414</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_NONCRY_EN</name>
+     <description>M31_PHY_NONCRY_EN</description>
+     <addressOffset>0x418</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_EN</name>
+     <description>M31_PHY_U2_COMPLIANCE_EN</description>
+     <addressOffset>0x420</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_DAC_ADJ</name>
+     <description>M31_PHY_U2_COMPLIANCE_DAC_ADJ</description>
+     <addressOffset>0x424</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_DAC_ADJ_EN</name>
+     <description>M31_PHY_U2_COMPLIANCE_DAC_ADJ_EN</description>
+     <addressOffset>0x428</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CLK_RDY</name>
+     <description>M31_PHY_CLK_RDY</description>
+     <addressOffset>0x42C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_PLL_EN</name>
+     <description>M31_PHY_PLL_EN</description>
+     <addressOffset>0x430</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_BIST_OK</name>
+     <description>M31_PHY_BIST_OK</description>
+     <addressOffset>0x434</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DATA_OE</name>
+     <description>M31_PHY_DATA_OE</description>
+     <addressOffset>0x438</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_OSCOUTEN</name>
+     <description>M31_PHY_OSCOUTEN</description>
+     <addressOffset>0x43C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_LPM_ALIVE</name>
+     <description>M31_PHY_LPM_ALIVE</description>
+     <addressOffset>0x440</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_HS_BIST_MODE</name>
+     <description>M31_PHY_HS_BIST_MODE</description>
+     <addressOffset>0x444</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CORECLKIN</name>
+     <description>M31_PHY_CORECLKIN</description>
+     <addressOffset>0x448</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XTLSEL</name>
+     <description>M31_PHY_XTLSEL</description>
+     <addressOffset>0x44C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_LS_EN</name>
+     <description>M31_PHY_LS_EN</description>
+     <addressOffset>0x450</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DEBUG_SEL</name>
+     <description>M31_PHY_DEBUG_SEL</description>
+     <addressOffset>0x454</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DEBUG_OUT</name>
+     <description>M31_PHY_DEBUG_OUT</description>
+     <addressOffset>0x458</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_OUTCLKSEL</name>
+     <description>M31_PHY_OUTCLKSEL</description>
+     <addressOffset>0x45C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_31_0</name>
+     <description>M31_PHY_XCFGI_31_0</description>
+     <addressOffset>0x460</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_63_32</name>
+     <description>M31_PHY_XCFGI_63_32</description>
+     <addressOffset>0x464</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_95_64</name>
+     <description>M31_PHY_XCFGI_95_64</description>
+     <addressOffset>0x468</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_127_96</name>
+     <description>M31_PHY_XCFGI_127_96</description>
+     <addressOffset>0x46C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_137_128</name>
+     <description>M31_PHY_XCFGI_137_128</description>
+     <addressOffset>0x470</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_HS_COARSE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_HS_COARSE_TUNE_NUM</description>
+     <addressOffset>0x474</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_HS_FINE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_HS_FINE_TUNE_NUM</description>
+     <addressOffset>0x478</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_FS_COARSE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_FS_COARSE_TUNE_NUM</description>
+     <addressOffset>0x47C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_FS_FINE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_FS_FINE_TUNE_NUM</description>
+     <addressOffset>0x480</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_LOCK_RANGE_MAX</name>
+     <description>M31_PHY_XCFG_LOCK_RANGE_MAX</description>
+     <addressOffset>0x484</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_LOCK_RANGE_MIN</name>
+     <description>M31_PHY_XCFGI_LOCK_RANGE_MIN</description>
+     <addressOffset>0x488</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_OB_RSEL</name>
+     <description>M31_PHY_XCFG_OB_RSEL</description>
+     <addressOffset>0x48C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_OC_RSEL</name>
+     <description>M31_PHY_XCFG_OC_RSEL</description>
+     <addressOffset>0x490</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGO</name>
+     <description>M31_PHY_XCFGO</description>
+     <addressOffset>0x494</addressOffset>
+    </register>
+    <register>
+     <name>MXM_INT</name>
+     <description>USB Added Maxim Interrupt Flag Register.</description>
+     <addressOffset>0x498</addressOffset>
+     <fields>
+      <field>
+       <name>VBUS</name>
+       <description>VBUS</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOVBUS</name>
+       <description>NOVBUS</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_INT_EN</name>
+     <description>USB Added Maxim Interrupt Enable Register.</description>
+     <addressOffset>0x49C</addressOffset>
+     <fields>
+      <field>
+       <name>VBUS</name>
+       <description>VBUS</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOVBUS</name>
+       <description>NOVBUS</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_SUSPEND</name>
+     <description>USB Added Maxim Suspend Register.</description>
+     <addressOffset>0x4A0</addressOffset>
+     <fields>
+      <field>
+       <name>SEL</name>
+       <description>Suspend register</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_REG_A4</name>
+     <description>USB Added Maxim Power Status Register</description>
+     <addressOffset>0x4A4</addressOffset>
+     <fields>
+      <field>
+       <name>VRST_VDDB_N_A</name>
+       <description>VRST_VDDB_N_A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--USBHS USB 2.0 High-speed Controller.-->
+  <peripheral>
+   <name>WDT</name>
+   <description>Windowed Watchdog Timer</description>
+   <baseAddress>0x40003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WWDT</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INT_LATE_VAL</name>
+       <description>Windowed Watchdog Interrupt Upper Limit. Sets the number of WDTCLK cycles until a windowed watchdog timer interrupt is generated (if enabled) if the CPU does not write the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE_VAL</name>
+       <description>Windowed Watchdog Reset Upper Limit. Sets the number of WDTCLK cycles until a system reset occurs (if enabled) if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Windowed Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_LATE</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Late.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_INT_EN</name>
+       <description>Windowed Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_RST_EN</name>
+       <description>Windowed Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Soon.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY_VAL</name>
+       <description>Windowed Watchdog Interrupt Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A windowed watchdog timer interrupt is generated (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY_VAL</name>
+       <description>Windowed Watchdog Reset Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A system reset occurs (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKRDY_IE</name>
+       <description>Switch Ready Interrupt Enable. Fires an interrupt when it is safe to swithc the clock.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY</name>
+       <description>Clock Status.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WIN_EN</name>
+       <description>Enables the Windowed Watchdog Function.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Windowed Mode Disabled (i.e. Compatibility Mode).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Windowed Mode Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Soon.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Late.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Windowed Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>RESET</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD_UPPER_LIMIT then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD_UPPER_LIMIT then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKSEL</name>
+     <description>Windowed Watchdog Timer Clock Select Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SOURCE</name>
+       <description>WWDT Clock Selection Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CNT</name>
+     <description>Windowed Watchdog Timer Count Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Current Value of the Windowed Watchdog Timer Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WDT Windowed Watchdog Timer-->
+  <peripheral derivedFrom="WDT">
+   <name>WDT1</name>
+   <description>Windowed Watchdog Timer 1</description>
+   <baseAddress>0x40003400</baseAddress>
+   <interrupt>
+    <name>WDT1</name>
+    <description>WDT1 IRQ</description>
+    <value>57</value>
+   </interrupt>
+  </peripheral>
+<!--WDT1 Windowed Watchdog Timer 1-->
+  <peripheral>
+   <name>SKBD</name>
+   <description>Secure Keyboard</description>
+   <baseAddress>0x40032000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Secure_Keypad</name>
+    <description>Secure Keypad interrupt</description>
+    <value>19</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0</name>
+     <description>Input Output Select Bits.  Each bit of IOSEL selects the pin direction for the corresponding KBDIO pin.  If IOSEL[0] = 1, KBDIO0 is an output.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>KBDIO0</name>
+       <description>Input Output Select for KBDIO0 pin.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Input</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Output</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="KBDIO0">
+       <name>KBDIO1</name>
+       <description>Input Output Select for KBDIO1 pin.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="KBDIO0">
+       <name>KBDIO2</name>
+       <description>Input Output Select for KBDIO2 pin.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="KBDIO0">
+       <name>KBDIO3</name>
+       <description>Input Output Select for KBDIO3 pin.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="KBDIO0">
+       <name>KBDIO4</name>
+       <description>Input Output Select for KBDIO4 pin.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="KBDIO0">
+       <name>KBDIO5</name>
+       <description>Input Output Select for KBDIO5 pin.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="KBDIO0">
+       <name>KBDIO6</name>
+       <description>Input Output Select for KBDIO6 pin.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="KBDIO0">
+       <name>KBDIO7</name>
+       <description>Input Output Select for KBDIO7 pin.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="KBDIO0">
+       <name>KBDIO8</name>
+       <description>Input Output Select for KBDIO8 pin.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="KBDIO0">
+       <name>KBDIO9</name>
+       <description>Input Output Select for KBDIO9 pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Control Register 1</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>AUTOSCAN_EN</name>
+       <description>Automatic Keyboard Scan Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="AUTOSCAN_EN">
+       <name>AUTOCLEAR</name>
+       <description>Auto Clear Bit</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTNUM</name>
+       <description>Output Number. Number of KBDIO pins selected as outputs. NOTE:
+                                                                                                                                                                     Output pins must be allocated contiguously starting with KBDIO0 and continuing through to KBDIO7.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>DBTM</name>
+       <description>Debounce Time. Number of milliseconds a keypress event must be active before it is considered actual. NOTE:
+                                                                                                                                                                     Debounce time values based on system running from an external 12MHz clock source with PLL0 enabled.  Other external crystal values will cause the debounce time to scale linearly.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>time4ms</name>
+         <description>4.1 ms</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>time5ms</name>
+         <description>5.3 ms</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>time6ms</name>
+         <description>6.5 ms</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>time7ms</name>
+         <description>7.6 ms</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>time8ms</name>
+         <description>8.8 ms</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>time10ms</name>
+         <description>10.0 ms</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>time11ms</name>
+         <description>11.2 ms</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>time12ms</name>
+         <description>12.3 ms</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>Busy bit. This bit is set by hardware when the automatic keyboard scan is enabled and running.  This bit is clear at all other times.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable Register</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>PUSH</name>
+       <description>Push Event Enable Bit. When set, this bit enables an interrupt to be generated on a key push event.  Automatic keyboard scan must be enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="PUSH">
+       <name>RELEASE</name>
+       <description>Release Event Enable Bit. When set, this bit enables an interrupt to be generated on a key release event.  Automatic keyboard scan must be enabled.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="PUSH">
+       <name>OVERRUN</name>
+       <description>Overrun Event Enable Bit. When set, this bit enables an interrupt to be generated on an overrun event.  Automatic keyboard scan must be enabled.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KBD_PINS</name>
+       <description>Keyboard Pins Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Interrupt Status Register</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>PUSH</name>
+       <description>Push Interrupt Flag. This bit is set by hardware when a key has been pushed.  If the interrupt is enabled for this flag, a system interrupt will be fired.  If the interrupt enable is not set, the flag will be set, but no interrupt will fire.  This bit must be cleared by software.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="PUSH">
+       <name>RELEASE</name>
+       <description>Release Interrupt Flag. This bit is set by hardware when a key has been released.  If the interrupt is enabled for this flag, a system interrupt will be fired.  If the interrupt enable is not set, the flag will be set, but no interrupt will fire.  This bit must be cleared by software.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="PUSH">
+       <name>OVERRUN</name>
+       <description>Overrun Event Enable Bit. This bit is set by hardware when an overrun event has occurred.  If the interrupt is enabled for this flag, a system interrupt will be fired.  If the interrupt enable is not set, the flag will be set, but no interrupt will fire.  This bit must be cleared by software.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>EVT[%s]</name>
+     <description>Key Register</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00000C00</resetValue>
+     <fields>
+      <field>
+       <name>IOIN</name>
+       <description>IO Input. Input pin of key event.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>IOOUT</name>
+       <description>IO Output. Output pin of key event.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>PUSH</name>
+       <description>If set to 1 the key has been released.  If set to 0 the key has been pushed.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pushed</name>
+         <description>Pushed</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>released</name>
+         <description>Released</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>If set to 1 this register has been read.  If set to 0 the key register has not been read since its last change.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notRead</name>
+         <description>This register has not been read since its last change.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>This register has been read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NEXT</name>
+       <description>If set to 1 one of the next key registers (x+1 to 3) contains a key event.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>none</name>
+         <description>No more key register contain a key event.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>more</name>
+         <description>Other key registers contain a key event.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO0</name>
+     <description>General Purpose Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO1</name>
+     <description>General Purpose Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SKBD Secure Keyboard-->
+  <peripheral>
+   <name>SEMA</name>
+   <description>The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.</description>
+   <baseAddress>0x4003E000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>SEMAPHORES[%s]</name>
+     <description>Read to test and set, returns prior value. Write 0 to clear semaphore.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>sema</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>irq0</name>
+     <description>Semaphore IRQ0 register.</description>
+     <addressOffset>0x40</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>en</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cm4_irq</name>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>mail0</name>
+     <description>Semaphore Mailbox 0 register.</description>
+     <addressOffset>0x44</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>data</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>irq1</name>
+     <description>Semaphore IRQ1 register.</description>
+     <addressOffset>0x48</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>en</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>rv32_irq</name>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>mail1</name>
+     <description>Semaphore Mailbox 1 register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>data</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>status</name>
+     <description>Semaphore status bits. 0 indicates the semaphore is free, 1 indicates taken.</description>
+     <addressOffset>0x100</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>status0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SEMA The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.-->
+  <peripheral>
+   <name>SCN</name>
+   <description>Smart Card Interface.</description>
+   <groupName>SCN</groupName>
+   <baseAddress>0x4002C000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SC0</name>
+    <description>SC0 IRQ</description>
+    <value>11</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CR</name>
+     <description>Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>CONV</name>
+       <description>Convention Select Bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CREP</name>
+       <description>Character Repeat Enable Bit.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WTEN</name>
+       <description>Wait Time Counter Enable Bit.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART</name>
+       <description>Smart Card Mode Bit.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CCEN</name>
+       <description>Clock Counter Enable Bit.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXFLUSH</name>
+       <description>Receive FIFO Flush.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXFLUSH</name>
+       <description>Transmit FIFO Flush.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXTHD</name>
+       <description>Receive FIFO Depth.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TXTHD</name>
+       <description>Transmit FIFO Depth.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>DUAL_MODE</name>
+       <description>Dual Internal AFE and Bypass Mode.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SR</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>PAR</name>
+       <description>Parity Error Detector Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WTOV</name>
+       <description>Waiting Time Counter Overflow.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CCOV</name>
+       <description>Clock Counter Overflow Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXCF</name>
+       <description>Transmit Complete Flag.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXEMPTY</name>
+       <description>Receive FIFO Empty Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXFULL</name>
+       <description>Receive FIFO Full Flag.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXEMPTY</name>
+       <description>Transmit FIFO Empty Flag.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXFULL</name>
+       <description>Transmit FIFO Full Flag.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXELT</name>
+       <description>Number of Bytes in the Receive FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TXELT</name>
+       <description>Number of Bytes in the Transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PN</name>
+     <description>Pin Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>CRDRST</name>
+       <description>Smart Card Reset Pin Control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRDCLK</name>
+       <description>Smart Card Clock Piin Control.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRDIO</name>
+       <description>Smart Card IO Pin Control.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRDC4</name>
+       <description>Smart Card SCn_C4 Pin Control.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRDC8</name>
+       <description>Smart Card SCn_C8 Pin Control.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKSEL</name>
+       <description>Smart Card Clock Select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IO_C48_EN</name>
+       <description>Pin Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ETUR</name>
+     <description>ETU Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>ETU</name>
+       <description>Elemental Time Unit Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>15</bitWidth>
+      </field>
+      <field>
+       <name>COMP</name>
+       <description>Compensation Mode Enable Bit.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HALF</name>
+       <description>Half ETU Count Selection Bit.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GTR</name>
+     <description>Guard Time Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>GT</name>
+       <description>Guard Time.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WT0R</name>
+     <description>Waiting Time 0 Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>WT</name>
+       <description>Wait Time.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WT1R</name>
+     <description>Waiting Time 1 Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>WT</name>
+       <description>Wait Time.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IER</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>PARIE</name>
+       <description>Parity Error Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WTIE</name>
+       <description>Waiting Time Overflow Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTIE</name>
+       <description>Clock Counter Overflow Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TCIE</name>
+       <description>Character Transmission Completion Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXEIE</name>
+       <description>Receive FIFO Empty Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXTIE</name>
+       <description>Receive FIFO Threshold Reached Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXFIE</name>
+       <description>Receive FIFO Full Interrupt Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXEIE</name>
+       <description>Transmit FIFO Empty Interrupt Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXTIE</name>
+       <description>Transmit FIFO Threshold Reached Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ISR</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>PARIS</name>
+       <description>Parity Error Interrupt Status Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WTIS</name>
+       <description>Waiting Time Overflow Interrupt Status Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTIS</name>
+       <description>Clock Counter Overflow Interrupt Status Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TCIS</name>
+       <description>Character Transmission Completion Interrupt Status Flag.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXEIS</name>
+       <description>Receive FIFO Empty Interrupt Status Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXTIS</name>
+       <description>Receive FIFO Threshold Reached Interrupt Status Flag.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXFIS</name>
+       <description>Receive FIFO Full Interrupt Status Flag.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXEIS</name>
+       <description>Transmit FIFO Empty Interrupt Status Flag.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXTIS</name>
+       <description>Transmit FIFO Threshold Reached Interrupt Status Flag.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXR</name>
+     <description>Transmit Register.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Transmit Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXR</name>
+     <description>Receive Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Receive Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>PARER</name>
+       <description>Parity Error Detect Bit.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CCR</name>
+     <description>Clock Counter Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>CCYC</name>
+       <description>Number of Clock Cycles to Count.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+      <field>
+       <name>MAN</name>
+       <description>Manual Mode.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SCN Smart Card Interface.-->
+ </peripherals>
+</device>

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32650/Include/max32650.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32650/Include/max32650.svd
@@ -1,0 +1,24217 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max32650</name>
+ <series>ARMCM4</series>
+ <version>1.0</version>
+ <description>MAX32650.</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>ADC</name>
+   <description>10-bit Analog to Digital Converter</description>
+   <baseAddress>0x40034000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>ADC</name>
+    <description>ADC IRQ</description>
+    <value>20</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>ADC Control</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>start</name>
+       <description>Start ADC Conversion</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>pwr</name>
+       <description>ADC Power Up</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>adc_off</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>adc_on</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>refbuf_pwr</name>
+       <description>ADC Reference Buffer Power Up</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>refbuf_off</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>refbuf_on</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ref_sel</name>
+       <description>ADC Reference Select</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>bandgap</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>vdd_div2</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ref_scale</name>
+       <description>ADC Reference Scale</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>input_scale</name>
+       <description>ADC Scale</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>clk_en</name>
+       <description>ADC Clock Enable</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ch_sel</name>
+       <description>ADC Channel Select</description>
+       <bitRange>[15:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ain0</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain1</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain2</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain3</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain0_div5</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain1_div5</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>vddb_div4</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>vdda</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>vcore</name>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>vrtc_div2</name>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rsv_0xa</name>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>vddio_div4</name>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>vddioh_div4</name>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>data_align</name>
+       <description>ADC Data Alignment Select</description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lsb_justified</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>msb_justified</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>ADC Status</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>active</name>
+       <description>ADC Conversion In Progress</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>pwr_up_active</name>
+       <description>AFE Power Up Delay Active</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no_delay</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>delay_active</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>overflow</name>
+       <description>ADC Overflow</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>underflow</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>overflow</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>ADC Output Data</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>data</name>
+       <description>ADC Converted Sample Data Output</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>ADC Interrupt Control Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>done_ie</name>
+       <description>ADC Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ref_ready_ie</name>
+       <description>ADC Reference Ready Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>hi_limit_ie</name>
+       <description>ADC Hi Limit Monitor Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>lo_limit_ie</name>
+       <description>ADC Lo Limit Monitor Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>overflow_ie</name>
+       <description>ADC Overflow Interrupt Enable</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>done_if</name>
+       <description>ADC Done Interrupt Flag</description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ref_ready_if</name>
+       <description>ADC Reference Ready Interrupt Flag</description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>hi_limit_if</name>
+       <description>ADC Hi Limit Monitor Interrupt Flag</description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>lo_limit_if</name>
+       <description>ADC Lo Limit Monitor Interrupt Flag</description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>overflow_if</name>
+       <description>ADC Overflow Interrupt Flag</description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>pending</name>
+       <description>ADC Interrupt Pending Status</description>
+       <bitRange>[22:22]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no_int</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>int_pending</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>LIMIT[%s]</name>
+     <description>ADC Limit</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ch_lo_limit</name>
+       <description>Low Limit Threshold</description>
+       <bitRange>[9:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_hi_limit</name>
+       <description>High Limit Threshold</description>
+       <bitRange>[21:12]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_sel</name>
+       <description>ADC Channel Select</description>
+       <bitRange>[27:24]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ain0</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain1</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain2</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain3</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain4</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain5</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain6</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain7</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain8</name>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain9</name>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain10</name>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain11</name>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ain12</name>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ch_lo_limit_en</name>
+       <description>Low Limit Monitoring Enable</description>
+       <bitRange>[28:28]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ch_hi_limit_en</name>
+       <description>High Limit Monitoring Enable</description>
+       <bitRange>[29:29]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ADC 10-bit Analog to Digital Converter-->
+  <peripheral>
+   <name>AESKEYS</name>
+   <description>AES Key Registers.</description>
+   <baseAddress>0x40005000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>KEY0[%s]</name>
+     <description>AES Key 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>KEY1[%s]</name>
+     <description>AES Key 1.</description>
+     <addressOffset>0x080</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>KEY2[%s]</name>
+     <description>AES Key 2.</description>
+     <addressOffset>0x100</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>KEY3[%s]</name>
+     <description>AES Key 3.</description>
+     <addressOffset>0x180</addressOffset>
+     <size>32</size>
+    </register>
+   </registers>
+  </peripheral>
+<!--AESKEYS AES Key Registers.-->
+  <peripheral>
+   <name>CLCD</name>
+   <description>Color LCD Controller</description>
+   <baseAddress>0x40031000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0xFFF</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CLK_CTRL</name>
+     <description>LCD Clock Control Register</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>LCD_CLKDIV</name>
+       <description>Clock divsor</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>STN_AC_BIAS</name>
+       <description>AC Bias Frequency Control. THis fiels sets the AC Bias Frequency output on the CLCD_VDEN pin for Color StN display mode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VDEN_POL</name>
+       <description>CLCD_VDEN Polarity Selection. This field sets the polarity of the video enable signal output pin.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ACTIVELO</name>
+         <description>Active Low</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ACTIVEHI</name>
+         <description>Active High</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VSYNC_POL</name>
+       <description>VSYNC Polarity Selection. This field sets the polarity of the vertical sync signal output pin.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ACTIVELO</name>
+         <description>Active Low</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ACTIVEHI</name>
+         <description>Active Hi</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HSYNC_POL</name>
+       <description>HSYNC Polarity Selection. This field sets the polarity of the horizontal sync signal output pin.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ACTIVELO</name>
+         <description>Active Low</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ACTIVEHI</name>
+         <description>Active Hi</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLK_EDGE_SEL</name>
+       <description>Clock Edge Selection. This field controls the clock edge that is used by the LCD panel to sample the data and signal lines.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>RISING</name>
+         <description>Rising edge</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>FALLING</name>
+         <description>Falling Edge</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLK_ACTIVE</name>
+       <description>Clock Active on Data. If the display type is Color STN 8-bit, this bit selects if the CLCD_CLK output is active always or only during data output to the display.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ALWAYS</name>
+         <description>Always Active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ONDATA</name>
+         <description>ACTIVE ON DATA</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VTIM_0</name>
+     <description>LCD Vertical Timing 0 Register</description>
+     <addressOffset>0x004</addressOffset>
+     <fields>
+      <field>
+       <name>VLINES</name>
+       <description>V Lines</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VBP_WIDTH</name>
+       <description>V BACK PORCH</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VTIM_1</name>
+     <description>LCD Vertical Timing 1 Register</description>
+     <addressOffset>0x008</addressOffset>
+     <fields>
+      <field>
+       <name>VSYNC_WIDTH</name>
+       <description>V Sync Width</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VFP_WIDTH</name>
+       <description>V Front PORCH</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HTIM</name>
+     <description>LCD Horizontal Timing Register.</description>
+     <addressOffset>0x00C</addressOffset>
+     <fields>
+      <field>
+       <name>HSYNC_WIDTH</name>
+       <description>Horizontal Sync Width in CLCD Clocks from 1 to 256 HSync Width = HSYNCWIDTH+1 Clocks</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HFP_WIDTH</name>
+       <description>Horizontal Front Porch size in lines from 1 to 256</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HSIZE_INDEX</name>
+       <description>Horizontal Front Porch Size in Pixels = (HSIZE + 1) *16</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HBP_WIDTH</name>
+       <description>Horizontal Back Porch size in CLCD Clocks from 1 to 256 -&gt; HBP= (HBACKPORCH+1) </description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>LCD Control Register</description>
+     <addressOffset>0x010</addressOffset>
+     <fields>
+      <field>
+       <name>CLCD_ENABLE</name>
+       <description>LCD Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCI_SEL</name>
+       <description>Vertical Compare Interrupt Source Select</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ON_VSYNC</name>
+         <description>On Vertical Sync</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ON_VBP</name>
+         <description>On Vertical Back Porch</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ON_VDEN</name>
+         <description>On Active Video</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ON_VFP</name>
+         <description>On Vertical Front Porch</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DISPTYPE</name>
+       <description>Display Type</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>8BITCOLORSTN</name>
+         <description>STN Color 8 bit</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TFT</name>
+         <description>TFT</description>
+         <value>8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BPP</name>
+       <description>BPP</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>BPP1</name>
+         <description>BPP 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BPP2</name>
+         <description>BPP 2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BPP4</name>
+         <description>BPP 4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BPP8</name>
+         <description>BPP 8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BPP16</name>
+         <description>BPP 16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BPP24</name>
+         <description>BPP 24</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE565</name>
+       <description>MODE565</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>BGR556</name>
+         <description>MODE 556</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RGB565</name>
+         <description>MODE 565</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ENDIAN</name>
+       <description>EMODE</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>LBLP</name>
+         <description>LLBP</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BBBP</name>
+         <description>BBBP</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>LBBP</name>
+         <description>LBBP</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RFU</name>
+         <description>RFU</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>COMPACT_24b</name>
+       <description>C24</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1_PFR</name>
+         <description>1 pixel per frame buffer entry</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1ANDA3RD_PFR</name>
+         <description>1 and 1/3 pixels per fram buffer entry</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BURST_SIZE</name>
+       <description>BURST</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>4WORDS</name>
+         <description>4 32-bit words.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8WORDS</name>
+         <description>8 32-bit words.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16WORDS</name>
+         <description>16 32-bit words.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LEND_POL</name>
+       <description>LEND Polarity Selection. This field sets the polarity of the line end signal output pin.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ACTIVELO</name>
+         <description>Active Low</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ACTIVEHI</name>
+         <description>Active High</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PWR_ENABLE</name>
+       <description>Display Power Enable. Enables power to the display using the PWREN output pin.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>LO</name>
+         <description>Power enable pin is set low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HI</name>
+         <description>Power enable pin is set high.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FRBUF</name>
+     <description>Frame buffer.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>FRAME_ADDR</name>
+       <description>Set this field to the beginning of the fram buffer data to display.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>LCD Interrupt Enable Register.</description>
+     <addressOffset>0x020</addressOffset>
+     <fields>
+      <field>
+       <name>UNDERFLOW_IE</name>
+       <description>Under FLow Interupt Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_RDY_IE</name>
+       <description>Address Ready Interupt Enable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCI_IE</name>
+       <description>VCI Interupt Enable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUS_ERROR_IE</name>
+       <description>BERR Interupt Enable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_STAT</name>
+     <description>LCD Status Register.</description>
+     <addressOffset>0x024</addressOffset>
+     <modifiedWriteValues>oneToClear</modifiedWriteValues>
+     <fields>
+      <field>
+       <name>UNDERFLOW</name>
+       <description>Under FLow Interupt Status</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt pending</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pend</name>
+         <description>Interrupt pending</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+       <enumeratedValues>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clears the interrupt flag</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_RDY</name>
+       <description>Address Ready Interupt Status</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt pending</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pend</name>
+         <description>Interrupt pending</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+       <enumeratedValues>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clears the interrupt flag</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCI</name>
+       <description>VCI Interupt Status</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt pending</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pend</name>
+         <description>Interrupt pending</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+       <enumeratedValues>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clears the interrupt flag</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUS_ERROR</name>
+       <description>BERR Interupt Status</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt pending</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pend</name>
+         <description>Interrupt pending</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+       <enumeratedValues>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clears the interrupt flag</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLCD_IDLE</name>
+       <description>LCD IDLE Staus</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>IDLE</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BUSY</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>256</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>PALETTE_RAM[%s]</name>
+     <description>Palette</description>
+     <addressOffset>0x400</addressOffset>
+     <fields>
+      <field>
+       <name>RED</name>
+       <description>Red Data for Pallet Entry.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>GREEN</name>
+       <description>Green Data for Pallet Entry.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>BLUE</name>
+       <description>Blue Data for Pallet Entry.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CLCD Color LCD Controller-->
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0</name>
+    <value>28</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1</name>
+    <value>29</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA2</name>
+    <value>30</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA3</name>
+    <value>31</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA4</name>
+    <value>68</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA5</name>
+    <value>69</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA6</name>
+    <value>70</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA7</name>
+    <value>71</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA8</name>
+    <value>72</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA9</name>
+    <value>73</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA10</name>
+    <value>74</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA11</name>
+    <value>75</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA12</name>
+    <value>76</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA13</name>
+    <value>77</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA14</name>
+    <value>78</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA15</name>
+    <value>79</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CN</name>
+     <description>DMA Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CH0_IEN</name>
+       <description>Channel 0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH1_IEN</name>
+       <description>Channel 1 Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH2_IEN</name>
+       <description>Channel 2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH3_IEN</name>
+       <description>Channel 3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH4_IEN</name>
+       <description>Channel 4 Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH5_IEN</name>
+       <description>Channel 5 Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH6_IEN</name>
+       <description>Channel 6 Interrupt Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH7_IEN</name>
+       <description>Channel 7 Interrupt Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH8_IEN</name>
+       <description>Channel 8 Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH9_IEN</name>
+       <description>Channel 9 Interrupt Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH10_IEN</name>
+       <description>Channel 10 Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH11_IEN</name>
+       <description>Channel 11 Interrupt Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH12_IEN</name>
+       <description>Channel 12 Interrupt Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH13_IEN</name>
+       <description>Channel 13 Interrupt Enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH14_IEN</name>
+       <description>Channel 14 Interrupt Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH15_IEN</name>
+       <description>Channel 15 Interrupt Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>DMA Interrupt Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CH0_IPEND</name>
+       <description>Channel 0 Interrupt Pending.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH1_IPEND</name>
+       <description>Channel 1 Interrupt Pending.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH2_IPEND</name>
+       <description>Channel 2 Interrupt Pending.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH3_IPEND</name>
+       <description>Channel 3 Interrupt Pending.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH4_IPEND</name>
+       <description>Channel 4 Interrupt Pending.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH5_IPEND</name>
+       <description>Channel 5 Interrupt Pending.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH6_IPEND</name>
+       <description>Channel 6 Interrupt Pending.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH7_IPEND</name>
+       <description>Channel 7 Interrupt Pending.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH8_IPEND</name>
+       <description>Channel 8 Interrupt Pending.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH9_IPEND</name>
+       <description>Channel 9 Interrupt Pending.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH10_IPEND</name>
+       <description>Channel 10 Interrupt Pending.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH11_IPEND</name>
+       <description>Channel 11 Interrupt Pending.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH12_IPEND</name>
+       <description>Channel 12 Interrupt Pending.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH13_IPEND</name>
+       <description>Channel 13 Interrupt Pending.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH14_IPEND</name>
+       <description>Channel 14 Interrupt Pending.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CH15_IPEND</name>
+       <description>Channel 15 Interrupt Pending.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Channel interrupt not currently asserted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Channel interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>16</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CFG</name>
+      <description>DMA Channel Configuration Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>CHEN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQSEL</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0RX</name>
+          <description>SPI0 RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1RX</name>
+          <description>SPI1 RX</description>
+          <value>0x02</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI2RX</name>
+          <description>SPI2 RX</description>
+          <value>0x03</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0RX</name>
+          <description>UART0 RX</description>
+          <value>0x04</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1RX</name>
+          <description>UART1 RX</description>
+          <value>0x05</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0RX</name>
+          <description>I2C0 RX</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1RX</name>
+          <description>I2C1 RX</description>
+          <value>0x08</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>ADC</name>
+          <description>Analog-to-Digital Converter Channel</description>
+          <value>0x09</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2RX</name>
+          <description>UART2 RX</description>
+          <value>0x0E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI3RX</name>
+          <description>SPI3 RX</description>
+          <value>0x0F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPIMSSRX</name>
+          <description>SPIMSS RX</description>
+          <value>0x10</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP1</name>
+          <description>USB Endpoint 1 RX</description>
+          <value>0x11</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP2</name>
+          <description>USB Endpoint 2 RX</description>
+          <value>0x12</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP3</name>
+          <description>USB Endpoint 3 RX</description>
+          <value>0x13</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP4</name>
+          <description>USB Endpoint 4 RX</description>
+          <value>0x14</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP5</name>
+          <description>USB Endpoint 5 RX</description>
+          <value>0x15</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP6</name>
+          <description>USB Endpoint 6 RX</description>
+          <value>0x16</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP7</name>
+          <description>USB Endpoint 7 RX</description>
+          <value>0x17</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP8</name>
+          <description>USB Endpoint 8 RX</description>
+          <value>0x18</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP9</name>
+          <description>USB Endpoint 9 RX</description>
+          <value>0x19</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP10</name>
+          <description>USB Endpoint 10 RX</description>
+          <value>0x1A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP11</name>
+          <description>USB Endpoint 11 RX</description>
+          <value>0x1B</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0TX</name>
+          <description>SPI0 TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1TX</name>
+          <description>SPI1 TX</description>
+          <value>0x22</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI2TX</name>
+          <description>SPI2 TX</description>
+          <value>0x23</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0TX</name>
+          <description>UART0 TX</description>
+          <value>0x24</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1TX</name>
+          <description>UART1 TX</description>
+          <value>0x25</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0TX</name>
+          <description>I2C0 TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1TX</name>
+          <description>I2C1 TX</description>
+          <value>0x28</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2TX</name>
+          <description>UART2 TX</description>
+          <value>0x2E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI3TX</name>
+          <description>SPI3 TX</description>
+          <value>0x2F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPIMSSTX</name>
+          <description>SPIMSS TX</description>
+          <value>0x30</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP1</name>
+          <description>USB Endpoint 1 TX</description>
+          <value>0x31</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP2</name>
+          <description>USB Endpoint 2 TX</description>
+          <value>0x32</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP3</name>
+          <description>USB Endpoint 3 TX</description>
+          <value>0x33</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP4</name>
+          <description>USB Endpoint 4 TX</description>
+          <value>0x34</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP5</name>
+          <description>USB Endpoint 5 TX</description>
+          <value>0x35</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP6</name>
+          <description>USB Endpoint 6 TX</description>
+          <value>0x36</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP7</name>
+          <description>USB Endpoint 7 TX</description>
+          <value>0x37</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP8</name>
+          <description>USB Endpoint 8 TX</description>
+          <value>0x38</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP9</name>
+          <description>USB Endpoint 9 TX</description>
+          <value>0x39</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP10</name>
+          <description>USB Endpoint 10 TX</description>
+          <value>0x3A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP11</name>
+          <description>USB Endpoint 11 TX</description>
+          <value>0x3B</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQWAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>normal</name>
+          <description>Normal timer start.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>delay</name>
+          <description>Delay timer start.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TOSEL</name>
+        <description>Time-Out Select. Selects the number of prescale clocks seen by the channel timer before a time-out conditions is generated for this channel. Important note: since the prescaler runs independent of the individual channel timers, the actual number of Pre-Scale clock edges seen has a margin of error equal to a single Pre-Scale clock.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PSSEL</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BRST</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>CHDIEN</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZIEN</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>ST</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>CH_ST</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>disabled</name>
+          <description>Disabled.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>enabled</name>
+          <description>Enabled.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_ST</name>
+        <description>Count-to-Zero (CTZ) Status</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+        <enumeratedValues>
+         <name>ctz_st_enum_rd</name>
+         <usage>read</usage>
+         <enumeratedValue>
+          <name>noEvent</name>
+          <description>The event has not occurred.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>ctz_occur</name>
+          <description>The event has occurred.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+        <enumeratedValues>
+         <name>ctz_st_enum_wr</name>
+         <usage>write</usage>
+         <enumeratedValue>
+          <name>Clear</name>
+          <description>Clears the interrupt flag</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLD_ST</name>
+        <description>Reload Status.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+        <enumeratedValues>
+         <usage>read</usage>
+         <enumeratedValue>
+          <name>noEvent</name>
+          <description>The event has not occurred.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>reloaded</name>
+          <description>The event has occurred.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+        <enumeratedValues>
+         <usage>write</usage>
+         <enumeratedValue>
+          <name>Clear</name>
+          <description>Clears the interrupt flag</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+        <enumeratedValues>
+         <usage>read</usage>
+         <enumeratedValue>
+          <name>noEvent</name>
+          <description>The event has not occurred.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>bus_err</name>
+          <description>The event has occurred.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+        <enumeratedValues>
+         <usage>write</usage>
+         <enumeratedValue>
+          <name>Clear</name>
+          <description>Clears the interrupt flag</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_ST</name>
+        <description>Time-Out Status.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+        <enumeratedValues>
+         <usage>read</usage>
+         <enumeratedValue>
+          <name>noEvent</name>
+          <description>The event has not occurred.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>expired</name>
+          <description>The event has occurred.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+        <enumeratedValues>
+         <usage>write</usage>
+         <enumeratedValue>
+          <name>Clear</name>
+          <description>Clears the interrupt flag</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC_RLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>SRC_RLD</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST_RLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>DST_RLD</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT_RLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT_RLD</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. This bit should be set after the address reload registers have been programmed. This bit is automatically cleared to 0 when reload occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+<!--DMA DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral>
+   <name>EMCC</name>
+   <description>External Memory Cache Controller Registers.</description>
+   <baseAddress>0x40033000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CACHE_ID</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CCHID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEM_SIZE</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCHSZ</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEMSZ</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CACHE_CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>ENABLE</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRITE_ALLOC</name>
+       <description>Write Allocate Enable. This bit only writable while the cache is disabled.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Write-no-allocate.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Write-allocate enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CWFST_DIS</name>
+       <description>Critical word first and streaming disable. This bit only writeable while the cache is disabled.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Critical word first and streaming disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Critical word first and streaming enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Cache Contents. Any time this register location is written (regardless of the data value), the cache controller immediately begins invalidating the entire contents of the cache memory. The cache will be in bypass mode until the invalidate operation is complete. System software can examine the Cache Ready bit (CACHE_CTRL.CACHE_RDY) to determine when the invalidate operation is complete. Note that it is not necessary to disable the cache controller prior to beginning this operation. Reads from this register always return 0.</description>
+     <addressOffset>0x0700</addressOffset>
+     <fields>
+      <field>
+       <name>IA</name>
+       <description>Invalidate all cache contents.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--EMCC External Memory Cache Controller Registers.-->
+  <peripheral>
+   <name>FLC</name>
+   <description>Flash Memory Control.</description>
+   <prependToName>FLSH_</prependToName>
+   <baseAddress>0x40029000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Flash_Controller</name>
+    <description>Flash Controller interrupt.</description>
+    <value>23</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ADDR</name>
+     <description>Flash Write Address.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address for next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Flash Clock Divide. The clock (PLL0) is divided by this value to generate a 1 MHz clock for Flash controller.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000064</resetValue>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Flash Clock Divide. The clock is divided by this value to generate a 1MHz clock for flash controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Flash Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WRITE</name>
+       <description>Write.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start_wr</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MASS_ERASE</name>
+       <description>Mass Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start_me</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PAGE_ERASE</name>
+       <description>Page Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start_pge</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WIDTH</name>
+       <description>This field sets the width of a write to the flash page. Select between 128-bit (default) and 32-bit.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>128_bit</name>
+         <description>Flash is written to in 128-bit increments.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>32_bit</name>
+         <description>Flash is written to in 32-bit increments.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERASE_CODE</name>
+       <description>Erase Code.  The ERASE_CODE must be set up property before erase operation can be initiated. These bits are automatically cleared after the operation is complete.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Flash erases disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pge</name>
+         <description>Enable Page Erase.</description>
+         <value>0x55</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>me</name>
+         <description>Enable Mass Erase. The debug port must be enabled.</description>
+         <value>0xAA</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>Flash Pending.  When Flash operation is in progress (busy), Flash reads and writes will fail. When PEND is set, write to all Flash registers, with exception of the Flash interrupt register, are ignored.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>UNLOCK_CODE</name>
+       <description>Flash Unlock.  The correct unlock code must be written to these four bits before any Flash write or erase operation is allowed.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Flash Unlocked.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Flash Locked.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Flash Interrupt Register.</description>
+     <addressOffset>0x024</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Flash Done Interrupt.  This bit is set to 1 upon Flash write or erase completion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACCESS_FAIL</name>
+       <description>Flash Access Fail.  This bit is set when an attempt is made to write the flash while the flash is busy or the flash is locked. This bit can only be set to 1 by hardware.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noerr</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONE_IE</name>
+       <description>Flash Done Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACCESS_FAIL_IE</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA[%s]</name>
+     <description>Flash Write Data.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACTNL</name>
+     <description>Access Control Register. Writing the ACNTL register with the following values in the order shown, allows read and write access to the system and user Information block: pflc-acntl = 0x3a7f5ca3; pflc-acntl = 0xa1e34f20; pflc-acntl = 0x9608b2c1. When unlocked, a write of any word will disable access to system and user information block. Readback of this register is always zero.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ACNTL</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FLC Flash Memory Control.-->
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x40008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN</name>
+     <description>GPIO Function Enable Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>alternate</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN_SET</name>
+     <description>GPIO Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set the corresponding bit in GPIO_EN register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear the corresponding bit in GPIO_EN register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_EN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_EN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT_EN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set the corresponding bit in GPIO_OUT_EN register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_EN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT_EN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear the corresponding bit in GPIO_OUT_EN register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set the corresponding bit in GPIO_OUT register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear the corresponding bit in GPIO_OUT register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_IN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Logic 0 (low) on GPIO input.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Logic 1 (high) on GPIO input.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_MODE</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_MODE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_POL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_POL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN_EN</name>
+     <description>GPIO Port Input Enable.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_IN_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Input Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Input Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_EN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_EN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_STAT</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_INT_STAT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear the corresponding bit in GPIO_INT_STAT register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WAKE_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WAKE_EN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set the corresponding bit in GPIO_WAKE_EN register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WAKE_EN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear the corresponding bit in GPIO_WAKE_EN register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_DUAL_EDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_DUAL_EDGE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dual</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PDPU_SEL0</name>
+     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PDPU_SEL0</name>
+       <description>The two bits in GPIO_PDPU_SEL0 and GPIO_PDPU_SEL1 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PDPU_SEL1</name>
+     <description>GPIO Input Mode Config 2. Each bit in this register enables the pull-down for the associated GPIO pin in this port.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PDPU_SEL1</name>
+       <description>The two bits in GPIO_PDPU_SEL0 and GPIO_PDPU_SEL1 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>Pull-down mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AF_SEL</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_AF_SEL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AF_SEL_SET</name>
+     <description>GPIO Alternate Function Selectset. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>AF_SEL_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set the corresponding bit in GPIO_AF_SEL register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AF_SEL_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_AF_SEL_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear the corresponding bit in GPIO_AF_SEL register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS_SEL0</name>
+     <description>GPIO Drive Strength  Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode. The total drive strength multiplier is the multiplication between the two drive strength select registers.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS_SEL0</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1X</name>
+         <description>1 x GPIO_DS_SEL1 = total drive strength multiplier.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2X</name>
+         <description>2 x GPIO_DS_SEL1 = total drive strength multiplier.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS_SEL1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode. The total drive strength multiplier is the multiplication between the two drive strength select registers.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS_SEL1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1X</name>
+         <description>1 x GPIO_DS_SEL0 = total drive strength multiplier.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4X</name>
+         <description>4 x GPIO_DS_SEL0 = total drive strength multiplier.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PSSEL</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PSSEL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>WEAK_PDPU</name>
+         <description>1MOhm Pull-Up/Down resistor connected to the input pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>STRONG_PDPU</name>
+         <description>25KOhm Pull-Up/Down resistor connected to the input pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VSSEL</name>
+     <description>GPIO Voltage Select.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_VSSEL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>VDDIO</name>
+         <description>Vddio set as the pin's supply voltage.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VDDIOH</name>
+         <description>Vddioh set as the pin's supply voltage.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GPIO0 Individual I/O for each GPIO-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO1</name>
+   <description>Individual I/O for each GPIO 1</description>
+   <baseAddress>0x40009000</baseAddress>
+   <interrupt>
+    <name>GPIO1</name>
+    <description>GPIO1 IRQ</description>
+    <value>25</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO1 Individual I/O for each GPIO 1-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO2</name>
+   <description>Individual I/O for each GPIO 2</description>
+   <baseAddress>0x4000A000</baseAddress>
+   <interrupt>
+    <name>GPIO2</name>
+    <description>GPIO2 IRQ</description>
+    <value>26</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO2 Individual I/O for each GPIO 2-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO3</name>
+   <description>Individual I/O for each GPIO 3</description>
+   <baseAddress>0x4000B000</baseAddress>
+   <interrupt>
+    <name>GPIO3</name>
+    <description>GPIO3 IRQ</description>
+    <value>58</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO3 Individual I/O for each GPIO 3-->
+  <peripheral>
+   <name>HPB</name>
+   <description>HyperBus Memory Controller</description>
+   <baseAddress>0x40039000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>HPB</name>
+    <description>HPB interrupt.</description>
+    <value>61</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>STATUS</name>
+     <description>HPB Status Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>RACT</name>
+       <description>Read transaction in progress.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noRead</name>
+         <description>No read transaction in progress.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read transaction in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDECERR</name>
+       <description>Read address error.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noErr</name>
+         <description>No error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>err</name>
+         <description>Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RRSTOERR</name>
+       <description>Reset during read error.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noErr</name>
+         <description>No error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>err</name>
+         <description>Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDSSTALL</name>
+       <description>Read data stall.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normalop</name>
+         <description>Read operation normal.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>stalled</name>
+         <description>Read stalled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WACT</name>
+       <description>Write transaction in progress.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noWrite</name>
+         <description>No write transaction in progress.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write transaction in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDECERR</name>
+       <description>Write address error.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noErr</name>
+         <description>No error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>err</name>
+         <description>Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRSTOERR</name>
+       <description>Reset during write error.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noErr</name>
+         <description>No error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>err</name>
+         <description>Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>HPB Interrupt Enable.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>ERRINTE</name>
+       <description>Error interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable error interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable error interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>HPB Interrupt Status Flags.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>ERRINT</name>
+       <description>Error interrupt status flags.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noInt</name>
+         <description>No interrupt pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Error interrupt pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>MBR[%s]</name>
+     <description>HPB Memory Base Address.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Memory Base Address.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>MCR[%s]</name>
+     <description>HPB Memory Configuration Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>DEV_TYPE</name>
+       <description>Memory device type select.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>hyperFlash</name>
+         <description>HyperFlash.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>xccelaPSRAM</name>
+         <description>Xccela PSRAM.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hyperRAM</name>
+         <description>HyperRAM.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRT</name>
+       <description>Configuration register target select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>mem_space</name>
+         <description>Access memory space.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>config_reg_space</name>
+         <description>Access configuration register space.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ_LATENCY</name>
+       <description>Xccela fixed read latency enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>variable</name>
+         <description>Variable read latency.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fixed</name>
+         <description>Fixed read latency.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HSE</name>
+       <description>Xccela half sleep exit.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Half-Sleep exit disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Half-Sleep exit enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MAXLEN</name>
+       <description>Maximum read/write..</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>MAXLEN_EN</name>
+       <description>Maximum CS# length enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Configurable CS# low time disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Configurable CS# low time enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>MTR[%s]</name>
+     <description>HPB Memory Timing Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>LATENCY</name>
+       <description>RAM Latency Clock Cycles.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5CLK</name>
+         <description>5 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6CLK</name>
+         <description>6 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3CLK</name>
+         <description>3 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4CLK</name>
+         <description>4 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WCSH</name>
+       <description>Write chip select hold after CK falling edge.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RCSH</name>
+       <description>Read chip select hold after CK falling edge.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>WCSS</name>
+       <description>Write chip select setup time to next CK rising edge.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RCSS</name>
+       <description>Read chip select setup time to next CK rising edge.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>WCSHI</name>
+       <description>Write chip select high between operations.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RCSHI</name>
+       <description>Read chip select high between operations.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--HPB HyperBus Memory Controller-->
+  <peripheral>
+   <name>I2C0</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>I2C</groupName>
+   <baseAddress>0x4001D000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2C0</name>
+    <description>I2C0 IRQ</description>
+    <value>13</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0</name>
+     <description>Control Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>I2CEN</name>
+       <description>I2C Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable I2C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable I2C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST</name>
+       <description>Master Mode Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave_mode</name>
+         <description>Slave Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master_mode</name>
+         <description>Master Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GCEN</name>
+       <description>General Call Address Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Ignore Gneral Call Address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Acknowledge general call address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Interactive Receive Mode.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interactive Receive Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interactive Receive Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACK</name>
+       <description>Data Acknowledge. This bit defines the acknowledge bit returned by the I2C receiver while IRXM = 1 HW forces ACK to 0 when IRXM = 0.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ack</name>
+         <description>return ACK (pulling SDA LOW).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>return NACK (leaving SDA HIGH).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_OUT</name>
+       <description>SCL Output. This bits control SCL output when SWOE =1.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive SCL low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Release SCL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDA_OUT</name>
+       <description>SDA Output. This bits control SDA output when SWOE = 1. </description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive SDA low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Release SDA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL</name>
+       <description>SCL status. This bit reflects the logic gate of SCL signal. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>SCL pin is logic low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>SCL pin is logic high.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDA</name>
+       <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>SDA pin is logic low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>SDA pin is logic high.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SWOE</name>
+       <description>Software Output Enable.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>I2C Outputs SCLO and SDAO disabled. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>I2C Outputs SCLO and SDAO enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read. This bit reflects the R/W bit of an address match (AMI = 1) or general call match (GCI = 1). This bit is valid 3 cycles after the relevant interrupt bit is set.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_STRD</name>
+       <description>This bit will disable slave clock stretching when set.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Slave clock stretching enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Slave clock stretching disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_PPM</name>
+       <description>SCL Push-Pull Mode. This bit controls whether SCL is operated in a the I2C standard open-drain mode, or in a non-standard push-pull mode where the Hi-Z output isreplaced with Drive-1. The non-standard mode should only be used when operating as a master and communicating with slaves that are guaranteed to never drive SCL low. </description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Standard open-drain operation: drive low for 0, Hi-Z for 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Non-standard push-pull operation: drive low for 0, drive high for 1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>Bus transaction active status bit.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>I2C Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>I2C Bus Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXE</name>
+       <description>RX FIFO empty.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXF</name>
+       <description>RX FIFO full.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXE</name>
+       <description>TX FIFO empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXF</name>
+       <description>TX FIFO full.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CKMD</name>
+       <description>SCL Drive Status.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>scl_not_active</name>
+         <description>Device not actively driving SCL clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>scl_active</name>
+         <description>Device operating as master and actively driving SCL clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL0</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DONEI</name>
+       <description>Transfer Done Interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXMI</name>
+       <description>Interactive Receive Interrupt.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GCI</name>
+       <description>Slave General Call Address Match Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AMI</name>
+       <description>Slave Address Match Interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXTHI</name>
+       <description>Receive Threshold Interrupt. This bit is automaticcaly cleared when RX_FIFO is below the threshold level.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. RX_FIFO equal or more bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXTHI</name>
+       <description>Transmit Threshold Interrupt. This bit is automaticcaly cleared when TX_FIFO is above the threshold level.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPI</name>
+       <description>STOP Interrupt.</description>
+       <bitRange>[6:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADRACKI</name>
+       <description>Address Acknowledge Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARBERI</name>
+       <description>Arbritation error Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOERI</name>
+       <description>timeout Error Interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADRERI</name>
+       <description>Address NACK Error Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATAERI</name>
+       <description>Data NACK Error Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNRERI</name>
+       <description>Do Not Respond Error Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STRTERI</name>
+       <description>Start Error Interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPERI</name>
+       <description>Stop Error Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXLOI</name>
+       <description>Transmit Lock Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN0</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONEIE</name>
+       <description>Transfer Done Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when DONE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXMIE</name>
+       <description>Description not available.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when RX_MODE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GCIE</name>
+       <description>Slave mode general call address match received input enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when GEN_CTRL_ADDR = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AMIE</name>
+       <description>Slave mode incoming address match interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when ADDR_MATCH = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXTHIE</name>
+       <description>RX FIFO Above Treshold Level Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXTHIE</name>
+       <description>TX FIFO Below Treshold Level Interrupt Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPIE</name>
+       <description>Stop Interrupt Enable</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when STOP = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADRACKIE</name>
+       <description>Received Address ACK from Slave Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARBERIE</name>
+       <description>Master Mode Arbitration Lost Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOERIE</name>
+       <description>Timeout Error Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADRERIE</name>
+       <description>Master Mode Address NACK Received Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATAERIE</name>
+       <description>Master Mode Data NACK Received Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNRERIE</name>
+       <description>Slave Mode Do Not Respond Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STRTERIE</name>
+       <description>Out of Sequence START condition detected interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPERIE</name>
+       <description>Out of Sequence STOP condition detected interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXLOIE</name>
+       <description>TX FIFO Locked Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL1</name>
+     <description>Interrupt Status Register 1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>RXOFI</name>
+       <description>Receiver Overflow Interrupt. When operating as a slave receiver, this bit is set when you reach the first data bit and the RX FIFO and shift register are both full.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXUFI</name>
+       <description>Transmit Underflow Interrupt. When operating as a slave transmitter, this bit is set when you reach the first data bit and the TX FIFO is empty and the master is still asking for more data (i.e the master hasn't sent a NACK yet).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN1</name>
+     <description>Interrupt Staus Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RXOFIE</name>
+       <description>Receiver Overflow Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXUFIE</name>
+       <description>Transmit Underflow Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO_LEN</name>
+     <description>FIFO Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RXLEN</name>
+       <description>Receive FIFO Length.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TXLEN</name>
+       <description>Transmit FIFO Length.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RX_CTRL0</name>
+     <description>Receive Control Register 0.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>DNR</name>
+       <description>Do Not Respond.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Always respond to address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dont_respond</name>
+         <description>Do not respond to address match when RX_FIFO is not empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXFSH</name>
+       <description>Receive FIFO Flush. This bit is automatically cleared to 0 after the operation. Setting this bit to 1 will affect RX_FIFO status.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush RX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXTH</name>
+       <description>Receive FIFO Threshold. These bits define the RX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RX_CTRL1</name>
+     <description>Receive Control Register 1.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>RXCNT</name>
+       <description>Receive Count Bits. These bits define the number of bytes to be received in a transaction, except for the case RXCNT = 0. RXCNT = 0 means 256 bytes to be received in a transaction.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>RXFIFO</name>
+       <description>Receive FIFO Count. These bits reflect the number of byte in the RX_FIFO. These bits are flushed when I2CEN = 0.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TX_CTRL0</name>
+     <description>Transmit Control Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>TXPRELD</name>
+       <description>Transmit FIFO Preaload Mode. Setting this bit will allow for high speed application to preload the transmit FIFO prior to Slave Address Match.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal TX FIFO Operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>preload</name>
+         <description>TX FIFO Preload mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXFSH</name>
+       <description>Transmit FIFO Flush. This bit is automatically cleared to 0 after the operation.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush TX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXTH</name>
+       <description>Transmit FIFO Threshold. These bits define the TX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TX_CTRL1</name>
+     <description>Transmit Control Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>TXRDY</name>
+       <description>Transmit FIFO Preload Ready.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_ready</name>
+         <description>TX FIFO not ready to transmit preloaded data.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>TX FIFO ready to transmit preloaded data.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXLAST</name>
+       <description>Slave mode transmit last.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pause_on_last</name>
+         <description>Hold SCL low after transmitting the last character in the TX FIFO until more characters are loaded.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>end_on_last</name>
+         <description>Release SCL after transmitting the last character in the TXT FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXFIFO</name>
+       <description>Transmit FIFO Count. These bits reflect the number of bytes in the TX_FIFO.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MSTR_MODE</name>
+     <description>Master Control Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Setting this bit to 1 will start a master transfer.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start Master Mode transfer.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RESTART</name>
+       <description>Setting this bit to 1 will generate a repeated START.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>restart</name>
+         <description>Send a repeated start bit.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Setting this bit to 1 will generate a STOP condition.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>stop</name>
+         <description>Send a stop condition.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SEA</name>
+       <description>Slave Extend Address Select.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7BIT_ADDR</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10BIT_ADDR</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_LO</name>
+     <description>Clock Low Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_LO</name>
+       <description>Clock low. In master mode, these bits define the SCL low period. In slave mode, these bits define the time SCL will be held low after data is outputted.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_HI</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_HI</name>
+       <description>Clock High. In master mode, these bits define the SCL high period.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TIMEOUT</name>
+     <description>Timeout Register</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>TO</name>
+       <description>SCL Timeout Period</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLV_ADDR</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>SLA</name>
+       <description>Slave Address.</description>
+       <bitRange>[9:0]</bitRange>
+      </field>
+      <field>
+       <name>EA</name>
+       <description>Slave Mode Extended Address Select.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7BIT_ADDR</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10BIT_ADDR</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TXEN</name>
+       <description>TX channel enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXEN</name>
+       <description>RX channel enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2C0 Inter-Integrated Circuit.-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C1</name>
+   <description>Inter-Integrated Circuit. 1</description>
+   <baseAddress>0x4001E000</baseAddress>
+   <interrupt>
+    <name>I2C1</name>
+    <description>I2C1 IRQ</description>
+    <value>36</value>
+   </interrupt>
+  </peripheral>
+<!--I2C1 Inter-Integrated Circuit. 1-->
+  <peripheral>
+   <name>ICC0</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x4002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CACHE_ID</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CCHID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEM_SIZE</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCHSZ</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEMSZ</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CACHE_CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>ENABLE</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ICC0 Instruction Cache Controller Registers-->
+  <peripheral>
+   <name>OWM</name>
+   <description>1-Wire Master Interface.</description>
+   <baseAddress>0x4003D000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>OneWire</name>
+    <value>67</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CFG</name>
+     <description>1-Wire Master Configuration.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>long_line_mode</name>
+       <description>Long Line Mode.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>force_pres_det</name>
+       <description>Force Line During Presence Detect.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_en</name>
+       <description>Bit Bang Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_mode</name>
+       <description>Provide an extra output control to control an external pullup.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_enable</name>
+       <description>Enable External Pullup.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>single_bit_mode</name>
+       <description>Enable Single Bit TX/RX Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>overdrive</name>
+       <description>Enables overdrive speed for 1-Wire operations.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>int_pullup_enable</name>
+       <description>Enable intenral pullup.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_DIV_1US</name>
+     <description>1-Wire Master Clock Divisor.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DIVISOR</name>
+       <description>Clock Divisor for 1Mhz.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL_STAT</name>
+     <description>1-Wire Master Control/Status.</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>start_ow_reset</name>
+       <description>Start OW Reset.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>sra_mode</name>
+       <description>SRA Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_oe</name>
+       <description>Bit Bang Output Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ow_input</name>
+       <description>OW Input State.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>od_spec_mode</name>
+       <description>Overdrive Spec Mode.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>presence_detect</name>
+       <description>Presence Pulse Detected.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>1-Wire Master Data Buffer.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>tx_rx</name>
+       <description>TX/RX Buffer.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>1-Wire Master Interrupt Flags.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>TX Data Empty Interrupt Flag.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>RX Data Ready Interrupt Flag</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Flag.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Flag.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>1-Wire Master Interrupt Enables.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>Tx Data Empty Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>Rx Data Ready Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Enable.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--OWM 1-Wire Master Interface.-->
+  <peripheral>
+   <name>PT</name>
+   <description>Pulse Train</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C020</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0010</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RATE_LENGTH</name>
+     <description>Pulse Train Configuration</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>rate_control</name>
+       <description>Pulse Train Enable and Rate Control. Set to 0 to disable the Pulse Train.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>27</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>mode</name>
+       <description>Pulse Train Output Mode/Train Length</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>32_BIT</name>
+         <description>Pulse train, 32 bit pattern.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SQUARE_WAVE</name>
+         <description>Square wave mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_BIT</name>
+         <description>Pulse train, 2 bit pattern.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_BIT</name>
+         <description>Pulse train, 3 bit pattern.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_BIT</name>
+         <description>Pulse train, 4 bit pattern.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5_BIT</name>
+         <description>Pulse train, 5 bit pattern.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_BIT</name>
+         <description>Pulse train, 6 bit pattern.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7_BIT</name>
+         <description>Pulse train, 7 bit pattern.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_BIT</name>
+         <description>Pulse train, 8 bit pattern.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9_BIT</name>
+         <description>Pulse train, 9 bit pattern.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_BIT</name>
+         <description>Pulse train, 10 bit pattern.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11_BIT</name>
+         <description>Pulse train, 11 bit pattern.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_BIT</name>
+         <description>Pulse train, 12 bit pattern.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13_BIT</name>
+         <description>Pulse train, 13 bit pattern.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14_BIT</name>
+         <description>Pulse train, 14 bit pattern.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15_BIT</name>
+         <description>Pulse train, 15 bit pattern.</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_BIT</name>
+         <description>Pulse train, 16 bit pattern.</description>
+         <value>16</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>17_BIT</name>
+         <description>Pulse train, 17 bit pattern.</description>
+         <value>17</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>18_BIT</name>
+         <description>Pulse train, 18 bit pattern.</description>
+         <value>18</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>19_BIT</name>
+         <description>Pulse train, 19 bit pattern.</description>
+         <value>19</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>20_BIT</name>
+         <description>Pulse train, 20 bit pattern.</description>
+         <value>20</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>21_BIT</name>
+         <description>Pulse train, 21 bit pattern.</description>
+         <value>21</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>22_BIT</name>
+         <description>Pulse train, 22 bit pattern.</description>
+         <value>22</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>23_BIT</name>
+         <description>Pulse train, 23 bit pattern.</description>
+         <value>23</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>24_BIT</name>
+         <description>Pulse train, 24 bit pattern.</description>
+         <value>24</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>25_BIT</name>
+         <description>Pulse train, 25 bit pattern.</description>
+         <value>25</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>26_BIT</name>
+         <description>Pulse train, 26 bit pattern.</description>
+         <value>26</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>27_BIT</name>
+         <description>Pulse train, 27 bit pattern.</description>
+         <value>27</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>28_BIT</name>
+         <description>Pulse train, 28 bit pattern.</description>
+         <value>28</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>29_BIT</name>
+         <description>Pulse train, 29 bit pattern.</description>
+         <value>29</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30_BIT</name>
+         <description>Pulse train, 30 bit pattern.</description>
+         <value>30</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>31_BIT</name>
+         <description>Pulse train, 31 bit pattern.</description>
+         <value>31</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRAIN</name>
+     <description>Write the repeating bit pattern that is shifted out, LSB first, when configured in Pulse Train mode. See PT_RATE_LENGTH.mode for setting the length.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>LOOP</name>
+     <description>Pulse Train Loop Count</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>count</name>
+       <description>Number of loops for this pulse train to repeat.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>delay</name>
+       <description>Delay between loops of the Pulse Train in PT Peripheral Clock cycles</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>12</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESTART</name>
+     <description> Pulse Train Auto-Restart Configuration.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt_x_select</name>
+       <description>Auto-Restart PT X Select</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_x_loop_exit</name>
+       <description>Enable Auto-Restart on PT X Loop Exit</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt_y_select</name>
+       <description>Auto-Restart PT Y Select</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_y_loop_exit</name>
+       <description>Enable Auto-Restart on PT Y Loop Exit</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PT Pulse Train-->
+  <peripheral derivedFrom="PT">
+   <name>PT1</name>
+   <description>Pulse Train 1</description>
+   <baseAddress>0x4003C030</baseAddress>
+  </peripheral>
+<!--PT1 Pulse Train 1-->
+  <peripheral derivedFrom="PT">
+   <name>PT2</name>
+   <description>Pulse Train 2</description>
+   <baseAddress>0x4003C040</baseAddress>
+  </peripheral>
+<!--PT2 Pulse Train 2-->
+  <peripheral derivedFrom="PT">
+   <name>PT3</name>
+   <description>Pulse Train 3</description>
+   <baseAddress>0x4003C050</baseAddress>
+  </peripheral>
+<!--PT3 Pulse Train 3-->
+  <peripheral derivedFrom="PT">
+   <name>PT4</name>
+   <description>Pulse Train 4</description>
+   <baseAddress>0x4003C060</baseAddress>
+  </peripheral>
+<!--PT4 Pulse Train 4-->
+  <peripheral derivedFrom="PT">
+   <name>PT5</name>
+   <description>Pulse Train 5</description>
+   <baseAddress>0x4003C070</baseAddress>
+  </peripheral>
+<!--PT5 Pulse Train 5-->
+  <peripheral derivedFrom="PT">
+   <name>PT6</name>
+   <description>Pulse Train 6</description>
+   <baseAddress>0x4003C080</baseAddress>
+  </peripheral>
+<!--PT6 Pulse Train 6-->
+  <peripheral derivedFrom="PT">
+   <name>PT7</name>
+   <description>Pulse Train 7</description>
+   <baseAddress>0x4003C090</baseAddress>
+  </peripheral>
+<!--PT7 Pulse Train 7-->
+  <peripheral derivedFrom="PT">
+   <name>PT8</name>
+   <description>Pulse Train 8</description>
+   <baseAddress>0x4003C0A0</baseAddress>
+  </peripheral>
+<!--PT8 Pulse Train 8-->
+  <peripheral derivedFrom="PT">
+   <name>PT9</name>
+   <description>Pulse Train 9</description>
+   <baseAddress>0x4003C0B0</baseAddress>
+  </peripheral>
+<!--PT9 Pulse Train 9-->
+  <peripheral derivedFrom="PT">
+   <name>PT10</name>
+   <description>Pulse Train 10</description>
+   <baseAddress>0x4003C0C0</baseAddress>
+  </peripheral>
+<!--PT10 Pulse Train 10-->
+  <peripheral derivedFrom="PT">
+   <name>PT11</name>
+   <description>Pulse Train 11</description>
+   <baseAddress>0x4003C0D0</baseAddress>
+  </peripheral>
+<!--PT11 Pulse Train 11-->
+  <peripheral derivedFrom="PT">
+   <name>PT12</name>
+   <description>Pulse Train 12</description>
+   <baseAddress>0x4003C0E0</baseAddress>
+  </peripheral>
+<!--PT12 Pulse Train 12-->
+  <peripheral derivedFrom="PT">
+   <name>PT13</name>
+   <description>Pulse Train 13</description>
+   <baseAddress>0x4003C0F0</baseAddress>
+  </peripheral>
+<!--PT13 Pulse Train 13-->
+  <peripheral derivedFrom="PT">
+   <name>PT14</name>
+   <description>Pulse Train 14</description>
+   <baseAddress>0x4003C1000</baseAddress>
+  </peripheral>
+<!--PT14 Pulse Train 14-->
+  <peripheral derivedFrom="PT">
+   <name>PT15</name>
+   <description>Pulse Train 15</description>
+   <baseAddress>0x4003C110</baseAddress>
+  </peripheral>
+<!--PT15 Pulse Train 15-->
+  <peripheral>
+   <name>PTG</name>
+   <description>Pulse Train Generation</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0018</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>PT</name>
+    <description>Pulse Train IRQ</description>
+    <value>59</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ENABLE</name>
+     <description>Global Enable/Disable Controls for All Pulse Trains</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Enable/Disable control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Enable/Disable control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Enable/Disable control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Enable/Disable control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Enable/Disable control for PT4</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Enable/Disable control for PT5</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Enable/Disable control for PT6</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Enable/Disable control for PT7</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Enable/Disable control for PT8</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Enable/Disable control for PT9</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Enable/Disable control for PT10</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Enable/Disable control for PT11</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Enable/Disable control for PT12</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Enable/Disable control for PT13</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Enable/Disable control for PT14</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Enable/Disable control for PT15</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESYNC</name>
+     <description>Global Resync (All Pulse Trains) Control</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Resync control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Resync control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Resync control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Resync control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Resync control for PT4</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Resync control for PT5</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Resync control for PT6</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Resync control for PT7</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Resync control for PT8</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Resync control for PT9</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Resync control for PT10</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Resync control for PT11</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Resync control for PT12</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Resync control for PT13</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Resync control for PT14</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Resync control for PT15</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Pulse Train Interrupt Flags</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Flag</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Flag</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Flag</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Pulse Train 8 Stopped Interrupt Flag</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Pulse Train 9 Stopped Interrupt Flag</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Pulse Train 10 Stopped Interrupt Flag</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Pulse Train 11 Stopped Interrupt Flag</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Pulse Train 12 Stopped Interrupt Flag</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Pulse Train 13 Stopped Interrupt Flag</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Pulse Train 14 Stopped Interrupt Flag</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Pulse Train 15 Stopped Interrupt Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Pulse Train Interrupt Enable/Disable</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Pulse Train 8 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Pulse Train 9 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Pulse Train 10 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Pulse Train 11 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Pulse Train 12 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Pulse Train 13 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Pulse Train 14 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Pulse Train 15 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_EN</name>
+     <description>Pulse Train Global Safe Enable.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT8</name>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT9</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT10</name>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT11</name>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT12</name>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT13</name>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT14</name>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT15</name>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_DIS</name>
+     <description>Pulse Train Global Safe Disable.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT8</name>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT9</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT10</name>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT11</name>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT12</name>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT13</name>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT14</name>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT15</name>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PTG Pulse Train Generation-->
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x40006800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAMRET</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en1</name>
+         <description>Enable System RAM 0 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en2</name>
+         <description>Enable System RAM 0 and 1 retention.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en3</name>
+         <description>Enable System RAM 0 and 1 retention, if RREGEN=0, Enable all System RAM retention.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RREGEN</name>
+       <description>Backup Mode RAM Retention Regulator Enable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BKGRND</name>
+       <description>Background Mode Enable. This bit allows low-power background mode operations, while the CPU is in DeepSleep.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FWKM</name>
+       <description>Fast Wake-Up Mode. This bit enables fast wake-up from DeepSleep mode. (5uS typical). </description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BGOFF</name>
+       <description>Bandgap OFF. This controls the System Bandgap in DeepSleep mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>Bandgap is always ON.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>Bandgap is OFF in DeepSleep mode(default).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PORVCOREMD</name>
+       <description>VCORE POR Monitor for DEEPSLEEP and BACKUP Disable Write 1 to disable the power failure monitor. With the power failure monitor enabled, if the voltage drops below the trigger voltage the device enters a Power-On Reset.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON(default)</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREMD</name>
+       <description>VDDC(Vcore) Monitor Disable. This bit controls the power monitor on the VCore supply in all operating modes.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON(default)</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VRTCMD</name>
+       <description>VRTC Monitor Disable. This bit controls the power monitor on the Always-On Supply in all operating modes.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON(default)</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDAMD</name>
+       <description>VDDA Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON(default)</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDIOMD</name>
+       <description>VDDIO Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON(default)</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDIOHMD</name>
+       <description>VFDDIOH Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON(default)</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PORVDDIOMD</name>
+       <description>VFDDIOH Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON(default)</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PORVDDIOHMD</name>
+       <description>VFDDIOH Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON(default)</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDBMD</name>
+       <description>VDDB Power-On Reset Monitor Disable. This bit controls the Power-On Reset monitor on VDDB supply in all operating mods.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO0_WK_FL</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO0.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin(s) transition(s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO0_WK_EN</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin(s) on transition(s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO1_WK_FL</name>
+     <description>Low Power I/O Wakeup Status Register 1. This register indicates the low power wakeup status for GPIO1.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin(s) transition(s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO1_WK_EN</name>
+     <description>Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup functionality for GPIO1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin(s) on transition(s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO2_WK_FL</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO2.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin(s) transition(s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO2_WK_EN</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin(s) on transition(s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO3_WK_FL</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO3.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin(s) transition(s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO3_WK_EN</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO3.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin(s) on transition(s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>USB_WK_FL</name>
+     <description>Low Power Peripheral Wakeup Status Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>USBLSWKST</name>
+       <description>USB UTMI Linestate Detect Wakeup Flag(write one to clear). One or both of these bits will be set when the USB bus activity causes the linestate to change and the device to wake while USB wakeup is enabled using PMLUSBWKEN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dplus</name>
+         <description>D Plus line state change.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dminus</name>
+         <description>D Minus line state change.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USBVBUSWKST</name>
+       <description>USB VBUS Detect Wakeup Flag (write one to clear). This bit will be set when the USB power supply is powered on or powered off.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>stchng</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>USB_WK_EN</name>
+     <description>Low Power Peripheral Wakeup Enable Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>USBLSWKEN</name>
+       <description>USB UTMI Linestate Detect Wakeup Enable. These bits allow wakeup from the corresponding USB linestate signal(s) on transition(s) from low to high or high to low when PM.USBWKEN is set.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USBVBUSWKEN</name>
+       <description>USB VBUS Detect Wakeup Enable. This bit allows wakeup from the USB power supply on or off status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEM_PWR</name>
+     <description>Low Power Memory Shutdown Control.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>SRAM0SD</name>
+       <description>System RAM block 0 Shut Down.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM1SD</name>
+       <description>System RAM block 1 Shut Down.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM2SD</name>
+       <description>System RAM block 2 Shut Down.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM3SD</name>
+       <description>System RAM block 3 Shut Down.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM4SD</name>
+       <description>System RAM block 4 Shut Down.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM5SD</name>
+       <description>System RAM block 5 Shut Down.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM6SD</name>
+       <description>System RAM block 6 Shut Down.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHESD</name>
+       <description>Instruction Cache RAM Shut Down.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHEXIPSD</name>
+       <description>XiP Instruction Cache RAM Shut Down.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCACHESD</name>
+       <description>System Cache RAM Shut Down.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRYPTOSD</name>
+       <description>Crypto MAA RAM Shut Down.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USBFIFOSD</name>
+       <description>USB FIFO Shut Down.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROMSD</name>
+       <description>ROM Shut Down.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PWRSEQ Power Sequencer / Low Power Control Register.-->
+  <peripheral>
+   <name>RTC</name>
+   <description>Real Time Clock and Alarm.</description>
+   <baseAddress>0x40006000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>RTC</name>
+    <description>RTC interrupt.</description>
+    <value>3</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>RTC Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC</name>
+       <description>RTC Sub-second Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TODA</name>
+     <description>Time-of-day Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-day Alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSECA</name>
+     <description>RTC sub-second alarm.  This register contains the reload value for the sub-second alarm.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>This register contains the reload value for the sub-second alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>RTC Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>ENABLE</name>
+       <description>Real Time Clock Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM_EN</name>
+       <description>Alarm Time-of-Day Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM_EN</name>
+       <description>Alarm Sub-second Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>RTC Busy. This bit is set to 1 by hardware when changes to RTC registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READY</name>
+       <description>RTC Ready. This bit is set to 1 by hardware when the RTC count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the RTC count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_ready</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READY_INT_EN</name>
+       <description>RTC Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM_FL</name>
+       <description>Time-of-Day Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM_FL</name>
+       <description>Sub-second Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQWOUT_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FREQ_SEL</name>
+       <description>Frequency Output Selection. When SQE=1, these bits specify the output frequency on the SQW pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq1Hz</name>
+         <description>1 Hz (Compensated).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq512Hz</name>
+         <description>512 Hz (Compensated).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq4KHz</name>
+         <description>4 KHz.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACRE</name>
+       <description>Asynchronous Counter Read Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>sync</name>
+         <description>SEC and SSEC registers synchronized and should only be accessed while CTRL.rdy = 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>async</name>
+         <description>SEC and SSEC registers are asynchronous and will require software interaction to ensure data accuracy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRITE_EN</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical RTC bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Writes to RTC_CTRL.enable are ignored.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Writes to RTC_CTRL.enable are allowed.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>RTC Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>FILTER_EN</name>
+       <description>Enables analog deglitch filter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_SEL</name>
+       <description>If IBIAS_EN is 1, selects 4x,2x mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HYST_EN</name>
+       <description>Enables high current hysteresis buffer.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_EN</name>
+       <description>Enables higher 4x,2x current modes.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYPASS</name>
+       <description>RTC Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>32KOUT</name>
+       <description>RTC 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--RTC Real Time Clock and Alarm.-->
+  <peripheral>
+   <name>SDHC</name>
+   <description>SDHC/SDIO Controller</description>
+   <baseAddress>0x40037000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SDHC</name>
+    <value>66</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SDMA</name>
+     <description>SDMA System Address / Argument 2.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>SDMA System Address / Argument 2  of Auto CMD23.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_SIZE</name>
+     <description>Block Size.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>TRANS</name>
+       <description>Transfer Block Size.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>HOST_BUF</name>
+       <description>Host SDMA Buffer Boundary.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>4KB</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8KB</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16KB</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>32KB</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>64KB</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>128KB</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>256KB</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>512KB</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_CNT</name>
+     <description>Block Count.</description>
+     <addressOffset>0x06</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Blocks Count For Current Transfer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ARG_1</name>
+     <description>Argument 1.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>CMD</name>
+       <description>Command Argument 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRANS</name>
+     <description>Transfer Mode.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>DMA_EN</name>
+       <description>DMA Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BLK_CNT_EN</name>
+       <description>Block Count Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTO_CMD_EN</name>
+       <description>Auto CMD Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cmd12</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cmd23</name>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ_WRITE</name>
+       <description>Data Transfer Direction Select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MULTI</name>
+       <description>Multi / Single Block Select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>multi</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>single</name>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMD</name>
+     <description>Command.</description>
+     <addressOffset>0x0E</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>RESP_TYPE</name>
+       <description>Response Type Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>none</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>resp136</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>resp48</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>resp48_busy</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRC_CHK_EN</name>
+       <description>Command CRC Check Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IDX_CHK_EN</name>
+       <description>Command Index Check Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_PRES_SEL</name>
+       <description>Data Present Select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TYPE</name>
+       <description>Command Type.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>suspend</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>resume</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>abort</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IDX</name>
+       <description>Command Index.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>RESP[%s]</name>
+     <description>Response 0 Register 0-15.</description>
+     <addressOffset>0x010</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_RESP</name>
+       <description>Command Response.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUFFER</name>
+     <description>Buffer Data Port.</description>
+     <addressOffset>0x20</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Buffer Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESENT</name>
+     <description>Present State.</description>
+     <addressOffset>0x024</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CMD_COMP</name>
+       <description>Command Inhibit (CMD).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DAT</name>
+       <description>Command Inhibit (DAT).</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DAT_LINE_ACTIVE</name>
+       <description>DAT Line Active.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Request.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WRITE_TRANSFER</name>
+       <description>Write Transfer Active.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>READ_TRANSFER</name>
+       <description>Read Transfer Active.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BUFFER_WRITE</name>
+       <description>Buffer Write Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BUFFER_READ</name>
+       <description>Buffer Read Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CARD_INSERTED</name>
+       <description>Card Inserted.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CARD_STATE</name>
+       <description>Card State Stable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CARD_DETECT</name>
+       <description>Card Detect Pin Level.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WP</name>
+       <description>Write Protect Switch Pin Level.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DAT_SIGNAL_LEVEL</name>
+       <description>DAT[3:0] Line Signal Level.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CMD_SIGNAL_LEVEL</name>
+       <description>CMD Line Signal Level.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HOST_CN_1</name>
+     <description>Host Control 1.</description>
+     <addressOffset>0x028</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>LED_CN</name>
+       <description>LED Control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TRANSFER_WIDTH</name>
+       <description>Data Transfer Width.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HS_EN</name>
+       <description>High Speed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA_SELECT</name>
+       <description>DMA Select.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>EXT_DATA_TRANSFER_WIDTH</name>
+       <description>Extended Data Transfer Width.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_DETECT_TEST</name>
+       <description>Card Detect Test Level.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_DETECT_SIGNAL</name>
+       <description>Card Detect Signal Selection.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWR</name>
+     <description>Power Control.</description>
+     <addressOffset>0x029</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>BUS_POWER</name>
+       <description>SD Bus Power.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUS_VOLT_SEL</name>
+       <description>SD Bus Voltage Select.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1v8_typ</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3v_typ</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3v3_typ</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_GAP</name>
+     <description>Block Gap Control.</description>
+     <addressOffset>0x02A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>STOP</name>
+       <description>Stop At Block Gap Request.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CONT</name>
+       <description>Continue Request.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>READ_WAIT</name>
+       <description>Read Wait Control.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTR</name>
+       <description>Interrupt At Block Gap.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKEUP</name>
+     <description>Wakeup Control.</description>
+     <addressOffset>0x02B</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>CARD_INT</name>
+       <description>Wakeup Event Enable On Card Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INS</name>
+       <description>Wakeup Event Enable On SD Card Insertion.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REM</name>
+       <description>Wakeup Event Enable On SD Card Removal.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_CN</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x02C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>INTERNAL_CLK_EN</name>
+       <description>Internal Clock Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTERNAL_CLK_STABLE</name>
+       <description>Internal Clock Stable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SD_CLK_EN</name>
+       <description>SD Clock Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLK_GEN_SEL</name>
+       <description>Clock Generator Select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>UPPER_SDCLK_FREQ_SEL</name>
+       <description>Upper Bits of SDCLK Frequency Select.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SDCLK_FREQ_SEL</name>
+       <description>SDCLK Frequency Select.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TO</name>
+     <description>Timeout Control.</description>
+     <addressOffset>0x02E</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>DATA_COUNT_VALUE</name>
+       <description>Data Timeout Counter Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>2POW13</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2POW14</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2POW15</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2POW16</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2POW17</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2POW18</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2POW19</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2POW20</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2POW21</name>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2POW22</name>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2POW23</name>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2POW24</name>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2POW25</name>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2POW26</name>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2POW27</name>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SW_RESET</name>
+     <description>Software Reset.</description>
+     <addressOffset>0x02F</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RESET_ALL</name>
+       <description>Software Reset For All.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESET_CMD</name>
+       <description>Software Reset For CMD Line.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESET_DAT</name>
+       <description>Software Reset For DAT Line.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_STAT</name>
+     <description>Normal Interrupt Status.</description>
+     <addressOffset>0x030</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_COMP</name>
+       <description>Command Complete.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRANS_COMP</name>
+       <description>Transfer Complete.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BLK_GAP_EVENT</name>
+       <description>Block Gap Event.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFF_WR_READY</name>
+       <description>Buffer Write Ready.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFF_RD_READY</name>
+       <description>Buffer Read Ready.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INSERTION</name>
+       <description>Card Insertion.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REMOVAL</name>
+       <description>Card Removal.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INTR</name>
+       <description>Card Interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Event.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERR_INTR</name>
+       <description>Error Interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ER_INT_STAT</name>
+     <description>Error Interrupt Status.</description>
+     <addressOffset>0x032</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Command Timeout Error.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Command CRC Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Command End Bit Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_IDX</name>
+       <description>Command Index Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Data Timeout Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Data CRC Error.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Data End Bit Error.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CURRENT_LIMIT</name>
+       <description>Current Limit Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AUTO_CMD_12</name>
+       <description>Auto CMD Error.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>ADMA Error.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Error.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Normal Interrupt Status Enable.</description>
+     <addressOffset>0x034</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_COMP</name>
+       <description>Command Complete Status Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRANS_COMP</name>
+       <description>Transfer Complete Status Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BLK_GAP</name>
+       <description>Block Gap Event Status Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Interrupt Status Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_WR</name>
+       <description>Buffer Write Ready Status Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_RD</name>
+       <description>Buffer Read Ready Status Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INSERT</name>
+       <description>Card Insertion Status Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REMOVAL</name>
+       <description>Card Removal Status Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INT</name>
+       <description>Card Interrupt Status Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Event Status Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ER_INT_EN</name>
+     <description>Error Interrupt Status Enable.</description>
+     <addressOffset>0x36</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Command Timeout Error Status Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Command CRC Error Status Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Command End Bit Error Status Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_IDX</name>
+       <description>Command Index Error Status Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Data Timeout Error Status Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Data CRC Error Status Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Data End Bit Error Status Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AUTO_CMD_12</name>
+       <description>Auto CMD Error Status Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>ADMA Error Status Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TUNING</name>
+       <description>Tuning Error Status Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VENDOR</name>
+       <description>Vendor Specific Error Status Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_SIGNAL</name>
+     <description>Normal Interrupt Signal Enable.</description>
+     <addressOffset>0x038</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_COMP</name>
+       <description>Command Complete Signal Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRANS_COMP</name>
+       <description>Transfer Complete Signal Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BLK_GAP</name>
+       <description>Block Gap Event Signal Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Interrupt Signal Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_WR</name>
+       <description>Buffer Write Ready Signal Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_RD</name>
+       <description>Buffer Read Ready Signal Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INSERT</name>
+       <description>Card Insertion Signal Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REMOVAL</name>
+       <description>Card Removal Signal Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INT</name>
+       <description>Card Interrupt Signal Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Event Signal Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ER_INT_SIGNAL</name>
+     <description>Error Interrupt Signal Enable.</description>
+     <addressOffset>0x03A</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Command Timeout Error Signal Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Command CRC Error Signal Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Command End Bit Error Signal Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_IDX</name>
+       <description>Command Index Error Signal Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Data Timeout Error Signal Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Data CRC Error Signal Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Data End Bit Error Signal Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CURRENT_LIMIT</name>
+       <description>Current Limit Error Signal Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AUTO_CMD_12</name>
+       <description>Auto CMD Error Signal Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>ADMA Error Signal Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TUNING</name>
+       <description>Tuning Error Signal Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAR_RESP</name>
+       <description>Target Response Error Signal Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTO_CMD_ER</name>
+     <description>Auto CMD Error Status.</description>
+     <addressOffset>0x03C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>NOT_EXCUTED</name>
+       <description>Auto CMD12 Not Executed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TO</name>
+       <description>Auto CMD Timeout Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRC</name>
+       <description>Auto CMD CRC Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>END_BIT</name>
+       <description>Auto CMD End Bit Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INDEX</name>
+       <description>Auto CMD Index Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOT_ISSUED</name>
+       <description>Command Not Issued By Auto CMD12 Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HOST_CN_2</name>
+     <description>Host Control 2.</description>
+     <addressOffset>0x03E</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>UHS</name>
+       <description>UHS Mode Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>sdr12</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sdr25</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sdr50</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ddr50</name>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>1_8V_SIGNAL</name>
+       <description>1.8V Signaling Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>typeB</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeA</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeC</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typrD</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXCUTE</name>
+       <description>Execute Tuning.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SAMPLING_CLK</name>
+       <description>Sampling Clock Select.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ASYNCH_INT</name>
+       <description>Asynchronous Interrupt Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PRESET_VAL_EN</name>
+       <description>Preset Value Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_0</name>
+     <description>Capabilities 0-31.</description>
+     <addressOffset>0x040</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TO_FREQ</name>
+       <description>Timeout Clock Frequency.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1mhz</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLK_UNIT</name>
+       <description>Timeout Clock Unit.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_FREQ</name>
+       <description>Base Clock Frequency For SD Clock.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>MAX_BLK_LEN</name>
+       <description>Max Block Length.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>2048_bytes</name>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>8_BIT</name>
+       <description>8-bit Support for Embedded Device.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ADMA2</name>
+       <description>ADMA2 Support.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS</name>
+       <description>High Speed Support.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDMA</name>
+       <description>SDMA Support.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SUSPEND</name>
+       <description>Suspend/Resume Support.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>3_3V</name>
+       <description>Voltage Support 3.3V.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>3_0V</name>
+       <description>Voltage Support 3.0V.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>1_8V</name>
+       <description>Voltage Support 1.8V.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>64_BIT_SYS_BUS</name>
+       <description>64-bit System Bus Support.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ASYNC_INT</name>
+       <description>Asynchronous Interrupt Support.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SLOT_TYPE</name>
+       <description>Slot Type.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_1</name>
+     <description>Capabilities 32-63.</description>
+     <addressOffset>0x044</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDR50</name>
+       <description>SDR50 Support.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDR104</name>
+       <description>SDR104 Support.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>0</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DDR50</name>
+       <description>DDR50 Support.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_A</name>
+       <description>Driver Type A Support.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_C</name>
+       <description>Driver Type C Support.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_D</name>
+       <description>Driver Type D Support.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TIMER_CNT_TUNING</name>
+       <description>Timer Count for Re-Tuning.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1sec</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2sec</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4sec</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8sec</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16sec</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>32sec</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>64sec</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>128sec</name>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>256sec</name>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>512sec</name>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1024sec</name>
+         <value>11</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TUNING_SDR50</name>
+       <description>Use Tuning for SDR50.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Modes.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_MULTI</name>
+       <description>Clock Multiplier.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAX_CURR_CFG</name>
+     <description>Maximum Current Capabilities.</description>
+     <addressOffset>0x048</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>3_3V</name>
+       <description>Maximum Current for 3.3V.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>3_0V</name>
+       <description>Maximum Current for 3.0V.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>1_8V</name>
+       <description>Maximum Current for 1.8V.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FORCE_CMD</name>
+     <description>Force Event for Auto CMD Error Status.</description>
+     <addressOffset>0x050</addressOffset>
+     <size>16</size>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>NOT_EXCU</name>
+       <description>Force Event for Auto CMD12 Not Executed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TO</name>
+       <description>Force Event for Auto CMD Timeout Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>CRC</name>
+       <description>Force Event for Auto CMD CRC Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>END_BIT</name>
+       <description>Force Event for Auto CMD End Bit Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>INDEX</name>
+       <description>Force Event for Auto CMD Index Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>NOT_ISSUED</name>
+       <description>Force Event for Command Not Issued By Auto CMD12 Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FORCE_EVENT_INT_STAT</name>
+     <description>Force Event for Error Interrupt Status.</description>
+     <addressOffset>0x052</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Force Event for Command Timeout Error.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Force Event for Command CRC Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Force Event for Command End Bit Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CMD_INDEX</name>
+       <description>Force Event for Command Index Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Force Event for Data Timeout Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Force Event for Data CRC Error.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Force Event for Data End Bit Error.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CURR_LIMIT</name>
+       <description>Force Event for Current Limit Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>AUTO_CMD</name>
+       <description>Force Event for Auto CMD Error.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>Force Event for ADMA Error.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>STAT_VENDOR</name>
+       <description>Force Event for Vendor Specific Error Status.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADMA_ER</name>
+     <description>ADMA Error Status.</description>
+     <addressOffset>0x054</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>STATE</name>
+       <description>ADMA Error State.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>LEN_MISMATCH</name>
+       <description>ADMA Length Mismatch Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADMA_ADDR_0</name>
+     <description>ADMA System Address 0-31.</description>
+     <addressOffset>0x058</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>ADMA System Address  Part 1 (part 2 is ADMA_ADDR_1).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADMA_ADDR_1</name>
+     <description>ADMA System Address 32-63.</description>
+     <addressOffset>0x05C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>ADMA System Address  Part 1 (part 2 is ADMA_ADDR_1).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_0</name>
+     <description>Preset Value for Initialization.</description>
+     <addressOffset>0x060</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>typeB</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeA</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeC</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeD</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_1</name>
+     <description>Preset Value for Default Speed.</description>
+     <addressOffset>0x062</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>typeB</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeA</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeC</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeD</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_2</name>
+     <description>Preset Value for High Speed.</description>
+     <addressOffset>0x064</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>typeB</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeA</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeC</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeD</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_3</name>
+     <description>Preset Value for SDR12.</description>
+     <addressOffset>0x066</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>typeB</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeA</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeC</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeD</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_4</name>
+     <description>Preset Value for SDR25.</description>
+     <addressOffset>0x068</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>typeB</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeA</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeC</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeD</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_5</name>
+     <description>Preset Value for SDR50.</description>
+     <addressOffset>0x06A</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>typeB</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeA</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeC</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeD</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_6</name>
+     <description>Preset Value for SDR104.</description>
+     <addressOffset>0x06C</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>typeB</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeA</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeC</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeD</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_7</name>
+     <description>Preset Value for DDR50.</description>
+     <addressOffset>0x06E</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>typeB</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeA</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeC</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>typeD</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SHARED_BUS</name>
+     <description>SHARED_BUS.</description>
+     <addressOffset>0x0E0</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>SLOT_INT</name>
+     <description>Slot Interrupt Status.</description>
+     <addressOffset>0x0FC</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>INT_SIGNALS</name>
+       <description>Interrupt Signal For Each Slot.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HOST_CN_VER</name>
+     <description>Host Controller Version.</description>
+     <addressOffset>0x0FE</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>SPEC_VER</name>
+       <description>Specification Version Number.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VEND_VER</name>
+       <description>Vendor Version Number.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SDHC SDHC/SDIO Controller-->
+  <peripheral>
+   <name>SEMA</name>
+   <description>The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.</description>
+   <baseAddress>0x4003E000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>0x04</dimIncrement>
+     <name>SEMAPHORES[%s]</name>
+     <description>Read to test and set, returns prior value. Write 0 to clear semaphore.</description>
+     <addressOffset>0x000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>sema</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>status</name>
+     <description>Semaphore status bits. 0 indicates the semaphore is free, 1 indicates taken.</description>
+     <addressOffset>0x100</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>STATUS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SEMA The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.-->
+  <peripheral>
+   <name>SMON</name>
+   <description>The Security Monitor block used to monitor system threat conditions.</description>
+   <baseAddress>0x40004000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>EXTSCN</name>
+     <description>External Sensor Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x3800FFC0</resetMask>
+     <fields>
+      <field>
+       <name>EXTS_EN0</name>
+       <description>External Sensor Enable for input/output pair 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN1</name>
+       <description>External Sensor Enable for input/output pair 1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN2</name>
+       <description>External Sensor Enable for input/output pair 2.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN3</name>
+       <description>External Sensor Enable for input/output pair 3.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN4</name>
+       <description>External Sensor Enable for input/output pair 4.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN5</name>
+       <description>External Sensor Enable for input/output pair 5.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTCNT</name>
+       <description>External Sensor Error Counter. These bits set the number of external sensor accepted mismatches that have to occur within a single bit period before an external sensor alarm is triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>EXTFRQ</name>
+       <description>External Sensor Frequency. These bits define the frequency at which the external sensors are clocked to/from the EXTS_IN and EXTS_OUT pair.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq2000Hz</name>
+         <description>Div 4 (2000Hz).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq1000Hz</name>
+         <description>Div 8 (1000Hz).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq500Hz</name>
+         <description>Div 16 (500Hz).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq250Hz</name>
+         <description>Div 32 (250Hz).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq125Hz</name>
+         <description>Div 64 (125Hz).</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq63Hz</name>
+         <description>Div 128 (63Hz).</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq31Hz</name>
+         <description>Div 256 (31Hz).</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RFU</name>
+         <description>Reserved. Do not use.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DIVCLK</name>
+       <description>Clock Divide.  These bits are used to divide the 8KHz input clock. The resulting divided clock is used for all logic within the Security Monitor Block. Note:
+                                                             If the input clock is divided with these bits, the error count threshold table and output frequency will be affected accordingly with the same divide factor.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1 (8000 Hz).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2 (4000 Hz).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4 (2000 Hz).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8 (1000 Hz).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16 (500 Hz).</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32 (250 Hz).</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64 (125 Hz).</description>
+         <value>6</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>Busy. This bit is set to 1 by hardware after EXTSCN register is written to. This bit is automatically cleared to 0 after this register information has been transferred to the security monitor domain.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Update in Progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock Register. Once locked, the EXTSCN register can no longer be modified.  Only a battery disconnect will clear this bit. VBAT powers this register.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTSCN</name>
+     <description>Internal Sensor Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x7F00FFF7</resetMask>
+     <fields>
+      <field>
+       <name>SHIELD_EN</name>
+       <description>Die Shield Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TEMP_EN</name>
+       <description>Temperature Sensor Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VBAT_EN</name>
+       <description>Battery Monitor Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOTEMP_SEL</name>
+       <description>Low Temperature Detection Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>neg50C</name>
+         <description>-50 degrees C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>neg30C</name>
+         <description>-30 degrees C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORELOEN</name>
+       <description>VCORE Undervoltage Detect Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREHIEN</name>
+       <description>VCORE Overvoltage Detect Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDLOEN</name>
+       <description>VDD Undervoltage Detect Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDHIEN</name>
+       <description>VDD Overvoltage Detect Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VGLEN</name>
+       <description>Voltage Glitch Detection Enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock Register. Once locked, the INTSCN register can no longer be modified.  Only a battery disconnect will clear this bit. VBAT powers this register.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECALM</name>
+     <description>Security Alarm Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000000</resetValue>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>DRS</name>
+       <description>Destructive Reset Trigger. Setting this bit will generate a DRS. This bit is self-cleared by hardware.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>Key Wipe Trigger. Set to 1 to initiate a wipe of the AES key register. It does not reset the part, or log a timestamp. AES and DES registers are not affected by this bit. This bit is automatically cleared to 0 after the keys have been wiped.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHIELDF</name>
+       <description>Die Shield Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOTEMP</name>
+       <description>Low Temperature Detect.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HITEMP</name>
+       <description>High Temperature Detect.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATLO</name>
+       <description>Battery Undervoltage Detect.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATHI</name>
+       <description>Battery Overvoltage Detect.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTF</name>
+       <description>External Sensor Flag.   This bit is set to 1 when any of the EXTSTAT bits are set.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDLO</name>
+       <description>VDD Undervoltage Detect Flag.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORELO</name>
+       <description>VCORE Undervoltage Detect Flag.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREHI</name>
+       <description>VCORE Overvoltage Detect Flag.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDHI</name>
+       <description>VDD Overvoltage Flag.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VGL</name>
+       <description>Voltage Glitch Detection Flag.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT0</name>
+       <description>External Sensor 0 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT1</name>
+       <description>External Sensor 1 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT2</name>
+       <description>External Sensor 2 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT3</name>
+       <description>External Sensor 3 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT4</name>
+       <description>External Sensor 4 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT5</name>
+       <description>External Sensor 5 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN0</name>
+       <description>External Sensor 0 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN1</name>
+       <description>External Sensor 1 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN2</name>
+       <description>External Sensor 2 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN3</name>
+       <description>External Sensor 3 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN4</name>
+       <description>External Sensor 4 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN5</name>
+       <description>External Sensor 5 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECDIAG</name>
+     <description>Security Diagnostic Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00000001</resetValue>
+     <resetMask>0xFFC0FE02</resetMask>
+     <fields>
+      <field>
+       <name>BORF</name>
+       <description>Battery-On-Reset Flag. This bit is set once the back up battery is conneted.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHIELDF</name>
+       <description>Die Shield Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOTEMP</name>
+       <description>Low Temperature Detect.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HITEMP</name>
+       <description>High Temperature Detect.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATLO</name>
+       <description>Battery Undervoltage Detect.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATHI</name>
+       <description>Battery Overvoltage Detect.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DYNF</name>
+       <description>Dynamic Sensor Flag.  This bit is set to 1 when any of the EXTSTAT bits are set.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESKT</name>
+       <description>AES Key Transfer.  This bit is set to 1 when AES Key has been transferred from the TRNG to the battery backed AES key register. This bit can only be reset by a BOR.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>incomplete</name>
+         <description>Key has not been transferred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>Key has been transferred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT0</name>
+       <description>External Sensor 0 Detect.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT1</name>
+       <description>External Sensor 1 Detect.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT2</name>
+       <description>External Sensor 2 Detect.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT3</name>
+       <description>External Sensor 3 Detect.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT4</name>
+       <description>External Sensor 4 Detect.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT5</name>
+       <description>External Sensor 5 Detect.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DLRTC</name>
+     <description>DRS Log RTC Value. This register contains the 32 bit value in the RTC second register when the last DRS event occurred.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-only</access>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>DLRTC</name>
+       <description>DRS Log RTC Value. This register contains the 32 bit value in the RTC second register when the last DRS event occured.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECST</name>
+     <description>Security Monitor Status</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>EXTSRS</name>
+       <description>External Sensor Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Allowed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notallowed</name>
+         <description>Not allowed.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INTSRS</name>
+       <description>Internal Sensor Status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Allowed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notallowed</name>
+         <description>Not allowed.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SECALRS</name>
+       <description>Securit Alarm Status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Allowed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notallowed</name>
+         <description>Not allowed.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SMON The Security Monitor block used to monitor system threat conditions.-->
+  <peripheral>
+   <name>SPI0</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x40046000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>16</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FIFO32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>FIFO16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>FIFO32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>FIFO8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>FIFO32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SPI_EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MM_EN</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Start Select Control. Used in Master mode to control the behavior of the Slave Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>deassert</name>
+         <description>SPI De-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>assert</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_SEL</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3</name>
+         <description>SS3 is selected.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLK_PHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>risingEdge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fallingEdge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLK_POL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUM_BITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16BITS</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1BITS</name>
+         <description>1 bits per character.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2BITS</name>
+         <description>2 bits per character.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3BITS</name>
+         <description>3 bits per character.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4BITS</name>
+         <description>4 bits per character.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5BITS</name>
+         <description>5 bits per character.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6BITS</name>
+         <description>6 bits per character.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7BITS</name>
+         <description>7 bits per character.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8BITS</name>
+         <description>8 bits per character.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9BITS</name>
+         <description>9 bits per character.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10BITS</name>
+         <description>10 bits per character.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11BITS</name>
+         <description>11 bits per character.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12BITS</name>
+         <description>12 bits per character.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13BITS</name>
+         <description>13 bits per character.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14BITS</name>
+         <description>14 bits per character.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15BITS</name>
+         <description>15 bits per character.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUS_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin (s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>4wire</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3wire</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_POL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3_high</name>
+         <description>SS3 active high.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SS_TIME</name>
+     <description>Register for controlling SPI peripheral/Slave Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SSACT1</name>
+       <description>Slave Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSACT2</name>
+       <description>Slave Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSINACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_CFG</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>SCALE</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <description>Divide SPI Clock Frequency by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <description>Divide SPI Clock Frequency by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <description>Divide SPI Clock Frequency by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV8</name>
+         <description>Divide SPI Clock Frequency by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV16</name>
+         <description>Divide SPI Clock Frequency by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV32</name>
+         <description>Divide SPI Clock Frequency by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV64</name>
+         <description>Divide SPI Clock Frequency by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV128</name>
+         <description>Divide SPI Clock Frequency by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV256</name>
+         <description>Divide SPI Clock Frequency by 256.</description>
+         <value>8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_FIFO_LEVEL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CLEAR</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CNT</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DMA_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_LEVEL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CLEAR</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CNT</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_DMA_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_LEVEL</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LEVEL</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_LEVEL</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LEVEL</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_FL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_LEVEL</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LEVEL</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_LEVEL</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LEVEL</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notActive</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPI0 SPI peripheral.-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI1</name>
+   <description>SPI peripheral. 1</description>
+   <baseAddress>0x40047000</baseAddress>
+   <interrupt>
+    <name>SPI1</name>
+    <description>SPI1 IRQ</description>
+    <value>17</value>
+   </interrupt>
+  </peripheral>
+<!--SPI1 SPI peripheral. 1-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI2</name>
+   <description>SPI peripheral. 2</description>
+   <baseAddress>0x40048000</baseAddress>
+   <interrupt>
+    <name>SPI2</name>
+    <description>SPI2 IRQ</description>
+    <value>18</value>
+   </interrupt>
+  </peripheral>
+<!--SPI2 SPI peripheral. 2-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI3</name>
+   <description>SPI peripheral. 3</description>
+   <baseAddress>0x400BE000</baseAddress>
+   <interrupt>
+    <name>SPI3</name>
+    <description>SPI3 IRQ</description>
+    <value>56</value>
+   </interrupt>
+  </peripheral>
+<!--SPI3 SPI peripheral. 3-->
+  <peripheral>
+   <name>SPIMSS</name>
+   <description>Serial Peripheral Interface.</description>
+   <prependToName>SPIMSS</prependToName>
+   <baseAddress>0x40018000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>DATA</name>
+     <description>SPI 16-bit Data Access</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>SPI data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>SPI Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>stop</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MMEN</name>
+       <description>SPI Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OD_OUT_EN</name>
+       <description>Wired OR (open drain) Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idleLo</name>
+         <description>SCLK idles Low (0) after character transmission/reception.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>idleHi</name>
+         <description>SCLK idles High (1) after character transmission/reception.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PHASE</name>
+       <description>Phase Select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeEdge</name>
+         <description>Transmit on active edge of SCLK.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>inactiveEdge</name>
+         <description>Transmit on inactive edge of SCLK.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BIRQ</name>
+       <description>Baud Rate Generator Timer Interrupt Request.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STR</name>
+       <description>Start SPI Interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRQE</name>
+       <description>Interrupt Request Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>SPI Interrupt Flag Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>SLAS</name>
+       <description>Slave Select. If the SPI is in slave mode, this bit indicates if the SPI is selected. If the SPI is in master mode this bit has no meaning.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>selected</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notSelected</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXST</name>
+       <description>Transmit Status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TUND</name>
+       <description>Transmit Underrun.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>underrun</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROVR</name>
+       <description>Receive Overrun.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>overrun</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABT</name>
+       <description>Slave Mode Transaction Abort.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aborted</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>COL</name>
+       <description>Collision.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>collision</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOVR</name>
+       <description>Transmit Overrun.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>overrun</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRQ</name>
+       <description>SPI Interrupt Request.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MOD</name>
+     <description>SPI Mode Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>SSV</name>
+       <description>Slave Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lo</name>
+         <description>The SSEL pin will be driven low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hi</name>
+         <description>The SSEL pin will be driven high.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEL</name>
+       <description>Slave Select I/O.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>input</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>output</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16bits</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1bits</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2bits</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3bits</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4bits</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5bits</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6bits</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7bits</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8bits</name>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9bits</name>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10bits</name>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11bits</name>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12bits</name>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13bits</name>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14bits</name>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15bits</name>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_ALIGN</name>
+       <description>Transmit Left Justify.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lsb</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>msb</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BRG</name>
+     <description>Baud Rate Reload Value. The SPI Baud Rate register is a 16-bit reload value for the SPI Baud Rate Generator. The reload value must be greater than or equal to 0002H for proper SPI operation (maximum baud rate is PCLK frequency divided by 4).</description>
+     <addressOffset>0x14</addressOffset>
+     <resetValue>0x0000FFFF</resetValue>
+     <fields>
+      <field>
+       <name>DIV</name>
+       <description>Baud Rate Reload Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>SPI DMA Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00070007</resetValue>
+     <fields>
+      <field>
+       <name>TX_FIFO_LVL</name>
+       <description>Transmit FIFO Level. Set the number of free entries in the TxFIFO when a TxDMA request occurs.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1entries</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2entries</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3entries</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4entries</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5entries</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6entries</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7entries</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8entries</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CLR</name>
+       <description>Transmit FIFO Clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Start TX FIFO Clear operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CNT</name>
+       <description>Transmit FIFO Count.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DMA_EN</name>
+       <description>Transmit DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_LVL</name>
+       <description>Receive FIFO Level. Sets the RX FIFO DMA request threshold. This configures the number of filled RxFIFO entries before activating an RxDMA request.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <name>fifo_level_enum</name>
+        <enumeratedValue>
+         <name>1entries</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2entries</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3entries</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4entries</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5entries</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6entries</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7entries</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8entries</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CLR</name>
+       <description>Receive FIFO Clear.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Start RX FIFO clear operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CNT</name>
+       <description>Receive FIFO Count.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_DMA_EN</name>
+       <description>Receive DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>I2S_CTRL</name>
+     <description>I2S Control Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>I2S_EN</name>
+       <description>I2S Mode Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2S_MUTE</name>
+       <description>I2S Mute transmit.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Transmit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>muted</name>
+         <description>Transmit data is replaced with 0.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2S_PAUSE</name>
+       <description>I2S Pause transmit/receive.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Transmit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pause</name>
+         <description>Halt transmit and receive FIFO and DMA access, transmit 0's.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2S_MONO</name>
+       <description>I2S Monophonic Audio Mode.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>stereo</name>
+         <description>Stereophonic audio.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>mono</name>
+         <description>Monophonic audio format.Each transmit data word is replicated on both left/right channels. Receive data is taken from left channel, right channel receive data is ignored.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2S_LJ</name>
+       <description>I2S Left Justify.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lag</name>
+         <description>Normal I2S audio protocol.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>syncronized</name>
+         <description>Audio data is synchronized with SSEL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIMSS Serial Peripheral Interface.-->
+  <peripheral>
+   <name>SPIXR</name>
+   <description>SPIXR peripheral.</description>
+   <baseAddress>0x4003A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>DATA32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>DATA16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>DATA32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>DATA8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>DATA32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ctrl1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ENABLE</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MASTER</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode, Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction completes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.      </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Slave Select Control.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>deassert</name>
+         <description>SPI de-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>assert</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ctrl2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ctrl3</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>risingEdge</name>
+         <description>Data sampled on rising edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fallingEdge</name>
+         <description>Data sample on falling edge.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>inverted</name>
+         <description>Inverted clock.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLK_INV</name>
+       <description>Invert SCLK Feedback in Master Mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>SCLK is not inverted to Line Receiver.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16BITS</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1BITS</name>
+         <description>1 bits per character.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2BITS</name>
+         <description>2 bits per character.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3BITS</name>
+         <description>3 bits per character.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4BITS</name>
+         <description>4 bits per character.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5BITS</name>
+         <description>5 bits per character.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6BITS</name>
+         <description>6 bits per character.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7BITS</name>
+         <description>7 bits per character.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8BITS</name>
+         <description>8 bits per character.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9BITS</name>
+         <description>9 bits per character.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10BITS</name>
+         <description>10 bits per character.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11BITS</name>
+         <description>11 bits per character.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12BITS</name>
+         <description>12 bits per character.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13BITS</name>
+         <description>13 bits per character.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14BITS</name>
+         <description>14 bits per character.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15BITS</name>
+         <description>15 bits per character.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin (s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>4wire</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3wire</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSPOL</name>
+       <description>Slave Select Polarity</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeLow</name>
+         <description>Slave select is active low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeHigh</name>
+         <description>Slave select is active high.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SS_TIME</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SSACT1</name>
+       <description>Slave Select Action delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>SSACT2</name>
+       <description>Slave Select Action delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>SSINACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BRG_CTRL</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>SCALE</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>clk_freq = f_pclk/1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>clk_freq = f_pclk/2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>clk_freq = f_pclk/4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>clk_freq = f_pclk/8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>clk_freq = f_pclk/16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>clk_freq = f_pclk/32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>clk_freq = f_pclk/64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>clk_freq = f_pclk/128.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div256</name>
+         <description>clk_freq = f_pclk/256.</description>
+         <value>8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_FIFO_LEVEL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CLEAR</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CNT</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>TX_DMA_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_LEVEL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CLEAR</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear the Receive FIFIO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CNT</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RX_DMA_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>int_fl</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_LEVEL</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LEVEL</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>int_en</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_LEVEL</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LEVEL</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_FL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_LEVEL</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LEVEL</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_LEVEL</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LEVEL</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notActive</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>XMEM_CTRL</name>
+     <description>Register to control external memory.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>XMEM_RD_CMD</name>
+       <description>Read command.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>XMEM_WR_CMD</name>
+       <description>Write command.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>XMEM_DCLKS</name>
+       <description>Dummy clocks.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>XMEM_EN</name>
+       <description>XMEM enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>External memory disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>External memory enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXR SPIXR peripheral.-->
+  <peripheral>
+   <name>SPIXFC</name>
+   <description>SPI XiP Flash Configuration Controller</description>
+   <baseAddress>0x40027000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPIXFC</name>
+    <description>SPIXFC IRQ</description>
+    <value>38</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CFG</name>
+     <description>Configuration Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>SSEL</name>
+       <description>Slaves Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave0</name>
+         <description>Slave 0 is selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description>Defines SPI Mode, Only valid values are 0 and 3.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>mode0</name>
+         <description>SPIX Mode 0. CLK Polarity = 0, CLK Phase = 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>mode3</name>
+         <description>SPIX Mode 3. CLK Polarity = 1, CLK Phase = 1.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PGSZ</name>
+       <description>Page Size.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>4bytes</name>
+         <description>4 bytes.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8bytes</name>
+         <description>8 bytes.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16bytes</name>
+         <description>16 bytes.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>32bytes</name>
+         <description>32 bytes.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HICLK</name>
+       <description>SCLK High Clocks. Number of system clocks that SCLK will be high when SCLK pulses are generated. 0 Correspond to 16 system clocks and, all other values defines the number of system clock taht SCLK will be held high.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16CLK</name>
+         <description>16 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1CLK</name>
+         <description>1 system clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2CLK</name>
+         <description>2 system clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3CLK</name>
+         <description>3 system clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4CLK</name>
+         <description>4 system clocks.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5CLK</name>
+         <description>5 system clocks.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6CLK</name>
+         <description>6 system clocks.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7CLK</name>
+         <description>7 system clocks.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8CLK</name>
+         <description>8 system clocks.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9CLK</name>
+         <description>9 system clocks.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10CLK</name>
+         <description>10 system clocks.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11CLK</name>
+         <description>11 system clocks.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12CLK</name>
+         <description>12 system clocks.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13CLK</name>
+         <description>13 system clocks.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14CLK</name>
+         <description>14 system clocks.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15CLK</name>
+         <description>15 system clocks.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCLK</name>
+       <description>SCLK low Clocks. Number of system clocks that SCLK will be low when SCLK pulses are generated. 0 correspond to 16 system clocks and, all other values defines the number of system clock taht SCLK will be held low.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16CLK</name>
+         <description>16 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1CLK</name>
+         <description>1 system clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2CLK</name>
+         <description>2 system clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3CLK</name>
+         <description>3 system clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4CLK</name>
+         <description>4 system clocks.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5CLK</name>
+         <description>5 system clocks.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6CLK</name>
+         <description>6 system clocks.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7CLK</name>
+         <description>7 system clocks.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8CLK</name>
+         <description>8 system clocks.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9CLK</name>
+         <description>9 system clocks.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10CLK</name>
+         <description>10 system clocks.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11CLK</name>
+         <description>11 system clocks.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12CLK</name>
+         <description>12 system clocks.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13CLK</name>
+         <description>13 system clocks.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14CLK</name>
+         <description>14 system clocks.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15CLK</name>
+         <description>15 system clocks.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSACT</name>
+       <description>Slaves Select Activate Timing.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0CLK</name>
+         <description>0 sytem clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2CLK</name>
+         <description>2 sytem clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4CLK</name>
+         <description>4 sytem clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8CLK</name>
+         <description>8 sytem clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INACT</name>
+       <description>Slaves Select Inactive Timing.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>4CLK</name>
+         <description>4 sytem clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6CLK</name>
+         <description>6 sytem clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8CLK</name>
+         <description>8 sytem clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12CLK</name>
+         <description>12 sytem clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IOSMPL</name>
+       <description>Sample Delay</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>NODLY</name>
+         <description>No sample clock delay.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1CLK</name>
+         <description>1 system clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2CLK</name>
+         <description>2 system clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3CLK</name>
+         <description>3 system clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4CLK</name>
+         <description>4 system clocks.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5CLK</name>
+         <description>5 system clocks.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6CLK</name>
+         <description>6 system clocks.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7CLK</name>
+         <description>7 system clocks.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8CLK</name>
+         <description>8 system clocks.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9CLK</name>
+         <description>9 system clocks.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10CLK</name>
+         <description>10 system clocks.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11CLK</name>
+         <description>11 system clocks.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12CLK</name>
+         <description>12 system clocks.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13CLK</name>
+         <description>13 system clocks.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14CLK</name>
+         <description>14 system clocks.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15CLK</name>
+         <description>15 system clocks.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SS_POL</name>
+     <description>SPIX Controller Slave Select Polarity Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>SSPOL_0</name>
+       <description>Slave Select Polarity.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GEN_CTRL</name>
+     <description>SPIX Controller General Controller Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ENABLE</name>
+       <description>SPI Master enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable SPI Master, putting a reset state.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable SPI Master for processing transactions.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TFIFOEN</name>
+       <description>Transaction FIFO Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Transaction FIFO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Transaction FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RFIFOEN</name>
+       <description>Result FIFO Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Result FIFO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Result FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BBMODE</name>
+       <description>Bit-Bang Mode.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Bit-Bang Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Bit-Bang Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSDR</name>
+       <description>This bits reflects the state of the currently selected slave select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output0</name>
+         <description>Selected Slave select output = 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>output1</name>
+         <description>Selected Slave select output = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCKDR</name>
+       <description>SSCLK Drive and State.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>sck0</name>
+         <description>SCLK is 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sck1</name>
+         <description>SCLK is 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDATAIN</name>
+       <description>SDIO Input Data Value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BBDAT</name>
+       <description>No description available.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BBDATOEN</name>
+       <description>Bit Bang SDIO Output Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SIMPLE</name>
+       <description>Simple Mode Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Simple Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Simple Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SIMPLERX</name>
+       <description>Simple Receive Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>initSPI</name>
+         <description>Initiate SPI transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SMPLSS</name>
+       <description>Simple Mode Slave Select.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>deassertSS</name>
+         <description>Deassert Slave select when SIMPLE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCKFB</name>
+       <description>Enable SCLK Feedback Mode.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCKFBINV</name>
+       <description>SCK Invert.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>invert</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO_CTRL</name>
+     <description>SPIX Controller FIFO Control and Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>TFIFOLVL</name>
+       <description>Transaction FIFO Almost Empty Level.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TFIFOCNT</name>
+       <description>Transaction FIFO Used.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RFIFOLVL</name>
+       <description>Results FIFO Almost Full Level.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RFIFOCNT</name>
+       <description>Result FIFO Used.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SP_CTRL</name>
+     <description>SPIX Controller Special Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>SAMPL</name>
+       <description>Setting this bit to a 1 enables the ability to drive SDIO outputs prior to the assertion of Slave Select. This bit must only be set when the SPIXF bus is idle and the transaction FIFO is empty. This bit is automatically cleared by hardware after the next slave select assertion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable sample mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable sample mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDIO_OUT</name>
+       <description>SDIO Output Value Sample Mode</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDIO_OUT_EN</name>
+       <description>SDIO Output Enable Sample Mode</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCKINH3</name>
+       <description>SCLK Inhibit Mode3. In SPI Mode 3, some SPI flash read timing diagrams show the last SCLK going low prior to de-assertion. The default is to support this additional falling edge of clock. When this bit is set and the device is in SPI Mode 3, the SPI clock is held high while Slave Select is de-asserted. This is to support some SPI flash write timing diagrams.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Allow trailing SCLK low pulse prior to Slave Select de-assertion.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Inhibit trailing SCLK low pulse prior to Slave Select de-assertion.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>SPIX Controller Interrupt Status Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>TSTALL</name>
+       <description>Transaction Stalled Interrupt Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RSTALL</name>
+       <description>Results Stalled Interrupt Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TRDY</name>
+       <description>Transaction Ready Interrupt Status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDONE</name>
+       <description>Results Done Interrupt Status.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TFIFOAE</name>
+       <description>Transaction FIFO Almost Empty Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RFIFOAF</name>
+       <description>Results FIFO Almost Full Flag.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>SPIX Controller Interrupt Enable Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>TSTALLIE</name>
+       <description>Transaction Stalled Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RSTALLIE</name>
+       <description>Results Stalled Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TRDYIE</name>
+       <description>Transaction Ready Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDONEIE</name>
+       <description>Results Done Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TFIFOAEIE</name>
+       <description>Transaction FIFO Almost Empty Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RFIFOAFIE</name>
+       <description>Results FIFO Almost Full Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXFC SPI XiP Flash Configuration Controller-->
+  <peripheral>
+   <name>SPIXFC_FIFO</name>
+   <description>SPI XiP Master Controller FIFO.</description>
+   <baseAddress>0x400BC000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>TX_8</name>
+     <description>SPI TX FIFO 8-Bit Write</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <dataType>uint8_t</dataType>
+    </register>
+    <register>
+     <name>TX_16</name>
+     <description>SPI TX FIFO 16-Bit Write</description>
+     <alternateRegister>TX_8</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <dataType>uint16_t</dataType>
+    </register>
+    <register>
+     <name>TX_32</name>
+     <description>SPI TX FIFO 32-Bit Write</description>
+     <alternateRegister>TX_8</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <dataType>uint32_t</dataType>
+    </register>
+    <register>
+     <name>RX_8</name>
+     <description>SPI RX FIFO 8-Bit Access</description>
+     <addressOffset>0x04</addressOffset>
+     <size>8</size>
+     <dataType>uint8_t</dataType>
+    </register>
+    <register>
+     <name>RX_16</name>
+     <description>SPI RX FIFO 16-Bit Access</description>
+     <alternateRegister>RX_8</alternateRegister>
+     <addressOffset>0x04</addressOffset>
+     <size>16</size>
+     <dataType>uint16_t</dataType>
+    </register>
+    <register>
+     <name>RX_32</name>
+     <description>SPI RX FIFO 32-Bit Access</description>
+     <alternateRegister>RX_8</alternateRegister>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+     <dataType>uint32_t</dataType>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXFC_FIFO SPI XiP Master Controller FIFO.-->
+  <peripheral>
+   <name>SPIXF</name>
+   <description>SPIXF Master</description>
+   <baseAddress>0x40026000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CFG</name>
+     <description>SPIX Configuration Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Defines SPI Mode, Only valid values are 0 and 3.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>mode0</name>
+         <description>Description not available.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>mode3</name>
+         <description>Description not available.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSPOL</name>
+       <description>Slave Select Polarity.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Slave Select is Active High.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Slave Select is Active Low.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEL</name>
+       <description>Slave Select. Only valid value is zero.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave0</name>
+         <description>Select slave 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCLK</name>
+       <description>Number of system clocks that SCLK will be low when SCLK pulses are generated.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>HICLK</name>
+       <description>Number of system clocks that SCLK will be high when SCLK pulses are generated.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>SSACT</name>
+       <description>Slave Select Active Timing.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>off</name>
+         <description>0 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2clk</name>
+         <description>2 System clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4clk</name>
+         <description>4 System clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8clk</name>
+         <description>8 System clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSIACT</name>
+       <description>Slave Select Inactive Timing.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1clk</name>
+         <description>1 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3clk</name>
+         <description>3 System clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5clk</name>
+         <description>5 System clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9clk</name>
+         <description>9 System clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FETCH_CTRL</name>
+     <description>SPIX Fetch Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>CMDVAL</name>
+       <description>Command Value sent to target to initiate fetching from SPI flash.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>CMDWTH</name>
+       <description>Command Width. Number of data I/O used to send commands.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>mono</name>
+         <description>Single SDIO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dual</name>
+         <description>Dual SDIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>quad</name>
+         <description>Quad SDIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>invalid</name>
+         <description>Invalid.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_WIDTH</name>
+       <description>Address Width. Number of data I/O used to send address, and mode/dummy clocks.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>single</name>
+         <description>Single SDIO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dual</name>
+         <description>Dual SDIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>quad</name>
+         <description>Quad SDIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>invalid</name>
+         <description>Invalid.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>Data Width. Number of data I/O used to receive data.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>single</name>
+         <description>Single SDIO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dual</name>
+         <description>Dual SDIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>quad</name>
+         <description>Quad SDIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>invalid</name>
+         <description>Invalid.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR4</name>
+       <description>Four Byte Address Mode. Enables 4-byte Flash Address Mode.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>3byte</name>
+         <description>3 Byte Address Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4byte</name>
+         <description>4 Byte Address Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MODE_CTRL</name>
+     <description>SPIX Mode Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>MDCLK</name>
+       <description>Mode Clocks. Number of SPI clocks needed during mode/dummy phase of fetch.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>NOCMD</name>
+       <description>No Command Mode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>always</name>
+         <description>Send read command every time SPI transaction is initiated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>once</name>
+         <description>Send read command only once. NO read command in subsequent SPI transactions.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE_SEND</name>
+       <description>Mode Send.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>next</name>
+         <description>Send mode byte on next transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MODE_DATA</name>
+     <description>SPIX Mode Data Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MDDATA</name>
+       <description>Mode Data. Specifies the data to send with the Dummy/Mode clocks.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MDOE</name>
+       <description>Mode Output Enable. Output enable state for each corresponding data bit in MD_DATA. 0: output enable off, I/O is tristate and 1: Output enable on, I/O is driving MD_DATA.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FB_CTRL</name>
+     <description>SPIX Feedback Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>FBMD</name>
+       <description>Enable SCLK feedback mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable SCLK feedback mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable SCLK feedback mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FBINV</name>
+       <description>Invert SCLK in feedback mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Invert SCLK feedback mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Invert SCLK feedback mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IO_CTRL</name>
+     <description>SPIX IO Control Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>SCK_DS</name>
+       <description>SCLK drive Strength. This bit controls the drive strength on the SCLK pin.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Low</name>
+         <description>Low drive strength.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>High</name>
+         <description>High drive strength.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_DS</name>
+       <description>Slave Select Drive Strength. This bit controls the drive strength on the dedicated slave select pin.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Low</name>
+         <description>Low drive strength.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>High</name>
+         <description>High drive strength.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDIO_DS</name>
+       <description>SDIO Drive Strength. This bit controls the drive strength of all SDIO pins.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Low</name>
+         <description>Low drive strength.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>High</name>
+         <description>High drive strength.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PUPDCTRL</name>
+       <description>IO Pullup/Pulldown Control. These bits control the pullups and pulldowns associated with all SPI XiP SDIO pins.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>tri_state</name>
+         <description>Tristate.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pull_Up</name>
+         <description>Pull-Up.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pull_down</name>
+         <description>Pull-Down.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SEC_CTRL</name>
+     <description>SPIX Memory Security Control Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>DEC_EN</name>
+       <description>Decryption Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable decryption of SPIX data.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable decryption of SPIX data.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTH_DISABLE</name>
+       <description>Integrity Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Integrity checking enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Integrity checking disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUS_IDLE</name>
+     <description>Bus Idle</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>BUSIDLE</name>
+       <description>A 16-bit timer will be triggered for each external access. The timer will be restarted if another access is performed before the timer expires. When the timer expires, slave select will be deactivated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXF SPIXF Master-->
+  <peripheral>
+   <name>BBFC</name>
+   <description>Battery Backed Function Control Register.</description>
+   <baseAddress>0x40058000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>BBFCR0</name>
+     <description>Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CKPDRV</name>
+       <description>Hyperbus CK Drive Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CKNPDRV</name>
+       <description>Hyperbus CKN Drive Setting.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RDSDLLEN</name>
+       <description>Hyperbus RDS DLL Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--BBFC Battery Backed Function Control Register.-->
+  <peripheral>
+   <name>NBBFC</name>
+   <description>Non Battery-Backed Function Control Register.</description>
+   <baseAddress>0x40000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>REG0</name>
+     <description>Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RDSGCSEL</name>
+       <description>Hyperbus RDS Gray Code Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RDSGCSET</name>
+       <description>Hyperbus RDS Set.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>internal</name>
+         <description>Select internal setting.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>gray_code</name>
+         <description>Select gray code.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HYPCGDLY</name>
+       <description>Hyperbus Clock Generator Delay.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>USBRCKSEL</name>
+       <description>USB Reference Clock Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>sys</name>
+         <description>Generated clock from system clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dig</name>
+         <description>Digital clock from a GPIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>QSPI0SEL</name>
+       <description>QSPI0 Function Select.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>med</name>
+         <description>Select SPI Medical functions.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>qspi0</name>
+         <description>Select QSPI0 function.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0DGEN0</name>
+       <description>I2C0 SDA Glitch Filter Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0DGEN1</name>
+       <description>I2C0 SCL Glitch Filter Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN0</name>
+       <description>I2C1 SDA Glitch Filter Enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN1</name>
+       <description>I2C1 SCL Glitch Filter Enable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REG1</name>
+     <description>Register 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ACEN</name>
+       <description>Auto-calibration Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACRUN</name>
+       <description>Autocalibration Run.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDTRM</name>
+       <description>Load Trim.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GAININV</name>
+       <description>Invert Gain.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ATOMIC</name>
+       <description>Atomic mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MU</name>
+       <description>MU value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REG2</name>
+     <description>Register 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INTTRIM</name>
+       <description>Initial Trim Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>MINTRM</name>
+       <description>Minimum Trim Setting.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>MAXTRM</name>
+       <description>Maximum Trim Setting.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REG3</name>
+     <description>Register 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONECNT</name>
+       <description>Automatic Calibration Done Counter Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--NBBFC Non Battery-Backed Function Control Register.-->
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x40000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SCON</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>BSTAPEN</name>
+       <description>Boundary Scan TAP enable. When enabled, the JTAG port is connected to the Boundary Scan TAP. Otherwise, the port is connected to the ARM ICE function. This bit is reset by the POR. Reset value and access depend on the part number.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Boundary Scan TAP port disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Boundary Scan TAP port enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLASH_PAGE_FLIP</name>
+       <description>Flips the Flash bottom and top halves. (Depending on the total flash size, each half is either 256K or 512K). Initiating a flash page flip will cause a flush of both the data buffer on the DCODE bus and the internal instruction buffer.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Physical layout matches logical layout.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flipped</name>
+         <description>Bottom half mapped to logical top half and vice versa.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CCACHE_FLUSH</name>
+       <description>Code Cache Flush. This bit is used to flush the code caches and the instruction buffer of the Cortex-M4. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DCACHE_FLUSH</name>
+       <description>Write 1 to flush the external memory controller's 16KB cache. This bit is automatically cleared to 0 when the flush is complete.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal External Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>External cache being flushed.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DCACHE_DIS</name>
+       <description>Disable EMCC used for SPIXR or HyperBus/Xccela Bus code and data cache. </description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>enabled</name>
+         <description>EMCC enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>disabled</name>
+         <description>EMCC disabled and line buffer bypassed. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CCHK</name>
+       <description>Compute ROM Checksum. This bit is self-cleared when calculation is completed. Once set, software clearing this bit is ignored and the bit will remain set until the operation is completed.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CHKRES</name>
+       <description>ROM Checksum Result. This bit is only valid when CHKRD=1.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pass</name>
+         <description>ROM Checksum Correct.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fail</name>
+         <description>ROM Checksum Fail.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OVR</name>
+       <description>These bits select the operating voltage range.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0v9</name>
+         <description>0.9V +/- 10%.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1V</name>
+         <description>1.0V +/- 10%.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1V1</name>
+         <description>1.1V +/- 10%.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>WDT0</name>
+       <description>Watchdog Timer Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO1</name>
+       <description>GPIO1 Reset. Setting this bit to 1 resets GPIO1 pins to their default states.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO2</name>
+       <description>GPIO2 Reset. Setting this bit to 1 resets GPIO2 pins to their default states.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TIMER0</name>
+       <description>Timer0 Reset. Setting this bit to 1 resets Timer 0 blocks.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TIMER1</name>
+       <description>Timer1 Reset. Setting this bit to 1 resets Timer 1 blocks.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TIMER2</name>
+       <description>Timer2 Reset. Setting this bit to 1 resets Timer 2 blocks.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TIMER3</name>
+       <description>Timer3 Reset. Setting this bit to 1 resets Timer 3 blocks.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TIMER4</name>
+       <description>Timer4 Reset. Setting this bit to 1 resets Timer 4 blocks.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TIMER5</name>
+       <description>Timer5 Reset. Setting this bit to 1 resets Timer 5 blocks.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART0</name>
+       <description>UART0 Reset. Setting this bit to 1 resets all UART 0 blocks.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART1</name>
+       <description>UART1 Reset. Setting this bit to 1 resets all UART 1 blocks.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI0</name>
+       <description>SPI0 Reset. Setting this bit to 1 resets all SPI 0 blocks.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI1</name>
+       <description>SPI1 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI2</name>
+       <description>SPI2 Reset. Setting this bit to 1 resets all SPI 2 blocks.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>I2C0</name>
+       <description>I2C0 Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>RTC</name>
+       <description>RTC Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TPU</name>
+       <description>Trust Protection Unit Reset. Setting this bit to 1 resets the AES block, the SHA block and the DES block.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>HBC</name>
+       <description>HyperBus/Xccela controller reset.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TFT</name>
+       <description>TFT controller reset.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>USB</name>
+       <description>USB Reset.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>ADC</name>
+       <description>Analog to Digital converter reset.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART2</name>
+       <description>UART 2 reset.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SOFT</name>
+       <description>Soft Reset. Setting this bit to 1 resets everything except the CPU and the watchdog timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>PERIPH</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SYS</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_CTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>SYSCLK_PRESCALE</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the PLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSOSC_SEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CRYPTO</name>
+         <description>Internal Primary Oscilatior Clock</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HFXIN</name>
+         <description>24MHz Internal Oscillator is used for the system clock.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>NANORING</name>
+         <description>8kHz Internal Nano Ring Oscillator is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HIRC96</name>
+         <description>120 MHz Internal Oscillator.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HIRC8</name>
+         <description>Internal 7.3728MHz oscillator.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>X32K</name>
+         <description>External 32KHz oscillator.</description>
+         <value>6</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSOSC_RDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CCD</name>
+       <description>Cryptographic clock divider</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>non_div</name>
+         <description>The cryptographic accelerator clock is running in non-divided mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div</name>
+         <description>The cryptographic accelerator clock is running in divided mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>X32K_EN</name>
+       <description>32KHz External Clock Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="X32K_EN">
+       <name>CRYPTO_EN</name>
+       <description>50MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="X32K_EN">
+       <name>HIRC96_EN</name>
+       <description>120MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="X32K_EN">
+       <name>HIRC8_EN</name>
+       <description>7.3728MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HIRC8_VS</name>
+       <description>7.3728MHz Internal Oscillator Voltage Source Select</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>X32K_RDY</name>
+       <description>32KHz External Oscillator Ready.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="X32K_RDY">
+       <name>CRYPTO_RDY</name>
+       <description>50MHz Internal Oscillator Ready.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="X32K_RDY">
+       <name>HIRC96_RDY</name>
+       <description>120MHz Internal Oscillator Ready.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="X32K_RDY">
+       <name>HIRC8_RDY</name>
+       <description>7.3728MHz Internal Oscillator Ready.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="X32K_RDY">
+       <name>NANORING_RDY</name>
+       <description>Internal Nano Ring Oscillator Low Frequency Reference Clock Ready.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PMR</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This two bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>backup</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIOWKEN</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RTCWKEN</name>
+       <description>RTC Wake Up Enable. This bit enables an RTC alarm to wake the device from any low-power mode to ACTIVE mode.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>USBWKEN</name>
+       <description>USB Wake Up Enable. This enables a USB wakeup event to cause the device to exit from all low power modes into ACTIVE mode.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRYPTOPD</name>
+       <description>Crypto Oscilator Power Down. This bit selects whether the oscillator is automatically powered down when the device transitions to DEEPSLEEP mode. </description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HIRC96PD</name>
+       <description>120MHz Internal Oscillator power down. This bit selects whether the oscillator is automatically powered down when the device transitions to DEEPSLEEP mode. </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HIRC8PD</name>
+       <description>7.3728MHz Internal Oscillator power down. This bit selects whether the oscillator is automatically powered down when the device transitions to DEEPSLEEP mode. </description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLK_DIV</name>
+     <description>Peripheral Clock Divider.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>SDHCFRQ</name>
+       <description>This bit selects the frequency of the SDHC clock. If set, the clock oscillates at 50Mhz, otherwise it will oscillate at 60MHz.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>60M</name>
+         <description>SDHC Freq = 120MHz/2.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>50M</name>
+         <description>SDHC Freq = 50Mhz.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADCFRQ</name>
+       <description>ADC Clock divider. ADC Clock Frequency = Periph_Clock/adcfrq. Values 0 and 1 invalid.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>ADC Freq = Periph_Clock/2.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div3</name>
+         <description>ADC Freq = Periph_Clock/3.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>ADC Freq = Periph_Clock/4.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div5</name>
+         <description>ADC Freq = Periph_Clock/5.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div6</name>
+         <description>ADC Freq = Periph_Clock/6.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div7</name>
+         <description>ADC Freq = Periph_Clock/7.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>ADC Freq = Periph_Clock/8.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div9</name>
+         <description>ADC Freq = Periph_Clock/9.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div10</name>
+         <description>ADC Freq = Periph_Clock/10.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div11</name>
+         <description>ADC Freq = Periph_Clock/11.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div12</name>
+         <description>ADC Freq = Periph_Clock/12.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div13</name>
+         <description>ADC Freq = Periph_Clock/13.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div14</name>
+         <description>ADC Freq = Periph_Clock/14.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div15</name>
+         <description>ADC Freq = Periph_Clock/15.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AONDIV</name>
+       <description>Always-ON (AON) domain CLock Divider. These bits define the AON domain clock divider.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>PCLK divide by 4.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>PCLK divide by 8.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>PCLK divide by 16.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>PCLK divide by 32.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLK_DIS0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0</name>
+       <description>GPIO0 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO1</name>
+       <description>GPIO1 Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO2</name>
+       <description>GPIO2 Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USB</name>
+       <description>USB Disable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TFT</name>
+       <description>TFT Disable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SPI0</name>
+       <description>SPI 0 Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SPI1</name>
+       <description>SPI 1 Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SPI2</name>
+       <description>SPI 2 Disable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>UART0</name>
+       <description>UART 0 Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>UART1</name>
+       <description>UART 1 Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0</name>
+       <description>I2C 0 Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TPU</name>
+       <description>Trust Protection Unit Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TIMER0</name>
+       <description>Timer 0 Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TIMER1</name>
+       <description>Timer 1 Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TIMER2</name>
+       <description>Timer 2 Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TIMER3</name>
+       <description>Timer 3 Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TIMER4</name>
+       <description>Timer 4 Disable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TIMER5</name>
+       <description>Timer 5 Disable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADC</name>
+       <description>ADC Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1</name>
+       <description>I2C 1 Disable.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PT</name>
+       <description>Pulse Train Engine Disable.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SPIXIPF</name>
+       <description>SPI-XIPF Disable.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SPIXIPM</name>
+       <description>XSPI Master Clock Disable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEM_CLK</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM0LS</name>
+       <description>System RAM 0 Light Sleep Mode. Write 1 to put RAM0 in light sleep power mode.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM1LS</name>
+       <description>System RAM 1 Light Sleep Mode. Write 1 to put RAM1 in light sleep power mode.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM2LS</name>
+       <description>System RAM 2 Light Sleep Mode. Write 1 to put RAM2 in light sleep power mode.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM3LS</name>
+       <description>System RAM 3 Light Sleep Mode. Write 1 to put RAM3 in light sleep power mode.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM4LS</name>
+       <description>System RAM 4 Light Sleep Mode. Write 1 to put RAM4 in light sleep power mode.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM5LS</name>
+       <description>System RAM 4 Light Sleep Mode. Write 1 to put RAM5 in light sleep power mode.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM6LS</name>
+       <description>System RAM 4 Light Sleep Mode. Write 1 to put RAM6 in light sleep power mode.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHELS</name>
+       <description>ICache RAM Light Sleep Mode.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHEXIPLS</name>
+       <description>SPI-XIPF Instruction Cache RAM Light Sleep Mode.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCACHELS</name>
+       <description>Internal RAM Cache Light Sleep Mode.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRYPTOLS</name>
+       <description>Crypto RAM Light Sleep Mode.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USBLS</name>
+       <description>USB FIFO Light Sleep Mode.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROMLS</name>
+       <description>ROM Light Sleep Mode.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEM_ZERO</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>SRAM0Z</name>
+       <description>System RAM Block 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM1Z</name>
+       <description>System RAM Block 1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM2Z</name>
+       <description>System RAM Block 2.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM3Z</name>
+       <description>System RAM Block 3.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM4Z</name>
+       <description>System RAM Block 4.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM5Z</name>
+       <description>System RAM Block 5.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM6Z</name>
+       <description>System RAM Block 6.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHEZ</name>
+       <description>Instruction Cache (ICC0) zeroization.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHEXIPZ</name>
+       <description>SPI-XIPF Instruction Cache (ICC1) zeroization.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCACHEDATAZ</name>
+       <description>EMCC data zeroization.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCACHETAGZ</name>
+       <description>EMCC tag zeroization.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRYPTOZ</name>
+       <description>Crypto MAA Memory zeroization.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USBFIFOZ</name>
+       <description>USB FIFO zeroization.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYS_STAT</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICELOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CODEINTERR</name>
+       <description>Flash SPI-XIPF Code Integrity Error Status Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noerr</name>
+         <description> .</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>err</name>
+         <description>SPI-XIPF code integrity error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCMEMF</name>
+       <description>HyperBus/Xccela Cache Memory Error Status Flag.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noerr</name>
+         <description>Normal operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>memfault</name>
+         <description>HyperBus/Xccela cahce memory fault.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>I2C1</name>
+       <description>I2C1 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>PT</name>
+       <description>Pulse Train Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPIXIP</name>
+       <description>SPI-XIPF Reset.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>XSPIM</name>
+       <description>XSPI Master Reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>GPIO3</name>
+       <description>GPIO3 Reset.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SDHC</name>
+       <description>SDHC Reset.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>OWIRE</name>
+       <description>One-Wire Reset.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>WDT1</name>
+       <description>WDT1 Reset.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPI3</name>
+       <description>SPI3 Reset.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2S</name>
+       <description>I2S (SPIMSS) Reset.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>XIPR</name>
+       <description>SPIXR Reset.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SEMA</name>
+       <description>Semaphore Block Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLK_DIS1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>UART2</name>
+       <description>UART2 Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TRNG</name>
+       <description>TRNG Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SFLC</name>
+       <description>Secore Flash Controller Clock Disable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HBC</name>
+       <description>HyperBus/Xccela Clock Disable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO3</name>
+       <description>GPIO3 Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCACHE</name>
+       <description>System Cache Clock Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDMA</name>
+       <description>Smart DMA Clock Disable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SEMA</name>
+       <description>Semaphore Block Clock Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDHC</name>
+       <description>SDHC Controller Clock Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHE</name>
+       <description>Flash Instruction Cache Clock Disable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHEXIPF</name>
+       <description>SPI-XIPF Flash Clock Disable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OW</name>
+       <description>One-Wire Clock Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SPI3</name>
+       <description>SPI3 Clock Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2S</name>
+       <description>I2S (SPIMSS) Clock Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SPIXIPR</name>
+       <description>SPIXR RAM Clock Disable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVENT_EN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>DMAEVENT</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>DMA CTZ Event will not wake up the device.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>DMA CTZ Event Wake-up Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXEVENT</name>
+       <description>Enable RXEV pin event. When this bit is set, a logic high of GPIO0[24] will cause an RXEV event to wake the CPU from WFE sleep mode. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>A receive event is not generated when an external input transitions from low to high.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>A receive event is generated when external event is triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXEVENT</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO[25].</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit event disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>A transmit event is enabled on Send Event instruction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REV</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYS_STAT_IE</name>
+     <description>System Status Interrupt Enable Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEULIE</name>
+       <description>ARM ICE Unlock Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CIEIE</name>
+       <description>SPI-XIPF Code Intergrity Error Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCMFIE</name>
+       <description>HyperBus/Xccela Cache Memory Fault Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCR Global Control Registers.-->
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x40000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SISTAT</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>MAGIC</name>
+       <description>Magic Word Validation.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>magicNotSet</name>
+         <description>Magic word was not set (OTP has not been initialized properly).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>magicSet</name>
+         <description>Magic word was set (OTP contains valid settings).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRCERR</name>
+       <description>CRC Error Status.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No CRC errors occurred during the read of the OTP memory block.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>A CRC error occurred while reading the OTP. The address of the failure location in the OTP memory is stored in the ERRADDR register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ERRADDR</name>
+     <description>Read-only field set by the SIB block if a CRC error occurs during the read of the OTP memory. Contains the failing address in OTP memory (when CRCERR equals 1).</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ERRADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FSTAT</name>
+     <description>funcstat register.</description>
+     <addressOffset>0x100</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>FPU</name>
+       <description>FPU Function.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USB</name>
+       <description>USB Device.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADC</name>
+       <description>10-bit Sigma Delta ADC.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>XIP</name>
+       <description>XiP function.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PBM</name>
+       <description>Pixel Bit Manipulator Function.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HBC</name>
+       <description>Hyperbus Control Function.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDHC</name>
+       <description>SDHC function.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SMPHR</name>
+       <description>SMPHR function.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCACHE</name>
+       <description>SRCC function.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFSTAT</name>
+     <description>secfuncstat register.</description>
+     <addressOffset>0x104</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TRNG</name>
+       <description>TRNG function.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AES</name>
+       <description>AES function.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHA</name>
+       <description>SHA function.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MAA</name>
+       <description>MAA function.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIR System Initialization Registers.-->
+  <peripheral>
+   <name>TRIMSIR</name>
+   <description>Trim System Initilazation Registers</description>
+   <baseAddress>0x40054000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>rsv0</name>
+     <description>RFU</description>
+     <addressOffset>0x00</addressOffset>
+    </register>
+    <register>
+     <name>BB_SIR2</name>
+     <description>System Init. Configuration Register 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>BB_SIR3</name>
+     <description>System Init. Configuration Register 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRIMSIR Trim System Initilazation Registers-->
+  <peripheral>
+   <name>TMR0</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting.</description>
+   <groupName>Timers</groupName>
+   <baseAddress>0x40010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR0</name>
+    <description>TMR0 IRQ</description>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Count.  This register stores the current timer count.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Current count on the timer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Compare.  This register stores the compare value, which is used to set the maximum count value to initiate a reload of the timer to 0x0001.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x0000FFFF</resetValue>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>Timer compare value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>PWM.  This register stores the value that is compared to the current timer count.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>PWM</name>
+       <description>Timer PWM match value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Clear Interrupt. Writing a value (0 or 1) to a bit in this register clears the associated interrupt.</description>
+     <addressOffset>0x0C</addressOffset>
+     <modifiedWriteValues>oneToClear</modifiedWriteValues>
+     <fields>
+      <field>
+       <name>IRQ</name>
+       <description>Clear Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CN</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>TMODE</name>
+       <description>Timer Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>oneshot</name>
+         <description>One Shot Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Continuous Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>counter</name>
+         <description>Counter Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pwm</name>
+         <description>PWM Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>capture</name>
+         <description>Capture Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>compare</name>
+         <description>Compare Mode.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>gated</name>
+         <description>Gated Mode.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>capturecompare</name>
+         <description>Capture/Compare Mode.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES</name>
+       <description>Prescaler.  Set the Timer's prescaler value. The prescaler divides the PCLK input to the timer and sets the Timer's Count Clock, F_CNT_CLK = PCLK (HZ) /prescaler. The Timer's prescaler setting is a 4-bit value with pres3:pres[2:0].</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div256</name>
+         <description>Divide by 256. Additionally, TMRn-&gt;cn.pres3 must be set.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div512</name>
+         <description>Divide by 512. Additionally, TMRn-&gt;cn.pres3 must be set.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div1024</name>
+         <description>Divide by 1024. Additionally, TMRn-&gt;cn.pres3 must be set.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2048</name>
+         <description>Divide by 2048. Additionally, TMRn-&gt;cn.pres3 must be set.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4096</name>
+         <description>Divide by 4096. Additionally, TMRn-&gt;cn.pres3 must be set.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TPOL</name>
+       <description>Timer input/output polarity bit.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TEN</name>
+       <description>Timer Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES3</name>
+       <description>MSB of prescaler value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div256</name>
+         <description>Divide by 256. Additionally, TMRn-&gt;cn.pres3 must be set.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div512</name>
+         <description>Divide by 512. Additionally, TMRn-&gt;cn.pres3 must be set.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div1024</name>
+         <description>Divide by 1024. Additionally, TMRn-&gt;cn.pres3 must be set.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2048</name>
+         <description>Divide by 2048. Additionally, TMRn-&gt;cn.pres3 must be set.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4096</name>
+         <description>Divide by 4096. Additionally, TMRn-&gt;cn.pres3 must be set.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PWMSYNC</name>
+       <description>Timer PWM Synchronization Mode Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NOLHPOL</name>
+       <description>Timer PWM output 0A polarity bit.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal output polarity.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>invert</name>
+         <description>Inverted output polarity.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NOLLPOL</name>
+       <description>Timer PWM output 0A' polarity bit.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal output polarity.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>invert</name>
+         <description>Inverted output polarity.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PWMCKBD</name>
+       <description>Timer PWM output 0A Mode Disable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>NOLLCMP</name>
+       <description>Non-overlapping Low Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A and next rising edge of PWM output 0A'.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>NOLHCMP</name>
+       <description>Non-overlapping High Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A' and next rising edge of PWM output 0A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TMR0 32-bit reloadable timer that can be used for timing and event counting.-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR1</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 1</description>
+   <baseAddress>0x40011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+<!--TMR1 32-bit reloadable timer that can be used for timing and event counting. 1-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR2</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 2</description>
+   <baseAddress>0x40012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+<!--TMR2 32-bit reloadable timer that can be used for timing and event counting. 2-->
+  <peripheral>
+   <name>TPU</name>
+   <description>The Trust Protection Unit used to assist the computationally intensive operations of several common cryptographic algorithms.</description>
+   <baseAddress>0x40001000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Crypto_Engine</name>
+    <description>Crypto Engine interrupt.</description>
+    <value>27</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CRYPTO_CTRL</name>
+     <description>Crypto Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0xC0000000</resetValue>
+     <fields>
+      <field>
+       <name>RST</name>
+       <description>Reset. This bit is used to reset the crypto accelerator.  All crypto internal states and related registers are reset to their default reset values. Control register such as CRYPTO_CTRL, CIPHER_CTRL, HASH_CTRL, CRC_CTRL, MAA_CTRL (with the exception of the STC bit), HASH_MSG_SZ_[3:0] and MAA_MAWS will retain their values. This bit will automatically clear itself after one cycle.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_write</name>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>Starts reset operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT</name>
+       <description>Interrupt Enable. Generates an interrupt when done or error set.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRC</name>
+       <description>Source Select.  This bit selects the hash function and CRC generator input source.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inputFIFO</name>
+         <description>Input FIFO</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputFIFO</name>
+         <description>Output FIFO</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BSO</name>
+       <description>Byte Swap Output. Note. No byte swap will occur if there is not a full word.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BSI</name>
+       <description>Byte Swap Input. Note. No byte swap will occur if there is not a full word.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WAIT_EN</name>
+       <description>Wait Pin Enable. This can be used to hold off the crypto DMA until an external memory is ready. This is useful for transferring pages from NAND flash which may take several microseconds to become ready.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WAIT_POL</name>
+       <description>Wait Pin Polarity. When the wait pin is enabled, this bit selects its active state.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRSRC</name>
+       <description>Write FIFO Source Select. This field determines where data written to the write FIFO comes from. When data is written to the write FIFO, it is always written out the DMA. To decrypt or encrypt data, the write FIFO source should be set to the cipher output. To implement memcpy() or memset() functions, or to fill memory with random data, the write FIFO source should be set to the read FIFO. When calculating a HASH or CMAC, the write FIFO should be disabled.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>none</name>
+         <description>None.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cipherOutput</name>
+         <description>Cipher Output.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>readFIFO</name>
+         <description>Read FIFO.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDSRC</name>
+       <description>Read FIFO Source Select. This field selects the source of the read FIFO. Typically, it is set to use the DMA. To implement a memset() function, the read FIFO DMA should be disabled. To fill memory with random data or to hash random numbers, the read FIFO source should be set to the random number generator.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dmaDisabled</name>
+         <description>DMA Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dmaOrApb</name>
+         <description>DMA Or APB.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rng</name>
+         <description>RNG.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLAG_MODE</name>
+       <description>Done Flag Mode. This bit configures the access behavior of the individual CRYPTO_CTRL Done flags (CRYPTO_CTRL[27:24]). This bit is cleared only on reset to limit upkeep, i.e. once set, it will remain set until a reset occurs.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unres_wr</name>
+         <description>Unrestricted write (0 or 1) of CRYPTO_CTRL[27:24] flags.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>res_wr</name>
+         <description>Access to CRYPTO_CTRL[27:24] are write 1 to clear/write 0 no effect.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMADNEMSK</name>
+       <description>DMA Done Flag Mask. This bit masks the DMA_DONE flag from being used to generate the CRYPTO_CTRL.DONE flag, and this disables a DMA_DONE condition from generating and interrupt. The DMA_DONE flag itself is unaffected and still may be monitored. This allows more optimal interrupt-driven crypto operations using DMA.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_used</name>
+         <description>DMA_DONE not used in setting CRYPTO_CTRL.DONE bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>used</name>
+         <description>DMA_DONE used in setting CRYPTO_CTRL.DONE bit.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMA_DONE</name>
+       <description>DMA Done. DMA write/read operation is complete. This bit must be cleared before starting a DMA operation.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notDone</name>
+         <description>Not Done.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>done</name>
+         <description>Done.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GLS_DONE</name>
+       <description>Galois Done. FIFO is full and CRC or Hamming Code Generator is enabled. This bit must be cleared before starting a CRC operation Note that DMA_DONE must be polled instead of this bit to determine the end of DMA operation during the utilization of Hamming Code Generator.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notDone</name>
+         <description>Not Done.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>done</name>
+         <description>Done.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HSH_DONE</name>
+       <description>Hash Done. SHA operation is complete. This bit must be cleared before starting a HASH operation.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notDone</name>
+         <description>Not Done.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>done</name>
+         <description>Done.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CPH_DONE</name>
+       <description>Cipher Done. Either AES or DES encryption/decryption operation is complete. This bit must be cleared before starting a cipher operation.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notDone</name>
+         <description>Not Done.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>done</name>
+         <description>Done.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MAA_DONE</name>
+       <description>MAA Done. MAA operation is complete. This bit must be cleared before starting a new MAA operation. This bit is read only while the MAA is in progress. This bit is negate of MAA_CTRL.STC.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notDone</name>
+         <description>Not Done.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>done</name>
+         <description>Done.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERR</name>
+       <description>AHB Bus Error. This bit is set when the DMA encounters a bus error during a read or write operation. Once this bit is set, the DMA will stop. This bit can only be cleared by resetting the crypto block.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Ready. Crypto block ready for more data.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONE</name>
+       <description>Done. One or more cryptographic calculations complete (logical OR of done flags).</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notDone</name>
+         <description>Not Done.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>done</name>
+         <description>Done.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CIPHER_CTRL</name>
+     <description>Cipher Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ENC</name>
+       <description>Encrypt. Select encryption or decryption of input data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>encrypt</name>
+         <description>Encrypt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>decrypt</name>
+         <description>Decrypt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEY</name>
+       <description>Load Key from crypto DMA. This bit is automatically cleared by hardware after the DMA has completed loading the key. When the DMA operation is done, it sets the appropriate crypto DMA Done flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRC</name>
+       <description>Source of Random key.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>cipherKey</name>
+         <description>User cipher key (0x4000_1060).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>regFile</name>
+         <description>Key from battery-backed register file (0x4000_5000 to 0x4000_501F).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>qspiKey_regFile</name>
+         <description>Key from battery-backed register file (0x4000_5020 to 0x4000_502F).</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CIPHER</name>
+       <description>Cipher Operation Select.  Symmetric Block Cipher algorithm selection or memory operation.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes128</name>
+         <description>AES 128.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes192</name>
+         <description>AES 192.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes256</name>
+         <description>AES 256.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>des</name>
+         <description>DES.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>tdea</name>
+         <description>Triple DES.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description>Mode Select. Mode of operation for block cipher or memory operation. DES/TDES cannot be used in CFB, OFB or CTR modes.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ECB</name>
+         <description>ECB Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CBC</name>
+         <description>CBC Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CFB</name>
+         <description>CFB (AES only).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>OFB</name>
+         <description>OFB (AES only).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CTR</name>
+         <description>CTR (AES only).</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HASH_CTRL</name>
+     <description>HASH Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>INIT</name>
+       <description>Initialize. Initializes hash registers with standard constants.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>XOR</name>
+       <description>XOR data with IV from cipher block. Useful when calculating HMAC to XOR the input pad and output pad.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HASH</name>
+       <description>Hash function selection.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha1</name>
+         <description>SHA-1.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha224</name>
+         <description>SHA 224.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha256</name>
+         <description>SHA 256.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha384</name>
+         <description>SHA 384.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha512</name>
+         <description>SHA 512.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LAST</name>
+       <description>Last Message Bit. This bit shall be set along with the HASH_MSG_SZ register prior to hashing the last 512 or 1024-bit block of the message data. It will allow automatic preprocessing of the last message padding, which includes the trailing bit 1, followed by the respective number of zero bits for the last block size and finally the message length represented in bytes. The bit will be automatically cleared at the same time the HASH DONE is set, designating the completion of the last message hash.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEffect</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>lastMsgData</name>
+         <description>Last Message Data.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_CTRL</name>
+     <description>CRC Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>CRC_EN</name>
+       <description>Cyclic Redundancy Check Enable. The CRC cannot be enabled if the PRNG is enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MSB</name>
+       <description>MSB select. This bit selects the order of calculating CRC on data.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lsbFirst</name>
+         <description>LSB First.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>msbFirst</name>
+         <description>MSB First.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRNG</name>
+       <description>Pseudo Random Number Generator Enable. If entropy is disabled, this outputs one byte of pseudo random data per clock cycle. If entropy is enabled, data is output at a rate of one bit per clock cycle.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ENT</name>
+       <description>Entropy Enable. If the PRNG is enabled, this mixes the high frequency ring oscillator with the LFSR. If the PRNG is disabled, the raw entropy data is output at a rate of 1 bit per clock. This makes it possible to characterize the quality of the entropy source.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HAM</name>
+       <description>Hamming Code Enable. Enable hamming code calculation.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HRST</name>
+       <description>Hamming Reset. Reset Hamming code ECC generator for next block.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+       <enumeratedValues>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>Starts reset operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_SRC</name>
+     <description>Crypto DMA Source Address.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>DMA Source Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_DEST</name>
+     <description>Crypto DMA Destination Address.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>DMA Destination Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_CNT</name>
+     <description>Crypto DMA Byte Count.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>DMA Byte Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAA_CTRL</name>
+     <description>MAA Control Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>STC</name>
+       <description>Start Calculation. This bit functions as both the control and the status of the MAA. If the size value in the MAWS register is invalid, the STC bit will be cleared by hardware immediately.  Otherwise, the STC bit is automatically cleared following the completion of each calculation or detecting an error. Clearing the STC bit resets the controller to its default state.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLC</name>
+       <description>Calculation Configuration. These bits select desired calculation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>exp</name>
+         <description>Exponentiation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sq</name>
+         <description>Square operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>mult</name>
+         <description>Multiplication.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sq_mult</name>
+         <description>Square followed by a multiplication.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>add</name>
+         <description>Addition.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sub</name>
+         <description>Subtraction.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OCALC</name>
+       <description>Optimized Calculation Control.  For optimized calculation, unnecessary multiply operations after normalizing the exponent are skipped.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>none</name>
+         <description>No optimization.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>optimize</name>
+         <description>Optimize calculation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MAAER</name>
+       <description>MAA Error. The MAAER bit defaults to 0 and can only be set by hardware. Once set, it must be cleared by software otherwise no new operation can be initiated.  Software writes 1 to this bit has no effect and MAAER will maintain its original state.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AMS</name>
+       <description>Multiplier A Memory Select.  These bits select the starting position of the parameter 'a' within the logical segment specified by AMA.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>BMS</name>
+       <description>Multiplicand B Memory Select.  These bits select the starting position of the parameter 'b' within the logical segment specified by BMA.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>EMS</name>
+       <description>Exponent Memory Select.  These bits select the starting position of the parameter 'e' within the logical segment specified by EMA.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>MMS</name>
+       <description>Modulus Memory Select.  These bits select the starting position of the parameter 'm' within the logical segment 5.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>AMA</name>
+       <description>Multiplier / Operand A Memory Assignment. These bits select the logical cryptographic RAM segment for the parameter 'a'.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>BMA</name>
+       <description>Multiplicand / Operand B Memory Assignment. These bits select the logical cryptographic RAM segment for the parameter 'b'.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RMA</name>
+       <description>Result Memory Assignment. These bits select the logical cryptographic RAM segment for the parameter 'r'.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TMA</name>
+       <description>Temporary Memory Assignment. These bits select the logical cryptographic RAM segment for the parameter 't'.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CRYPTO_DIN[%s]</name>
+     <description>Crypto Data Input. Data input can be written to this register instead of using the DMA. This register writes to the FIFO. This register occupies four successive words to allow the use of multi-store instructions. Words can be written to any location, they will be placed in the FIFO in the order they are written. The endian swap input control bit affects this register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Crypto Data Input. Input can be written to this register instead of using DMA.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CRYPTO_DOUT[%s]</name>
+     <description>Crypto Data Output. Resulting data from cipher calculation. Data is placed in the lower words of these four registers depending on the algorithm. For block cipher modes, this register holds the result of most recent encryption or decryption operation. These registers are affected by the endian swap bits.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Crypto Data Output. Resulting data from cipher calculation. Data is placed in the lower words of these four registers depending on algorithm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_POLY</name>
+     <description>CRC Polynomial. The polynomial to be used for Galois Field calculations (CRC or LFSR) should be written to this register. This register is affected by the MSB control bit.</description>
+     <addressOffset>0x40</addressOffset>
+     <resetValue>0xEDB88320</resetValue>
+     <fields>
+      <field>
+       <name>POLY</name>
+       <description>CRC Polynomial. The polynomial to be used for Galois Field calculations (CRC or LFSR) should be written to this register. This register is affected by the MSB control bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_VAL</name>
+     <description>CRC Value. This is the state for the Galois Field. This register holds the result of a CRC calculation or the current state of the LFSR. This register is affected by the MSB control bit.</description>
+     <addressOffset>0x44</addressOffset>
+     <resetValue>0xFFFFFFFF</resetValue>
+     <fields>
+      <field>
+       <name>VAL</name>
+       <description>CRC Value. This is the state for the Galois Field. This register holds the result of a CRC calculation or the current state of LFSR. This register is affected by the MSB control bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_PRNG</name>
+     <description>Pseudo Random Value. Output of the Galois Field shift register. This holds the resulting pseudo-random number if entropy is disabled or true random number if entropy is enabled.</description>
+     <addressOffset>0x48</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>PRNG</name>
+       <description>Pseudo Random Value. Output of the Galois Field Shift Register. This holds the resulting pseudo-random number if entropy is disabled or true random number if entropy is enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HAM_ECC</name>
+     <description>Hamming ECC Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>ECC</name>
+       <description>Hamming ECC Value. These bits are the even parity of their corresponding bit groups.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PAR</name>
+       <description>Parity. This is the parity of the entire array.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>even</name>
+         <description>Even.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>odd</name>
+         <description>Odd.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CIPHER_INIT[%s]</name>
+     <description>Initial Vector. For block cipher operations that use CBC, CFB, OFB, or CNTR modes, this register holds the initial value. This register is updated with each encryption or decryption operation. This register is affected by the endian swap bits.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>IVEC</name>
+       <description>Initial Vector. For block cipher operations that use CBC, CFB, OFB, or CNTR modes, this register holds the initial value. This register is updated with each encryption or decryption operation. This register is affected by the endian swap bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CIPHER_KEY[%s]</name>
+     <description>Cipher Key.  This register holds the key used for block cipher operations. The lower words are used for block ciphers that use shorter key lengths. This register is affected by the endian swap input control bits.</description>
+     <addressOffset>0x60</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>KEY</name>
+       <description>Cipher Key. This register holds the key used for block cipher operations. The lower words are used for block ciphers that use shorter kye lengths. This register is affected by the endian swap input control bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>16</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>HASH_DIGEST[%s]</name>
+     <description>This register holds the calculated hash value. This register is affected by the endian swap bits.</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>HASH</name>
+       <description>This register holds the calculated hash value. This register is affected by the endian swap bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>HASH_MSG_SZ[%s]</name>
+     <description>Message Size. This register holds the lowest 32-bit of message size in bytes.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>MSGSZ</name>
+       <description>Message Size. This register holds the lowest 32-bit of message size in bytes.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAA_MAWS</name>
+     <description>MAA Word Size. This register defines the number of bits for a modular operation. This register must be set to a valid value prior to the MAA operation start. Valid values are from 1 to 2048.  Invalid values are ignored and will not initiate a MAA operation.</description>
+     <addressOffset>0xD0</addressOffset>
+     <fields>
+      <field>
+       <name>MSGSZ</name>
+       <description>MAA Word Size.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TPU The Trust Protection Unit used to assist the computationally intensive operations of several common cryptographic algorithms.-->
+  <peripheral>
+   <name>TRNG</name>
+   <description>Random Number Generator.</description>
+   <baseAddress>0x400B5000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TRNG</name>
+    <description>TRNG interrupt.</description>
+    <value>4</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>TRNG Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0xFFFFFFC0</resetValue>
+     <fields>
+      <field>
+       <name>RNG_IE</name>
+       <description>To enable IRQ generation when a new 32-bit Random number is ready.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RNG_ISC</name>
+       <description>Clears the RNG interrupt occuring after an 128-bit random number is ready.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear the RNG interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RNG_I4S</name>
+       <description>This bit is set when a new 128 bit random number is ready to be read (using 4 consecutive reads of TRNG_DATA. When set, an interrupt will be generated if TRNG_CTRL.rng_ie = 1. This bit is cleared by setting TRNG_CTRL.rng_isc.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_ready</name>
+         <description>128-bit random number not ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>128-bit random number ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RNG_IS</name>
+       <description>This bit is set when a new 32 bit random number is available in TRNG_DATA.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_ready</name>
+         <description>32-bit random number not ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>32-bit random number ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESKG</name>
+       <description>When enabled, the key for securing NVSRAM is generated and transferred to the secure key register automatically without user visibility or intervention. This bit is cleared by hardware once the key has been transferred to the secure key register.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data. The content of this register is valid only when RNG_IS =1. When TNRG is disabled, read returns 0x0000 0000.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRNG Random Number Generator.-->
+  <peripheral>
+   <name>UART0</name>
+   <description>UART</description>
+   <baseAddress>0x40042000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>UART0</name>
+    <description>UART0 IRQ</description>
+    <value>14</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0</name>
+     <description>Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ENABLE</name>
+       <description>UART enabled, to enable UART block, it is used to drive a gated clock in order to save power consumption when UART is not used. FIFOs are flushed when UART is disabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>UART disabled. FIFOs are flushed. Clock is gated off for power savings. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>UART enabled. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PARITY_EN</name>
+       <description>Enable/disable Parity bit (9th character).</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Parity </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Parity enabled as 9th bit</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PARITY_MODE</name>
+       <description>When PARITY_EN=1, selects odd, even, Mark or Space parity.
+                Mark parity = always 1;
+
+                Space parity = always 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>even</name>
+         <description>Even parity selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>odd</name>
+         <description>Odd parity selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>mark</name>
+         <description>Mark parity selected.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>space</name>
+         <description>Space parity selected.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PARITY_LVL</name>
+       <description>Selects parity based on 1s or 0s count (when PARITY_EN=1).</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ZERO</name>
+         <description>Parity calculation is based on number of 0s in frame.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ONE</name>
+         <description>Parity calculation is based on number of 1s in frame.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXFLUSH</name>
+       <description>Flushes the TX FIFO buffer.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No flush operation in progress/no effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>TX FIFO flush initiation or flush operation currently in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXFLUSH</name>
+       <description>Flushes the RX FIFO buffer.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No flush operation in progress/no effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>RX FIFO flush initiation or flush operation currently in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BITACC</name>
+       <description>If set, bit accuracy is selected, in this case the bit duration is the same for all the bits with the optimal accuracy. But the frame duration can have a significant deviation from the expected baudrate.If clear, frame accuracy is selected, therefore bits can have different duration in order to guarantee the minimum frame deviation.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>frame</name>
+         <description>Frame accuracy.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bit</name>
+         <description>Bit accuracy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SIZE</name>
+       <description>Selects UART character size.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5bit_data</name>
+         <description>5 bits.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6bit_data</name>
+         <description>6 bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7bit_data</name>
+         <description>7 bits.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8bit_data</name>
+         <description>8 bits.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Selects the number of stop bits that will be generated.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1_stopbits</name>
+         <description>1 stop bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_stopbits</name>
+         <description>1.5 stop bits if the character size is 5, 2 stop bits for all other character sizes.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLOW</name>
+       <description>Enables/disables hardware flow control.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW Flow Control disabled</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW Flow Control with RTS/CTS enabled</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLOWPOL</name>
+       <description>RTS/CTS polarity.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active_low</name>
+         <description>RTS/CTS asserted is logic 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active_high</name>
+         <description>RTS/CTS asserted is logic 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NULLMOD</name>
+       <description>NULL Modem Support (RTS/CTS and TXD/RXD swap).</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Direct convention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>swapped</name>
+         <description>Null Modem Mode. RTS/CTS swapped and TX/RX swapped.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>Break control bit. It causes a break condition to be transmitted to receiving UART.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Break characters are not generated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>break</name>
+         <description>Break characters are sent (all the bits are at '0' including start/parity/stop).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLK_SEL</name>
+       <description>Baud Rate Clock Source Select.  Selects the baud rate clock.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>periph_clk</name>
+         <description>System clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>alt_clk</name>
+         <description>Alternate 7.3727MHz internal clock.  Useful in low power modes when the system clock is slow.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_CNT</name>
+       <description>RX Time Out. RX time out interrupt will occur after TO_CNT Uart
+                       characters if RX-FIFO is not empty and RX FIFO has not been read.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Threshold Control register.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>RX_FIFO_LVL</name>
+       <description>RX FIFO Threshold Level.When the RX FIFO reaches this many bytes or higher, UARTn_INFTL.rx_fifo_level is set.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_LVL</name>
+       <description>TX FIFO Threshold Level. When the TX FIFO reaches this many bytes or higher, UARTn_INTFL.tx_fifo_level is set.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RTS_FIFO_LVL</name>
+       <description>RTS threshold control. When the RX FIFO reaches this many bytes or higher, the RTS output signal is deasserted, informing the transmitting UART to stop sending data to this UART.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TX_BUSY</name>
+       <description>Read-only flag indicating the UART transmit status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>The UART block is not currently transmitting chracters.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>UART block currently transmitting chracters.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_BUSY</name>
+       <description>Read-only flag indicating the UARTreceiver status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>The UART block is not currently receiving chracters.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>UART block currently receiving chracters.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PARITY</name>
+       <description>9th Received bit state. This bit identifies the state of the 9th bit of received data. Only available for UART_CTRL.SIZE[1:0]=3.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0</name>
+         <description>Received a parity bit of 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1</name>
+         <description>Received a parity bit of 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>Received BREAK status. BREAKS is cleared when UART_STAT register is read. Received data input is held in spacing (logic 0) state for longer than a full word transmission time (that is, the total time of Start bit + data bits + Parity + Stop bits).</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>recv</name>
+         <description>Break frame received.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EMPTY</name>
+       <description>Read-only flag indicating the RX FIFO state.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>RX FIFO empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Read-only flag indicating the RX FIFO state.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>full</name>
+         <description>RX FIFO full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Read-only flag indicating the TX FIFO state.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>TX FIFO empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>Read-only flag indicating the TX FIFO state.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>full</name>
+         <description>TX FIFO empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_NUM</name>
+       <description>Indicates the number of bytes currently in the RX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_NUM</name>
+       <description>Indicates the number of bytes currently in the TX FIFO.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_TO</name>
+       <description>Receiver Timeout Status. Indicates if timeout has occurred.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>expired</name>
+         <description>RX timeout has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>RX_FRAME_ERROR</name>
+       <description>Enable for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX Frame error interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX Frame error interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_PARITY_ERROR</name>
+       <description>Enable for RX Parity Error interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX Parity error interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX Parity error interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CTS</name>
+       <description>Enable for CTS signal change interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>CTS State Change interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>CTS State Change interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVERRUN</name>
+       <description>Enable for RX FIFO OVerrun interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX Overrun interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX Overrun interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_LVL</name>
+       <description>Enable for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX FIFO Threshold Level interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX FIFO Threshold Level interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_AE</name>
+       <description>Enable for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>TX FIFO One byte remaining (almost empty) interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX FIFO one byte remaining (almost empty) interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_LVL</name>
+       <description>Enable for interrupt when TX FIFO reaches the number of bytes configured by the TXTHD field.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>TX FIFO Threshold Level interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX FIFO Threshold Level interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>Enable for received BREAK character interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description> Break character received interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Break character recevied interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_TO</name>
+       <description>Enable for RX Timeout Interrupt. Trigger if there is no RX communication during n UART characters (n=UART_CN.RXTO).</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX Timeout interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX Timeout interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LAST_BREAK</name>
+       <description>Enable for Last break character interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Last break frame received interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Last break frame received interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Interrupt Status Flags.</description>
+     <addressOffset>0x10</addressOffset>
+     <size>32</size>
+     <modifiedWriteValues>oneToClear</modifiedWriteValues>
+     <fields>
+      <field>
+       <name>FRAME</name>
+       <description>FLAG for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Frame Error interrupt active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PARITY</name>
+       <description>FLAG for RX Parity Error interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Receive parity error interrupt active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CTS_CHANGE</name>
+       <description>FLAG for CTS signal change interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>CTS State change interrupt active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>FLAG for RX FIFO Overrun interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RX Overrun interrupt active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_LVL</name>
+       <description>FLAG for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RX FIFO Threshold level interrupt active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_AE</name>
+       <description>FLAG for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>TX FIFO one byte remaining interrupt active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_LVL</name>
+       <description>FLAG for interrupt when TX FIFO reaches the number of bytes configured by the TXTHD field.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>TX FIFO threshold level interrupt active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>FLAG for received BREAK character interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Break character received interrupt active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_TO</name>
+       <description>FLAG for RX Timeout Interrupt. Trigger if there is no RX communication during n UART characters (n=UART_CN.RXTO).</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Receive timeout expired interrupt active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LAST_BREAK</name>
+       <description>FLAG for Last break character interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Last break character received interrupt active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BAUD0</name>
+     <description>Baud rate register. Integer portion.</description>
+     <addressOffset>0x14</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>IBAUD</name>
+       <description>Integer portion of baud rate divisor value. IBAUD = InputClock / (factor * Baud Rate Frequency).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>FACTOR must be chosen to have IDIV&gt;
+                0. factor used in calculation = 128 &gt;
+                &gt;
+                FACTOR.
+            </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Baud Factor 128</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Baud Factor 64</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Baud Factor 32</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Baud Factor 16</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Baud Factor 8</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BAUD1</name>
+     <description>Baud rate register. Decimal Setting.</description>
+     <addressOffset>0x18</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DBAUD</name>
+       <description>Decimal portion of baud rate divisor value. DIV = InputClock/ (factor*Baud Rate Frequency). DDIV= (DIV-IDIV) *128.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Data buffer.</description>
+     <addressOffset>0x1C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>FIFO</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration.</description>
+     <addressOffset>0x20</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>TXDMA_EN</name>
+       <description>TX DMA channel enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>DMA is disabled </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>DMA is enabled </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXDMA_EN</name>
+       <description>RX DMA channel enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>DMA is disabled </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>DMA is enabled </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXDMA_LVL</name>
+       <description>TX threshold for DMA transmission.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RXDMA_LVL</name>
+       <description>RX threshold for DMA transmission.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXFIFO</name>
+     <description>Transmit FIFO Status register.</description>
+     <addressOffset>0x24</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Reading from this field returns the next character available at the output of the TX FIFO (if one is available, otherwise 00h is returned).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--UART0 UART-->
+  <peripheral derivedFrom="UART0">
+   <name>UART1</name>
+   <description>UART 1</description>
+   <baseAddress>0x40043000</baseAddress>
+   <interrupt>
+    <name>UART1</name>
+    <description>UART1 IRQ</description>
+    <value>15</value>
+   </interrupt>
+  </peripheral>
+<!--UART1 UART 1-->
+  <peripheral derivedFrom="UART0">
+   <name>UART2</name>
+   <description>UART 2</description>
+   <baseAddress>0x40044000</baseAddress>
+   <interrupt>
+    <name>UART2</name>
+    <description>UART2 IRQ</description>
+    <value>34</value>
+   </interrupt>
+  </peripheral>
+<!--UART2 UART 2-->
+  <peripheral>
+   <name>USBHS</name>
+   <description>USB 2.0 High-speed Controller.</description>
+   <baseAddress>0x400B1000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>USB</name>
+    <value>2</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FADDR</name>
+     <description>Function address register.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <resetMask>0x00</resetMask>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Function address for this controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>UPDATE</name>
+       <description>Set when ADDR is written, cleared when new address takes effect.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>POWER</name>
+     <description>Power management register.</description>
+     <addressOffset>0x01</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>EN_SUSPENDM</name>
+       <description>Enable SUSPENDM signal.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SUSPEND</name>
+       <description>Suspend mode detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESUME</name>
+       <description>Generate resume signaling.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESET</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS_MODE</name>
+       <description>High-speed mode detected.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS_ENABLE</name>
+       <description>High-speed mode enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SOFTCONN</name>
+       <description>Softconn.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ISO_UPDATE</name>
+       <description>Wait for SOF during Isochronous xfers.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRIN</name>
+     <description>Interrupt register for EP0 and IN EP1-15.</description>
+     <addressOffset>0x02</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_IN_INT</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP14_IN_INT</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP13_IN_INT</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP12_IN_INT</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP11_IN_INT</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP10_IN_INT</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP9_IN_INT</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP8_IN_INT</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP7_IN_INT</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP6_IN_INT</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP5_IN_INT</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP4_IN_INT</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP3_IN_INT</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP2_IN_INT</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP1_IN_INT</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP0_IN_INT</name>
+       <description>Endpoint 0 interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTROUT</name>
+     <description>Interrupt register for OUT EP 1-15.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_OUT_INT</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP14_OUT_INT</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP13_OUT_INT</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP12_OUT_INT</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP11_OUT_INT</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP10_OUT_INT</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP9_OUT_INT</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP8_OUT_INT</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP7_OUT_INT</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP6_OUT_INT</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP5_OUT_INT</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP4_OUT_INT</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP3_OUT_INT</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP2_OUT_INT</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP1_OUT_INT</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRINEN</name>
+     <description>Interrupt enable for EP 0 and IN EP 1-15.</description>
+     <addressOffset>0x06</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_IN_INT_EN</name>
+       <description>Endpoint 15 interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP14_IN_INT_EN</name>
+       <description>Endpoint 14 interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP13_IN_INT_EN</name>
+       <description>Endpoint 13 interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP12_IN_INT_EN</name>
+       <description>Endpoint 12 interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP11_IN_INT_EN</name>
+       <description>Endpoint 11 interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP10_IN_INT_EN</name>
+       <description>Endpoint 10 interrupt enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP9_IN_INT_EN</name>
+       <description>Endpoint 9 interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP8_IN_INT_EN</name>
+       <description>Endpoint 8 interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP7_IN_INT_EN</name>
+       <description>Endpoint 7 interrupt enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP6_IN_INT_EN</name>
+       <description>Endpoint 6 interrupt enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP5_IN_INT_EN</name>
+       <description>Endpoint 5 interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP4_IN_INT_EN</name>
+       <description>Endpoint 4 interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP3_IN_INT_EN</name>
+       <description>Endpoint 3 interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP2_IN_INT_EN</name>
+       <description>Endpoint 2 interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP1_IN_INT_EN</name>
+       <description>Endpoint 1 interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP0_INT_EN</name>
+       <description>Endpoint 0 interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTROUTEN</name>
+     <description>Interrupt enable for OUT EP 1-15.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_OUT_INT_EN</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP14_OUT_INT_EN</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP13_OUT_INT_EN</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP12_OUT_INT_EN</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP11_OUT_INT_EN</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP10_OUT_INT_EN</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP9_OUT_INT_EN</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP8_OUT_INT_EN</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP7_OUT_INT_EN</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP6_OUT_INT_EN</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP5_OUT_INT_EN</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP4_OUT_INT_EN</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP3_OUT_INT_EN</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP2_OUT_INT_EN</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP1_OUT_INT_EN</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRUSB</name>
+     <description>Interrupt register for common USB interrupts.</description>
+     <addressOffset>0x0A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SOF_INT</name>
+       <description>Start of Frame.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESET_INT</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESUME_INT</name>
+       <description>Resume detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SUSPEND_INT</name>
+       <description>Suspend detected.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRUSBEN</name>
+     <description>Interrupt enable for common USB interrupts.</description>
+     <addressOffset>0x0B</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SOF_INT_EN</name>
+       <description>Start of Frame.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESET_INT_EN</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESUME_INT_EN</name>
+       <description>Resume detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SUSPEND_INT_EN</name>
+       <description>Suspend detected.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FRAME</name>
+     <description>Frame number.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>FRAMENUM</name>
+       <description>Read the last received frame number, that is the 11-bit frame number received in the SOF packet.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INDEX</name>
+     <description>Index for banked registers.</description>
+     <addressOffset>0x0E</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>INDEX</name>
+       <description>Index Register Access Selector. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TESTMODE</name>
+     <description>USB 2.0 test mode enable register.</description>
+     <addressOffset>0x0F</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>FORCE_FS</name>
+       <description>Force USB to Full-speed after reset.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FORCE_HS</name>
+       <description>Force USB to High-speed after reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_PKT</name>
+       <description>Transmit fixed test packet.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_K</name>
+       <description>Force USB to continuous K state.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_J</name>
+       <description>Force USB to continuous J state.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_SE0_NAK</name>
+       <description>Respond to any valid IN token with NAK.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INMAXP</name>
+     <description>Maximum packet size for INx endpoint (x == INDEX).</description>
+     <addressOffset>0x10</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>MAXPACKETSIZE</name>
+       <description>Maximum Packet Size in a Single Transaction. That is the maximum packet size in bytes, that is transmitted for each microframe. The maximum value is 1024, subject to the limitations of the endpoint type set in USB 2.0 Specification, Chapter 9</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+      <field>
+       <name>NUMPACKMINUS1</name>
+       <description>Number of Split Packets - 1. Defines the maximum number of packets minus 1 that a USB payload can be split into. THis must be an exact multiple of maxpacketsize. Only applicable for HS High-Bandwidth isochronous endpoints and Bulk endpoints. Ignored in all other cases. </description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CSR0</name>
+     <description>Control status register for EP 0 (when INDEX == 0).</description>
+     <addressOffset>0x12</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SERV_SETUP_END</name>
+       <description>Clear EP0 Setup End Bit. Write a 1 to clear the setupend bit. Automatically cleared after being set </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SERV_OUTPKTRDY</name>
+       <description>Clear EP0 Out Packet Ready Bit. Write a 1 to clear the outpktrdy bit. Automatically cleared after being set.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SEND_STALL</name>
+       <description>Send EP0 STALL Handshake. Write a 1 to this bit to terminate the current control transaction by sneding a STALL handshake. Automatically cleared after being set. </description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SETUP_END</name>
+       <description>Read Setup End Status. Automatically set when a contorl transaction ends before the dataend bit has been set by fimrware. An interrupt is generated when this bit is set. Write 1 to servicedsetupend to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_END</name>
+       <description>Control Transaction Data End. Write a 1 to this bit after firmware completes any of the following three transactions: 1. set inpktrdy = 1 for the last data packet. 2. Set inpktrdy =1 for a zero-length data packet. 3. Clear outpktrdy = 0 after unloading the last data packet. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENT_STALL</name>
+       <description> Read EP0 STALL Handshake Sent Status Automatically set when a STALL handshake is transmitted. Write a 0 to clear. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPKTRDY</name>
+       <description>EP0 IN Packet Ready 1: Write a 1 after writing a data packet to the IN FIFO. Automatically cleared when the data packet is transmitted. An interrupt is generated when this bit is cleared. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPKTRDY</name>
+       <description>EP0 OUT Packet Ready Status Automatically set when a data packet is received in the OUT FIFO. An interrupt is generated when this bit is set. Write a 1 to the servicedoutpktrdy bit (above) to clear after the packet is unloaded from the OUT FIFO. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INCSRL</name>
+     <description>Control status lower register for INx endpoint (x == INDEX).</description>
+     <alternateRegister>CSR0</alternateRegister>
+     <addressOffset>0x12</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>INCOMPTX</name>
+       <description>Read Incomplete Split Transfer Error Status High-bandwidth isochronous transfers: Automatically set when a payload is split into multiple packets but insufficient IN tokens were received to send all packets. The current packets is flushed from the IN FIFO. Write 0 to clear.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLRDATATOG</name>
+       <description>Write 1 to clear IN endpoint data-toggle to 0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENTSTALL</name>
+       <description>Read STALL Handshake Sent Status Automatically set when a STALL handshake is transmitted, at which time the IN FIFO is flushed, and inpktrdy is cleared. Write 0 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENDSTALL</name>
+       <description>Send STALL Handshake.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>terminate</name>
+         <description>Terminate STALL handhsake</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Respond to an IN token with a STALL handshake</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSHFIFO</name>
+       <description>Flush Next Packet from IN FIFO. Write 1 to clear</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>UNDERRUN</name>
+       <description>Read IN FIFO Underrun Error Status Isochronous Mode: Automatically set if the IN FIFO is empty. Write 0 to clear</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFONOTEMPTY</name>
+       <description>Read FIFO Not Empty Status. Automatically set when there is at least one packet in the IN FIFO. Write a 0 to clear. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPKTRDY</name>
+       <description>IN Packet Ready. Write a 1 to clear </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INCSRU</name>
+     <description>Control status upper register for INx endpoint (x == INDEX).</description>
+     <addressOffset>0x13</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>AUTOSET</name>
+       <description>Auto Set inpktrdy. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>set</name>
+         <description>USBHS_INCSRL_inpktrdy must be set by firmware.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>auto</name>
+         <description>USBHS_INCSRL_inpktrdy is automatically set. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ISO</name>
+       <description>Isochronous Transfer Enable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>interrupt</name>
+         <description>Enable IN Bulk and IN interrupt transfers.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>isochronous</name>
+         <description>Enable IN Isochronous transfers. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description> Endpoint Direction Mode.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>out</name>
+         <description>Endpoint direction is OUT.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>in</name>
+         <description>Endpoint direction is IN. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FRCDATATOG</name>
+       <description> Force In Data - Toggle</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>received</name>
+         <description>Toggle data-toglge only when an ACK is received.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dontcare</name>
+         <description>Toggle data-toggle regardless of ACK. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPKTBUFDIS</name>
+       <description> Double Packet Buffering Disable </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Double packet buffering.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Double Packet Buffering.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTMAXP</name>
+     <description>Maximum packet size for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x14</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>NUMPACKMINUS1</name>
+       <description>Number of Split Packets -1. Defines the maximum number of packets - 1 that a usb payload is combined into. The value must be exact multiple of maxpacketsize. </description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>MAXPACKETSIZE</name>
+       <description>Maximum Packet in a Single Transaction. This is the maximum packet size, in bytes, that is transmitted for each microframe. The maximum value is 1024, subject to the limitations for the endpoint type set in USB2.0 spesification, chapter 9.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCSRL</name>
+     <description>Control status lower register for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x16</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>CLRDATATOG</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENTSTALL</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENDSTALL</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FLUSHFIFO</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DATAERROR</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>OVERRUN</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFOFULL</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>OUTPKTRDY</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCSRU</name>
+     <description>Control status upper register for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x17</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>AUTOCLEAR</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ISO</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DISNYET</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DPKTBUFDIS</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INCOMPRX</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>COUNT0</name>
+     <description>Number of received bytes in EP 0 FIFO (INDEX == 0).</description>
+     <addressOffset>0x18</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>COUNT0</name>
+       <description>Read Number of Data Bytes in the Endpoint 0 FIFO. Returns the number of data bytes in the endpoint 0 FIFO. This value changes as contents of the FIFO change. The value is only valued when USBHS_OUTSCRL_outpktrdy = 1 </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCOUNT</name>
+     <description>Number of received bytes in OUT EPx FIFO (x == INDEX).</description>
+     <alternateRegister>COUNT0</alternateRegister>
+     <addressOffset>0x18</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>OUTCOUNT</name>
+       <description>Read Number of Data Bytes in OUT FIFO. Returns the number of data bytes in the packet that are read next in the OUT FIFO. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>13</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO0</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO0</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO1</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO1</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO2</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO2</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO3</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x2c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO3</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO4</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO4</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO5</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO5</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO6</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO6</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO7</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x3c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO7</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO8</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO8</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO9</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO9</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO10</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO10</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO11</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x4c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO11</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO12</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO12</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO13</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO13</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO14</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO14</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO15</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x5c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO15</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HWVERS</name>
+     <description>HWVERS</description>
+     <addressOffset>0x6c</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>USBHS_HWVERS</name>
+       <description>USBHS Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EPINFO</name>
+     <description>Endpoint hardware information.</description>
+     <addressOffset>0x78</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>OUTENDPOINTS</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>INTENDPOINTS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RAMINFO</name>
+     <description>RAM width information.</description>
+     <addressOffset>0x79</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RAMBITS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SOFTRESET</name>
+     <description>Software reset register.</description>
+     <addressOffset>0x7A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RSTXS</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RSTS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTUCH</name>
+     <description>Chirp timeout timer setting.</description>
+     <addressOffset>0x80</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>C_T_UCH</name>
+       <description>HS Chirp Timeout Clock Cycles. This configures the chirp timeout used by this device to negotiate a HS connection with a FS Host. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTHSRTN</name>
+     <description>Sets delay between HS resume to UTM normal operating mode.</description>
+     <addressOffset>0x82</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>C_T_HSTRN</name>
+       <description>High Speed Resume Delay Clock Cycles. This configures the delay from when the RESUME state on the bus ends, the when the USBHS resumes normal operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_USB_REG_00</name>
+     <description>MXM_USB_REG_00</description>
+     <addressOffset>0x400</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_UTMI_RESET</name>
+     <description>M31_PHY_UTMI_RESET</description>
+     <addressOffset>0x404</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_UTMI_VCONTROL</name>
+     <description>M31_PHY_UTMI_VCONTROL</description>
+     <addressOffset>0x408</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CLK_EN</name>
+     <description>M31_PHY_CLK_EN</description>
+     <addressOffset>0x40C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_PONRST</name>
+     <description>M31_PHY_PONRST</description>
+     <addressOffset>0x410</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_NONCRY_RSTB</name>
+     <description>M31_PHY_NONCRY_RSTB</description>
+     <addressOffset>0x414</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_NONCRY_EN</name>
+     <description>M31_PHY_NONCRY_EN</description>
+     <addressOffset>0x418</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_EN</name>
+     <description>M31_PHY_U2_COMPLIANCE_EN</description>
+     <addressOffset>0x420</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_DAC_ADJ</name>
+     <description>M31_PHY_U2_COMPLIANCE_DAC_ADJ</description>
+     <addressOffset>0x424</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_DAC_ADJ_EN</name>
+     <description>M31_PHY_U2_COMPLIANCE_DAC_ADJ_EN</description>
+     <addressOffset>0x428</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CLK_RDY</name>
+     <description>M31_PHY_CLK_RDY</description>
+     <addressOffset>0x42C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_PLL_EN</name>
+     <description>M31_PHY_PLL_EN</description>
+     <addressOffset>0x430</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_BIST_OK</name>
+     <description>M31_PHY_BIST_OK</description>
+     <addressOffset>0x434</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DATA_OE</name>
+     <description>M31_PHY_DATA_OE</description>
+     <addressOffset>0x438</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_OSCOUTEN</name>
+     <description>M31_PHY_OSCOUTEN</description>
+     <addressOffset>0x43C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_LPM_ALIVE</name>
+     <description>M31_PHY_LPM_ALIVE</description>
+     <addressOffset>0x440</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_HS_BIST_MODE</name>
+     <description>M31_PHY_HS_BIST_MODE</description>
+     <addressOffset>0x444</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CORECLKIN</name>
+     <description>M31_PHY_CORECLKIN</description>
+     <addressOffset>0x448</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XTLSEL</name>
+     <description>M31_PHY_XTLSEL</description>
+     <addressOffset>0x44C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_LS_EN</name>
+     <description>M31_PHY_LS_EN</description>
+     <addressOffset>0x450</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DEBUG_SEL</name>
+     <description>M31_PHY_DEBUG_SEL</description>
+     <addressOffset>0x454</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DEBUG_OUT</name>
+     <description>M31_PHY_DEBUG_OUT</description>
+     <addressOffset>0x458</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_OUTCLKSEL</name>
+     <description>M31_PHY_OUTCLKSEL</description>
+     <addressOffset>0x45C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_31_0</name>
+     <description>M31_PHY_XCFGI_31_0</description>
+     <addressOffset>0x460</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_63_32</name>
+     <description>M31_PHY_XCFGI_63_32</description>
+     <addressOffset>0x464</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_95_64</name>
+     <description>M31_PHY_XCFGI_95_64</description>
+     <addressOffset>0x468</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_127_96</name>
+     <description>M31_PHY_XCFGI_127_96</description>
+     <addressOffset>0x46C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_137_128</name>
+     <description>M31_PHY_XCFGI_137_128</description>
+     <addressOffset>0x470</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_HS_COARSE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_HS_COARSE_TUNE_NUM</description>
+     <addressOffset>0x474</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_HS_FINE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_HS_FINE_TUNE_NUM</description>
+     <addressOffset>0x478</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_FS_COARSE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_FS_COARSE_TUNE_NUM</description>
+     <addressOffset>0x47C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_FS_FINE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_FS_FINE_TUNE_NUM</description>
+     <addressOffset>0x480</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_LOCK_RANGE_MAX</name>
+     <description>M31_PHY_XCFG_LOCK_RANGE_MAX</description>
+     <addressOffset>0x484</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_LOCK_RANGE_MIN</name>
+     <description>M31_PHY_XCFGI_LOCK_RANGE_MIN</description>
+     <addressOffset>0x488</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_OB_RSEL</name>
+     <description>M31_PHY_XCFG_OB_RSEL</description>
+     <addressOffset>0x48C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_OC_RSEL</name>
+     <description>M31_PHY_XCFG_OC_RSEL</description>
+     <addressOffset>0x490</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGO</name>
+     <description>M31_PHY_XCFGO</description>
+     <addressOffset>0x494</addressOffset>
+    </register>
+    <register>
+     <name>MXM_INT</name>
+     <description>USB Added Maxim Interrupt Flag Register.</description>
+     <addressOffset>0x498</addressOffset>
+     <fields>
+      <field>
+       <name>VBUS</name>
+       <description>VBUS</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOVBUS</name>
+       <description>NOVBUS</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_INT_EN</name>
+     <description>USB Added Maxim Interrupt Enable Register.</description>
+     <addressOffset>0x49C</addressOffset>
+     <fields>
+      <field>
+       <name>VBUS</name>
+       <description>VBUS</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOVBUS</name>
+       <description>NOVBUS</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_SUSPEND</name>
+     <description>USB Added Maxim Suspend Register.</description>
+     <addressOffset>0x4A0</addressOffset>
+     <fields>
+      <field>
+       <name>SEL</name>
+       <description>Suspend register</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_REG_A4</name>
+     <description>USB Added Maxim Power Status Register</description>
+     <addressOffset>0x4A4</addressOffset>
+     <fields>
+      <field>
+       <name>VRST_VDDB_N_A</name>
+       <description>VRST_VDDB_N_A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--USBHS USB 2.0 High-speed Controller.-->
+  <peripheral>
+   <name>WDT0</name>
+   <description>Watchdog Timer 0</description>
+   <baseAddress>0x40003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WDT0</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x7FFFF000</resetMask>
+     <fields>
+      <field>
+       <name>INT_PERIOD</name>
+       <description>Watchdog Interrupt Period. The watchdog timer will assert an interrupt, if enabled, if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_PERIOD</name>
+       <description>Watchdog Reset Period. The watchdog timer will assert a reset, if enabled, if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_EN</name>
+       <description>Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_FLAG</name>
+       <description>Watchdog Timer Interrupt Flag.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EN</name>
+       <description>Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EN</name>
+       <description>Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_FLAG</name>
+       <description>Watchdog Timer Reset Flag.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>WDT_RST</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WDT0 Watchdog Timer 0-->
+  <peripheral derivedFrom="WDT0">
+   <name>WDT1</name>
+   <description>Watchdog Timer 0 1</description>
+   <baseAddress>0x40003400</baseAddress>
+   <interrupt>
+    <name>WDT1</name>
+    <description>WDT1 IRQ</description>
+    <value>57</value>
+   </interrupt>
+  </peripheral>
+<!--WDT1 Watchdog Timer 0 1-->
+ </peripherals>
+</device>

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32655/Include/max32655.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32655/Include/max32655.svd
@@ -1,0 +1,12996 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max32655</name>
+ <series>ARMCM4</series>
+ <version>1.0</version>
+ <description>MAX32655 32-bit ARM Cortex-M4 microcontroller, 1024KB of flash, 760KB of system RAM, 128KB of Boot ROM.</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>ADC</name>
+   <description>10-bit Analog to Digital Converter</description>
+   <baseAddress>0x40034000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>ADC</name>
+    <description>ADC IRQ</description>
+    <value>20</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>ADC Control</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>start</name>
+       <description>Start ADC Conversion</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pwr</name>
+       <description>ADC Power Up</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>refbuf_pwr</name>
+       <description>ADC Reference Buffer Power Up</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ref_sel</name>
+       <description>ADC Reference Select</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ref_scale</name>
+       <description>ADC Reference Scale</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>scale</name>
+       <description>ADC Scale</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>clk_en</name>
+       <description>ADC Clock Enable</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_sel</name>
+       <description>ADC Channel Select</description>
+       <bitRange>[16:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AIN0</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN1</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN2</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN3</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN4</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN5</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN6</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN7</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VcoreA</name>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VcoreB</name>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vrxout</name>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vtxout</name>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VddA</name>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VddB</name>
+         <description>VddB/4</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vddio</name>
+         <description>Vddio/4</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vddioh</name>
+         <description>Vddioh/4</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VregI</name>
+         <description>VregI/4</description>
+         <value>16</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>adc_divsel</name>
+       <description>Scales the external inputs, all inputs are scaled the same</description>
+       <bitRange>[18:17]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV3</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>data_align</name>
+       <description>ADC Data Alignment Select</description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>ADC Status</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>active</name>
+       <description>ADC Conversion In Progress</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>afe_pwr_up_active</name>
+       <description>AFE Power Up Delay Active</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>overflow</name>
+       <description>ADC Overflow</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>ADC Output Data</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>adc_data</name>
+       <description>ADC Converted Sample Data Output</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>ADC Interrupt Control Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>done_ie</name>
+       <description>ADC Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ref_ready_ie</name>
+       <description>ADC Reference Ready Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>hi_limit_ie</name>
+       <description>ADC Hi Limit Monitor Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>lo_limit_ie</name>
+       <description>ADC Lo Limit Monitor Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>overflow_ie</name>
+       <description>ADC Overflow Interrupt Enable</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>done_if</name>
+       <description>ADC Done Interrupt Flag</description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>ref_ready_if</name>
+       <description>ADC Reference Ready Interrupt Flag</description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>hi_limit_if</name>
+       <description>ADC Hi Limit Monitor Interrupt Flag</description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>lo_limit_if</name>
+       <description>ADC Lo Limit Monitor Interrupt Flag</description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>overflow_if</name>
+       <description>ADC Overflow Interrupt Flag</description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>pending</name>
+       <description>ADC Interrupt Pending Status</description>
+       <bitRange>[22:22]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>LIMIT[%s]</name>
+     <description>ADC Limit</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ch_lo_limit</name>
+       <description>Low Limit Threshold</description>
+       <bitRange>[9:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_hi_limit</name>
+       <description>High Limit Threshold</description>
+       <bitRange>[21:12]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_sel</name>
+       <description>ADC Channel Select</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_lo_limit_en</name>
+       <description>Low Limit Monitoring Enable</description>
+       <bitRange>[29:29]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_hi_limit_en</name>
+       <description>High Limit Monitoring Enable</description>
+       <bitRange>[30:30]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ADC 10-bit Analog to Digital Converter-->
+  <peripheral>
+   <name>AESKEYS</name>
+   <description>AES Key Registers.</description>
+   <baseAddress>0x40007800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>KEY0</name>
+     <description>AES Key 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY1</name>
+     <description>AES Key 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY2</name>
+     <description>AES Key 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY3</name>
+     <description>AES Key 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY4</name>
+     <description>AES Key 4.</description>
+     <addressOffset>0x10</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY5</name>
+     <description>AES Key 5.</description>
+     <addressOffset>0x14</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY6</name>
+     <description>AES Key 6.</description>
+     <addressOffset>0x18</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY7</name>
+     <description>AES Key 7.</description>
+     <addressOffset>0x1C</addressOffset>
+     <size>32</size>
+    </register>
+   </registers>
+  </peripheral>
+<!--AESKEYS AES Key Registers.-->
+  <peripheral>
+   <name>AES</name>
+   <description>AES Keys.</description>
+   <baseAddress>0x40007400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>AES Control Register</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>AES Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>DMA Request To Read Data Output FIFO</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>DMA Request To Write Data Input FIFO</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start AES Calculation</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FLUSH</name>
+       <description>Flush the data input FIFO</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FLUSH</name>
+       <description>Flush the data output FIFO</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_SIZE</name>
+       <description>Encryption Key Size</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AES128</name>
+         <description>128 Bits.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES192</name>
+         <description>192 Bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES256</name>
+         <description>256 Bits.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TYPE</name>
+       <description>Encryption Type Selection</description>
+       <bitRange>[9:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>AES Status Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>AES Busy Status</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_EM</name>
+       <description>Data input FIFO empty status</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FULL</name>
+       <description>Data input FIFO full status</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_EM</name>
+       <description>Data output FIFO empty status</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FULL</name>
+       <description>Data output FIFO full status</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>AES Interrupt Flag Register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>AES Interrupt Enable Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>AES Data Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>AES FIFO</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--AES AES Keys.-->
+  <peripheral>
+   <name>CRC</name>
+   <description>CRC Registers.</description>
+   <baseAddress>0x4000F000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>CRC Control</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>CRC Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_EN</name>
+       <description>DMA Request Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB</name>
+       <description>MSB Select</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BYTE_SWAP_IN</name>
+       <description>Byte Swap CRC Data Input</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BYTE_SWAP_OUT</name>
+       <description>Byte Swap CRC Value Output</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>CRC Busy</description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN32</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN16</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN8</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>POLY</name>
+     <description>CRC Polynomial</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>POLY</name>
+       <description>CRC Polynomial</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VAL</name>
+     <description>Current CRC Value</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>VALUE</name>
+       <description>Current CRC Value</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CRC CRC Registers.-->
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0</name>
+    <value>28</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1</name>
+    <value>29</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA2</name>
+    <value>30</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA3</name>
+    <value>31</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>INTEN</name>
+     <description>DMA Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel 0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <description>Channel 1 Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <description>Channel 2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <description>Channel 3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>DMA Interrupt Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel Interrupt. To clear an interrupt, all active interrupt bits of the DMA_ST must be cleared. The interrupt bits are set only if their corresponding interrupt enable bits are set in DMA_CN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>4</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CTRL</name>
+      <description>DMA Channel Control Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>EN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQUEST</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1RX</name>
+          <description>SPI1 RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0RX</name>
+          <description>UART0 RX</description>
+          <value>0x04</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1RX</name>
+          <description>UART1 RX</description>
+          <value>0x05</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0RX</name>
+          <description>I2C0 RX</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1RX</name>
+          <description>I2C1 RX</description>
+          <value>0x08</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>ADC</name>
+          <description>ADC</description>
+          <value>0x09</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2RX</name>
+          <description>I2C2 RX</description>
+          <value>0x0A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2RX</name>
+          <description>UART2 RX</description>
+          <value>0x0E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0RX</name>
+          <description>SPI0 RX</description>
+          <value>0x0F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESRX</name>
+          <description>AES RX</description>
+          <value>0x10</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3RX</name>
+          <description>UART3 RX</description>
+          <value>0x1C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2SRX</name>
+          <description>I2S RX</description>
+          <value>0x1E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1TX</name>
+          <description>SPI1 TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0TX</name>
+          <description>UART0 TX</description>
+          <value>0x24</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1TX</name>
+          <description>UART1 TX</description>
+          <value>0x25</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0TX</name>
+          <description>I2C0 TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1TX</name>
+          <description>I2C1 TX</description>
+          <value>0x28</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2TX</name>
+          <description>I2C2 TX</description>
+          <value>0x2A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>CRCTX</name>
+          <description>CRC TX</description>
+          <value>0x2C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2TX</name>
+          <description>UART2 TX</description>
+          <value>0x2E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0TX</name>
+          <description>SPI0 TX</description>
+          <value>0x2F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESTX</name>
+          <description>AES TX</description>
+          <value>0x30</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3TX</name>
+          <description>UART3 TX</description>
+          <value>0x3C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2STX</name>
+          <description>I2S TX</description>
+          <value>0x3E</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_WAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_PER</name>
+        <description>Timeout Period Select.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_CLKDIV</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BURST_SIZE</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>DIS_IE</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IE</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>STATUS</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>STATUS</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IF</name>
+        <description>Count-to-Zero (CTZ) Interrupt Flag</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>RLD_IF</name>
+        <description>Reload Event Interrupt Flag.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>TO_IF</name>
+        <description>Time-Out Event Interrupt Flag.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRCRLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DSTRLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNTRLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>EN</name>
+        <description>Reload Enable. This bit should be set after the address reload registers have been programmed. This bit is automatically cleared to 0 when reload occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+<!--DMA DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral>
+   <name>DVS</name>
+   <description>Dynamic Voltage Scaling</description>
+   <prependToName>DVS_</prependToName>
+   <baseAddress>0x40003C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0030</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DVS</name>
+    <description>Dynamic Voltage Scaling Interrupt</description>
+    <value>83</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTL</name>
+     <description>Control Register</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>MON_ENA</name>
+       <description>Enable the DVS monitoring circuit</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ENA</name>
+       <description>Enable the power supply adjustment based on measurements</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PS_FB_DIS</name>
+       <description>Power Supply Feedback Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTRL_TAP_ENA</name>
+       <description>Use the TAP Select for automatic adjustment or monitoring</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PROP_DLY</name>
+       <description>Additional delay to monitor lines</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>MON_ONESHOT</name>
+       <description>Measure delay once</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GO_DIRECT</name>
+       <description>Operate in automatic mode or move directly</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DIRECT_REG</name>
+       <description>Step incrementally to target voltage</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PRIME_ENA</name>
+       <description>Include a delay line priming signal before monitoring</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LIMIT_IE</name>
+       <description>Enable Limit Error Interrupt</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RANGE_IE</name>
+       <description>Enable Range Error Interrupt</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_IE</name>
+       <description>Enable Adjustment Error Interrupt</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>REF_SEL</name>
+       <description>Select TAP used for voltage adjustment</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>INC_VAL</name>
+       <description>Step size to increment voltage when in automatic mode</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>DVS_PS_APB_DIS</name>
+       <description>Prevent the application code from adjusting Vcore</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DVS_HI_RANGE_ANY</name>
+       <description>Any high range signal from a delay line will cause a voltage adjustment</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FB_TO_IE</name>
+       <description>Enable Voltage Adjustment Timeout Interrupt</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FC_LV_IE</name>
+       <description>Enable Low Voltage Interrupt</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PD_ACK_ENA</name>
+       <description>Prevent DVS from ack'ing a request to enter a low power mode until in the idle state</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ABORT</name>
+       <description>Causes the DVS to enter the idle state immediately on a request to enter a low power mode</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>Status Fields</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000000</resetValue>
+     <fields>
+      <field>
+       <name>DVS_STATE</name>
+       <description>State machine state</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_UP_ENA</name>
+       <description>DVS Raising voltage</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_DWN_ENA</name>
+       <description>DVS Lowering voltage</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ACTIVE</name>
+       <description>Adjustment to a Direct Voltage</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTR_TAP_OK</name>
+       <description>Tap Enabled and the Tap is withing Hi/Low limits</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTR_TAP_SEL</name>
+       <description>Status of selected center tap delay line detect output</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SLOW_TRIP_DET</name>
+       <description>Provides the current combined status of all selected Low Range delay lines</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FAST_TRIP_DET</name>
+       <description>Provides the current combined status of all selected High Range delay lines</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PS_IN_RANGE</name>
+       <description>Indicates if the power supply is in range</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PS_VCNTR</name>
+       <description>Voltage Count value sent to the power supply</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>MON_DLY_OK</name>
+       <description>Indicates the monitor delay count is at 0</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_DLY_OK</name>
+       <description>Indicates the adjustment delay count is at 0</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LO_LIMIT_DET</name>
+       <description>Power supply voltage counter is at low limit</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HI_LIMIT_DET</name>
+       <description>Power supply voltage counter is at high limit</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VALID_TAP</name>
+       <description>At least one delay line has been enabled</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LIMIT_ERR</name>
+       <description>Interrupt flag that indicates a voltage count is at/beyond manufacturer limits</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RANGE_ERR</name>
+       <description>Interrupt flag that indicates a tap has an invalid value</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ERR</name>
+       <description>Interrupt flag that indicates up and down adjustment requested simultaneously</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>REF_SEL_ERR</name>
+       <description>Indicates the ref select register  bit is out of range</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FB_TO_ERR</name>
+       <description>Interrupt flag that indicates a timeout while adjusting the voltage</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FB_TO_ERR_S</name>
+       <description>Interrupt flag that mirror FB_TO_ERR and is write one clear</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FC_LV_DET_INT</name>
+       <description>Interrupt flag that indicates the power supply voltage requested is below the low threshold</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FC_LV_DET_S</name>
+       <description>Interrupt flag that mirrors FC_LV_DET_INT</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DIRECT</name>
+     <description>Direct control of target voltage</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>VOLTAGE</name>
+       <description>Sets the target power supply value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MON</name>
+     <description>Monitor Delay</description>
+     <addressOffset>0x00C</addressOffset>
+     <fields>
+      <field>
+       <name>DLY</name>
+       <description>Number of prescaled clocks between delay line samples</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+      <field>
+       <name>PRE</name>
+       <description>Number of clocks before DVS_MON_DLY is decremented</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADJ_UP</name>
+     <description>Up Delay Register</description>
+     <addressOffset>0x010</addressOffset>
+     <fields>
+      <field>
+       <name>DLY</name>
+       <description>Number of prescaled clocks between updates of the adjustment delay counter</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PRE</name>
+       <description>Number of clocks before DVS_ADJ_UP_DLY is decremented</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADJ_DWN</name>
+     <description>Down Delay Register</description>
+     <addressOffset>0x014</addressOffset>
+     <fields>
+      <field>
+       <name>DLY</name>
+       <description>Number of prescaled clocks between updates of the adjustment delay counter</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PRE</name>
+       <description>Number of clocks before DVS_ADJ_DWN_DLY is decremented</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>THRES_CMP</name>
+     <description>Up Delay Register</description>
+     <addressOffset>0x018</addressOffset>
+     <fields>
+      <field>
+       <name>VCNTR_THRES_CNT</name>
+       <description>Value used to determine 'low voltage' range</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VCNTR_THRES_MASK</name>
+       <description>Mask applied to threshold and vcount to determine if the device is in a low voltage range</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>5</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>TAP_SEL[%s]</name>
+     <description>DVS Tap Select Register</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Select delay line tap for lower bound of auto adjustment</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>LO_TAP_STAT</name>
+       <description>Returns last delay line tap value</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTR_TAP_STAT</name>
+       <description>Returns last delay line tap value</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HI_TAP_STAT</name>
+       <description>Returns last delay line tap value</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Selects delay line tap for high point of auto adjustment</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>CTR</name>
+       <description>Selects delay line tap for center point of auto adjustment</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>COARSE</name>
+       <description>Selects delay line tap for coarse or fixed delay portion of the line</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>DET_DLY</name>
+       <description>Number of HCLK between delay line launch and sampling</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>DELAY_ACT</name>
+       <description>Set if the delay is active</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--DVS Dynamic Voltage Scaling-->
+  <peripheral>
+   <name>FCR</name>
+   <description>Function Control Register.</description>
+   <baseAddress>0x40000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>FCTRL0</name>
+     <description>Function Control 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>I2C0DGEN0</name>
+       <description>I2C0 SDA Pad Deglitcher enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0DGEN1</name>
+       <description>I2C0 SCL Pad Deglitcher enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN0</name>
+       <description>I2C1 SDA Pad Deglitcher enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN1</name>
+       <description>I2C1 SCL Pad Deglitcher enable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2DGEN0</name>
+       <description>I2C2 SDA Pad Deglitcher enable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2DGEN1</name>
+       <description>I2C2 SCL Pad Deglitcher enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL0</name>
+     <description>Automatic Calibration 0.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ACEN</name>
+       <description>Auto-calibration Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACRUN</name>
+       <description>Autocalibration Run.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDTRM</name>
+       <description>Load Trim.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GAININV</name>
+       <description>Invert Gain.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ATOMIC</name>
+       <description>Atomic mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MU</name>
+       <description>MU value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>HIRC96MACTMROUT</name>
+       <description>HIRC96M Trim Value.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL1</name>
+     <description>Automatic Calibration 1.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INITTRM</name>
+       <description>Initial Trim Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL2</name>
+     <description>Automatic Calibration 2</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONECNT</name>
+       <description>Auto-callibration Done Counter Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>ACDIV</name>
+       <description>Auto-callibration Div Setting.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>URVBOOTADDR</name>
+     <description>RISC-V Boot Address.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>URVCTRL</name>
+     <description>RISC-V Control Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MEMSEL</name>
+       <description>RAM2, RAM3 exclusive ownership.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IFLUSHEN</name>
+       <description>URV instruction flush enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ERFOKS</name>
+     <description>ERFO Kick Start Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>KSERFO_CNT</name>
+       <description>Kick Start ERFO Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>KSERFO_EN</name>
+       <description>Kick Start ERFO Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KSERFODRIVER</name>
+       <description>Kick Start ERFO Driver.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>KSERFO2X</name>
+       <description>Kick Start ERFO 2X Pulse.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KSCLKSEL</name>
+       <description>Kick Start Clock Select for ERFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ISO</name>
+         <description>ISO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>IPO.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ERFO_INTFL</name>
+     <description>ERFO Ready Interrupt Flag register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>rdy</name>
+       <description>Ready interrupt flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ERFO_INTEN</name>
+     <description>ERFO Ready Interrupt Enable register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>rdy</name>
+       <description>Ready interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FCR Function Control Register.-->
+  <peripheral>
+   <name>FLC</name>
+   <description>Flash Memory Control.</description>
+   <prependToName>FLSH_</prependToName>
+   <baseAddress>0x40029000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Flash_Controller</name>
+    <description>Flash Controller interrupt.</description>
+    <value>23</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ADDR</name>
+     <description>Flash Write Address.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address for next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Flash Clock Divide. The clock (PLL0) is divided by this value to generate a 1 MHz clock for Flash controller.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000064</resetValue>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Flash Clock Divide. The clock is divided by this value to generate a 1MHz clock for flash controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Flash Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WR</name>
+       <description>Write.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="WR">
+       <name>ME</name>
+       <description>Mass Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="WR">
+       <name>PGE</name>
+       <description>Page Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERASE_CODE</name>
+       <description>Erase Code.  The ERASE_CODE must be set up property before erase operation can be initiated. These bits are automatically cleared after the operation is complete.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>erasePage</name>
+         <description>Enable Page Erase.</description>
+         <value>0x55</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>eraseAll</name>
+         <description>Enable Mass Erase. The debug port must be enabled.</description>
+         <value>0xAA</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PEND</name>
+       <description>Flash Pending.  When Flash operation is in progress (busy), Flash reads and writes will fail. When PEND is set, write to all Flash registers, with exception of the Flash interrupt register, are ignored.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LVE</name>
+       <description>Low Voltage enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNLOCK</name>
+       <description>Flash Unlock.  The correct unlock code must be written to these four bits before any Flash write or erase operation is allowed.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Flash Unlocked.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Flash Locked.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Flash Interrupt Register.</description>
+     <addressOffset>0x024</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Flash Done Interrupt.  This bit is set to 1 upon Flash write or erase completion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AF</name>
+       <description>Flash Access Fail.  This bit is set when an attempt is made to write the flash while the flash is busy or the flash is locked. This bit can only be set to 1 by hardware.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONEIE</name>
+       <description>Flash Done Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DONEIE">
+       <name>AFIE</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCDATA</name>
+     <description>ECC Data Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>EVEN</name>
+       <description>Error Correction Code Odd Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>ODD</name>
+       <description>Error Correction Code Even Data.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA[%s]</name>
+     <description>Flash Write Data.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACTRL</name>
+     <description>Access Control Register. Writing the ACTRL register with the following values in the order shown, allows read and write access to the system and user Information block:
+    pflc-actrl = 0x3a7f5ca3;
+    pflc-actrl = 0xa1e34f20;
+    pflc-actrl = 0x9608b2c1. When unlocked, a write of any word will disable access to system and user information block. Readback of this register is always zero.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ACTRL</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR0</name>
+     <description>WELR0</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>WELR0</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR1</name>
+     <description>WELR1</description>
+     <addressOffset>0x88</addressOffset>
+     <fields>
+      <field>
+       <name>WELR1</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR0</name>
+     <description>RLR0</description>
+     <addressOffset>0x90</addressOffset>
+     <fields>
+      <field>
+       <name>RLR0</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR1</name>
+     <description>RLR1</description>
+     <addressOffset>0x98</addressOffset>
+     <fields>
+      <field>
+       <name>RLR1</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FLC Flash Memory Control.-->
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x40000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SYSCTRL</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>BSTAPEN</name>
+       <description>Boundary Scan TAP enable. When enabled, the JTAG port is conneted to the Boundary Scan TAP instead of the ARM ICE.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH_PAGE_FLIP</name>
+       <description>Flips the Flash bottom and top halves. (Depending on the total flash size, each half is either 256K or 512K). Initiating a flash page flip will cause a flush of both the data buffer on the DCODE bus and the internal instruction buffer.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Physical layout matches logical layout.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>swapped</name>
+         <description>Bottom half mapped to logical top half and vice versa.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICC0_FLUSH</name>
+       <description>Code Cache Flush. This bit is used to flush the code caches and the instruction buffer of the Cortex-M4. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROMDONE</name>
+       <description>ROM_DONE status. Used to disable SWD interface during system initialization procedure</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CCHK</name>
+       <description>Compute ROM Checksum. This bit is self-cleared when calculation is completed. Once set, software clearing this bit is ignored and the bit will remain set until the operation is completed.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SWD_DIS</name>
+       <description> Serial Wire Debug Disable. This bit is used to disable the serial wire debug interface This bit is only writeable if (FMV lock word is not programmed) or if (ICE lock word is not programmed and the ROM_DONE bit is not set).</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHKRES</name>
+       <description>ROM Checksum Result. This bit is only valid when CHKRD=1.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pass</name>
+         <description>ROM Checksum Correct.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fail</name>
+         <description>ROM Checksum Fail.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OVR</name>
+       <description>Operating Voltage Range.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA">
+       <name>WDT0</name>
+       <description>Watchdog Timer 0 Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO1</name>
+       <description>GPIO1 Reset. Setting this bit to 1 resets GPIO1 pins to their default states.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR0</name>
+       <description>Timer 0 Reset. Setting this bit to 1 resets Timer 0 blocks.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR1</name>
+       <description>Timer 1 Reset. Setting this bit to 1 resets Timer 1 blocks.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR2</name>
+       <description>Timer 2 Reset. Setting this bit to 1 resets Timer 2 blocks.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR3</name>
+       <description>Timer 3 Reset. Setting this bit to 1 resets Timer 3 blocks.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART0</name>
+       <description>UART 0 Reset. Setting this bit to 1 resets all UART 0 blocks.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART1</name>
+       <description>UART 1 Reset. Setting this bit to 1 resets all UART 1 blocks.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI1</name>
+       <description>SPI 1 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>I2C0</name>
+       <description>I2C 0 Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>RTC</name>
+       <description>Real Time Clock Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SMPHR</name>
+       <description>Semaphore Reset.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TRNG</name>
+       <description>TRNG Reset. This reset is only available during the manufacture testing phase.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>CNN</name>
+       <description>CNN Reset.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>ADC</name>
+       <description>ADC Reset.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART2</name>
+       <description>UART2 Reset. Setting this bit to 1 resets all UART 2 blocks.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SOFT</name>
+       <description>Soft Reset. Setting this bit to 1 resets everything except the CPU and the watchdog timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>PERIPH</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SYS</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>SYSCLK_DIV</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the PLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_SEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ISO</name>
+         <description>The internal 60 MHz oscillator is used for the system clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERFO</name>
+         <description>32MHz Crystal is used for the system clock.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INRO</name>
+         <description>8 kHz LIRC is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>The internal 96 MHz oscillator is used for the system clock.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBRO</name>
+         <description>The internal 7.3725 MHz oscillator is used for the system clock.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERTCO</name>
+         <description> 32 kHz is used for the system clock.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EXTCLK</name>
+         <description> External clock on GPIO0.30.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_RDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_EN</name>
+       <description>32MHz Crystal Oscillator Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>32 kHz Crystal Oscillator Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>ISO_EN</name>
+       <description>60 MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>IPO_EN</name>
+       <description>100 MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>IBRO_EN</name>
+       <description>7.3725 MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_VS</name>
+       <description>7.3725 MHz High Frequency Internal Reference Clock Voltage Select. This register bit is used to select the power supply to the IBRO.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Vcor</name>
+         <description>VCore Supply</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1V</name>
+         <description>Dedicated 1V regulated supply.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_RDY</name>
+       <description>32MHz Crystal Oscillator Ready</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERTCO_RDY</name>
+       <description>32 kHz Crystal Oscillator Ready</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>ISO_RDY</name>
+       <description>60 MHz HIRC Ready.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>IPO_RDY</name>
+       <description>100 MHz HIRC Ready.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>IBRO_RDY</name>
+       <description>7.3725 MHz HIRC Ready.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>INRO_RDY</name>
+       <description>8 kHz Low Frequency Reference Clock Ready.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PM</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This two bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sleep</name>
+         <description>Cortex-M4 Active, RISC-V Sleep Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>standby</name>
+         <description>Standby Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>backup</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>lpm</name>
+         <description>LPM or CM4 Deep Sleep Mode.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>upm</name>
+         <description>UPM.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>powerdown</name>
+         <description>Power Down Mode.</description>
+         <value>10</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO_WE</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wake Up Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wake Up Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>RTC_WE</name>
+       <description>RTC Alarm Wake Up Enable. This bit enables RTC alarm as wakeup source. If enabled, the desired RTC alarm must be configured via the RTC control registers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>WUT_WE</name>
+       <description>WUT Wake Up Enable. This bit enables the Wake-Up Timer as wakeup source. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>AINCOMP_WE</name>
+       <description>AIN COMP Wake Up Enable. This bit enables AIN COMP as wakeup source. </description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ISO_PD</name>
+       <description>60 MHz power down. This bit selects the 60 MHz clock power state in DEEPSLEEP mode.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ISO_PD">
+       <name>IPO_PD</name>
+       <description>100 MHz power down. This bit selects 100 MHz clock power state in DEEPSLEEP mode. </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ISO_PD">
+       <name>IBRO_PD</name>
+       <description>7.3725 MHz power down. This bit selects 7.3725 MHz clock power state in DEEPSLEEP mode. </description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_BP</name>
+       <description>32MHz Oscillator Bypass</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIV</name>
+     <description>Peripheral Clock Divider.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>ADCFRQ</name>
+       <description>ADC clock Frequency. These bits define the ADC clock frequency. fADC = fPCLK / (ADCFRQ)</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CNNCLKDIV</name>
+       <description>CNN Clock Divider.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div2</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div1</name>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CNNCLKSEL</name>
+       <description>CNN Clock Select.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>system</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBRO60</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0</name>
+       <description>GPIO0 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>GPIO1</name>
+       <description>GPIO1 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>DMA</name>
+       <description>DMA Clock Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI1</name>
+       <description>SPI 1 Clock Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART0</name>
+       <description>UART 0 Clock Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART1</name>
+       <description>UART 1 Clock Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C0</name>
+       <description>I2C 0 Clock Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR0</name>
+       <description>Timer 0 Clock Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR1</name>
+       <description>Timer 1 Clock Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR2</name>
+       <description>Timer 2 Clock Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR3</name>
+       <description>Timer 3 Clock Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>ADC</name>
+       <description>ADC Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>CNN</name>
+       <description>CNN Clock Disable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C1</name>
+       <description>I2C 1 Clock Disable.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>PT</name>
+       <description>Pluse Train Clock Disable.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCTRL</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 2.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM0ECC</name>
+       <description>SYSRAM0 ECC Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMZ</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM Block 0 Zeroization.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM1</name>
+       <description>System RAM Block 1 Zeroization.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM2</name>
+       <description>System RAM Block 2 Zeroization.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM3</name>
+       <description>System RAM Block 3 Zeroization.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>SYSRAM0ECC</name>
+       <description>System RAM 0 ECC Zeroization.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICC0</name>
+       <description>Instruction Cachei 0 Zeroization.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICC1</name>
+       <description>Instruction Cachei 1 Zeroization.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSST</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICELOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>I2C1</name>
+       <description>I2C1 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>PT</name>
+       <description>PT Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>OWM</name>
+       <description>OWM Reset.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>CRC</name>
+       <description>CRC Reset.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AES</name>
+       <description>AES Reset.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPI0</name>
+       <description>SPI 0 Reset.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SMPHR</name>
+       <description>SMPHR Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2S</name>
+       <description>I2S Reset.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2C2</name>
+       <description>I2C2 Reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>DVS</name>
+       <description>DVS Reset.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SIMO</name>
+       <description>SIMO Reset.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>CPU1</name>
+       <description>CPU1 Reset.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>BTLE</name>
+       <description>Bluetooth Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART2</name>
+       <description>UART2 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="UART2">
+       <name>TRNG</name>
+       <description>TRNG Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SMPHR</name>
+       <description>SMPHR Clock Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>OWM</name>
+       <description>One-Wire Clock Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>CRC</name>
+       <description>CRC Clock Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>AES</name>
+       <description>AES Clock Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SPI0</name>
+       <description>SPI 0 Clock Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>PCIF</name>
+       <description>Parallel Camera Interface Clock Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>I2S</name>
+       <description>I2S Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>I2C2</name>
+       <description>I2C2 Clock Disable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>WDT0</name>
+       <description>Watch Dog Timer 0 Clock Disable.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>CPU1</name>
+       <description>CPU1 Clock Disable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVENTEN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Enable RXEV pin event. When this bit is set, a logic high of GPIO1.8 will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO1.9.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REVISION</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSIE</name>
+     <description>System Status Interrupt Enable Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEUNLOCK</name>
+       <description>ARM ICE Unlock Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCERR</name>
+     <description>ECC Error Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCCED</name>
+     <description>ECC Not Double Error Detect Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCIE</name>
+     <description>ECC IRQ Enable Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Interrup Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCADDR</name>
+     <description>ECC Error Address Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ECCERRAD</name>
+       <description>ECC Error Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLELDOCTRL</name>
+     <description>BTLE LDO Control Register</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>LDOBBEN</name>
+       <description>LDOBB Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBPULLD</name>
+       <description>LDOBB Pull Down.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBVSEL</name>
+       <description>LDOBB Voltage Setting.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_85</name>
+         <description>0.85V</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>0_9</name>
+         <description>0.9V</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0</name>
+         <description>1.0V</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1</name>
+         <description>1.1V</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDORFEN</name>
+       <description>LDORF Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORFPULLD</name>
+       <description>LDORF Pull Down.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORFVSEL</name>
+       <description>LDORF Voltage Setting.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_85</name>
+         <description>0.85V</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>0_9</name>
+         <description>0.9V</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0</name>
+         <description>1.0V</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1</name>
+         <description>1.1V</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDORFBYP</name>
+       <description>LDORF Bypass Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORFDISCH</name>
+       <description>LDORF Discharge.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBBYP</name>
+       <description>LDOBB Bypass Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBDISCH</name>
+       <description>LDOBB Discharge.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBENDLY</name>
+       <description>LDOBB Enable Delay.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORFENDLY</name>
+       <description>LDORF Enable Delay.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORFBYPENENDLY</name>
+       <description>LDORF Bypass Enable Delay.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBBYPENENDLY</name>
+       <description>LDOBB Bypass Enable Delay.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLELDODLY</name>
+     <description>BTLE LDO Delay Register</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>BYPDLYCNT</name>
+       <description>Bypass Delay Count.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBDLYCNT</name>
+       <description>LDOBB Delay Count.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>LDORFDLYCNT</name>
+       <description>LDOBB Delay Count.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPR</name>
+     <description>General Purpose Register.</description>
+     <addressOffset>0x80</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCR Global Control Registers.-->
+  <peripheral>
+   <name>GCFR</name>
+   <description>Global Control Function Register.</description>
+   <baseAddress>0x40005800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>REG0</name>
+     <description>Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ISO_WUP</name>
+       <description>ISO Warm Up Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>IPO_WUP</name>
+       <description>IPO Warm Up Value.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REG1</name>
+     <description>Register 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ERFO_WUP</name>
+       <description>ERFO Warm Up Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_WUP</name>
+       <description>IBRO Warm Up Value.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCFR Global Control Function Register.-->
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x40008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN0</name>
+     <description>GPIO Function Enable Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_SET</name>
+     <description>GPIO Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_OUT bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_IN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTMODE</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTMODE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTPOL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTPOL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INEN</name>
+     <description>GPIO Input Enable</description>
+     <addressOffset>0x30</addressOffset>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_INTFL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WKEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DUALEDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DUALEDGE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL0</name>
+     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL0</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL1</name>
+     <description>GPIO Input Mode Config 2. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL1</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_SET</name>
+     <description>GPIO Alternate Function Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN2</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_SET</name>
+     <description>GPIO Alternate Function 2 Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN2 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_CLR</name>
+     <description>GPIO Wake Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN2 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x7C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HYSEN</name>
+     <description>GPIO Input Hysteresis Enable.</description>
+     <addressOffset>0xA8</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_HYSEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SRSEL</name>
+     <description>GPIO Slew Rate Enable Register.</description>
+     <addressOffset>0xAC</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_SRSEL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>FAST</name>
+         <description>Fast Slew Rate selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SLOW</name>
+         <description>Slow Slew Rate selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS0</name>
+     <description>GPIO Drive Strength  Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS0</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ld</name>
+         <description>GPIO port pin is in low-drive mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hd</name>
+         <description>GPIO port pin is in high-drive mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PS</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VSSEL</name>
+     <description>GPIO Voltage Select.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GPIO0 Individual I/O for each GPIO-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO1</name>
+   <description>Individual I/O for each GPIO 1</description>
+   <baseAddress>0x40009000</baseAddress>
+   <interrupt>
+    <name>GPIO1</name>
+    <description>GPIO1 IRQ</description>
+    <value>25</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO1 Individual I/O for each GPIO 1-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO2</name>
+   <description>Individual I/O for each GPIO 2</description>
+   <baseAddress>0x40080400</baseAddress>
+   <interrupt>
+    <name>GPIO2</name>
+    <description>GPIO2 IRQ</description>
+    <value>26</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO2 Individual I/O for each GPIO 2-->
+  <peripheral>
+   <name>I2C0</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>I2C</groupName>
+   <baseAddress>0x4001D000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2C0</name>
+    <description>I2C0 IRQ</description>
+    <value>13</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>I2C Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable I2C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable I2C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave_mode</name>
+         <description>Slave Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master_mode</name>
+         <description>Master Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_EN</name>
+       <description>General Call Address Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Ignore Gneral Call Address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Acknowledge general call address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_EN</name>
+       <description>Interactive Receive Mode.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interactive Receive Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interactive Receive Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_ACK</name>
+       <description>Data Acknowledge. This bit defines the acknowledge bit returned by the I2C receiver while IRXM = 1 HW forces ACK to 0 when IRXM = 0.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ack</name>
+         <description>return ACK (pulling SDA LOW).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>return NACK (leaving SDA HIGH).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_OUT</name>
+       <description>SCL Output. This bits control SCL output when SWOE =1.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_scl_low</name>
+         <description>Drive SCL low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_scl</name>
+         <description>Release SCL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDA_OUT</name>
+       <description>SDA Output. This bits control SDA output when SWOE = 1. </description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_sda_low</name>
+         <description>Drive SDA low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_sda</name>
+         <description>Release SDA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL</name>
+       <description>SCL status. This bit reflects the logic gate of SCL signal. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDA</name>
+       <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BB_MODE</name>
+       <description>Software Output Enable.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>outputs_disable</name>
+         <description>I2C Outputs SCLO and SDAO disabled. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputs_enable</name>
+         <description>I2C Outputs SCLO and SDAO enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read. This bit reflects the R/W bit of an address match (AMI = 1) or general call match (GCI = 1). This bit is valid 3 cycles after the relevant interrupt bit is set.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKSTR_DIS</name>
+       <description>This bit will disable slave clock stretching when set.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Slave clock stretching enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Slave clock stretching disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ONE_MST_MODE</name>
+       <description>SCL Push-Pull Mode. This bit controls whether SCL is operated in a the I2C standard open-drain mode, or in a non-standard push-pull mode where the Hi-Z output isreplaced with Drive-1. The non-standard mode should only be used when operating as a master and communicating with slaves that are guaranteed to never drive SCL low. </description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Standard open-drain operation:
+					drive low for 0, Hi-Z for 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Non-standard push-pull operation:
+					drive low for 0, drive high for 1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HS_EN</name>
+       <description>High speed mode enable</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>Bus Status.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>I2C Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>I2C Bus Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>RX empty.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX Full.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX Empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>TX Full.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_BUSY</name>
+       <description>Clock Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_actively_driving_scl_clock</name>
+         <description>Device not actively driving SCL clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>actively_driving_scl_clock</name>
+         <description>Device operating as master and actively driving SCL clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL0</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <name>INT_FL0_Done</name>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Interactive Receive Interrupt.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave General Call Address Match Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave Address Match Interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Receive Threshold Interrupt. This bit is automaticcaly cleared when RX_FIFO is below the threshold level.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. RX_FIFO equal or more bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>Transmit Threshold Interrupt. This bit is automaticcaly cleared when TX_FIFO is above the threshold level.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP Interrupt.</description>
+       <bitRange>[6:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Address Acknowledge Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Arbritation error Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>timeout Error Interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Address NACK Error Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Data NACK Error Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Do Not Respond Error Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Start Error Interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Stop Error Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>Transmit Lock Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN0</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when DONE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Description not available.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when RX_MODE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave mode general call address match received input enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when GEN_CTRL_ADDR = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave mode incoming address match interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when ADDR_MATCH = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Above Treshold Level Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Below Treshold Level Interrupt Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Stop Interrupt Enable</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when STOP = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Received Address ACK from Slave Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Master Mode Arbitration Lost Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>Timeout Error Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Master Mode Address NACK Received Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Master Mode Data NACK Received Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Slave Mode Do Not Respond Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Out of Sequence START condition detected interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Out of Sequence STOP condition detected interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>TX FIFO Locked Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL1</name>
+     <description>Interrupt Status Register 1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt. When operating as a slave receiver, this bit is set when you reach the first data bit and the RX FIFO and shift register are both full.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt. When operating as a slave transmitter, this bit is set when you reach the first data bit and the TX FIFO is empty and the master is still asking for more data (i.e the master hasn't sent a NACK yet).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Status Flag.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN1</name>
+     <description>Interrupt Staus Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOLEN</name>
+     <description>FIFO Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RX_DEPTH</name>
+       <description>Receive FIFO Length.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DEPTH</name>
+       <description>Transmit FIFO Length.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL0</name>
+     <description>Receive Control Register 0.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>DNR</name>
+       <description>Do Not Respond.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Always respond to address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>not_respond_rx_fifo_empty</name>
+         <description>Do not respond to address match when RX_FIFO is not empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Receive FIFO Flush. This bit is automatically cleared to 0 after the operation. Setting this bit to 1 will affect RX_FIFO status.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush RX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_LVL</name>
+       <description>Receive FIFO Threshold. These bits define the RX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL1</name>
+     <description>Receive Control Register 1.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Receive Count Bits. These bits define the number of bytes to be received in a transaction, except for the case RXCNT = 0. RXCNT = 0 means 256 bytes to be received in a transaction.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Receive FIFO Count. These bits reflect the number of byte in the RX_FIFO. These bits are flushed when I2CEN = 0.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL0</name>
+     <description>Transmit Control Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_MODE</name>
+       <description>Transmit FIFO Preaload Mode. Setting this bit will allow for high speed application to preload the transmit FIFO prior to Slave Address Match.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TX_READY_MODE</name>
+       <description>Transmit FIFO Ready Manual Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW control of I2CTXRDY enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW control of I2CTXRDY disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO General Call Address Match Auto Flush Disable.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Write Auto Flush Disable.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Read Auto Flush Disable.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NACK_FLUSH_DIS</name>
+       <description>TX FIFO received NACK Auto Flush Disable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Transmit FIFO Flush. This bit is automatically cleared to 0 after the operation.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush TX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_VAL</name>
+       <description>Transmit FIFO Threshold. These bits define the TX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL1</name>
+     <description>Transmit Control Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_RDY</name>
+       <description>Transmit FIFO Preload Ready.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Transmit FIFO Count. These bits reflect the number of bytes in the TX_FIFO.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MSTCTRL</name>
+     <description>Master Control Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Setting this bit to 1 will start a master transfer.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>RESTART</name>
+       <description>Setting this bit to 1 will generate a repeated START.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Setting this bit to 1 will generate a STOP condition.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>EX_ADDR_EN</name>
+       <description>Slave Extend Address Select.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKLO</name>
+     <description>Clock Low Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock low. In master mode, these bits define the SCL low period. In slave mode, these bits define the time SCL will be held low after data is outputted.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKHI</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>HI</name>
+       <description>Clock High. In master mode, these bits define the SCL high period.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HSCLK</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock Low. This field sets the Hs-Mode clock low count. In Slave mode, this is the time SCL is held low after data is output on SDA.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Clock High. This field sets the Hs-Mode clock high count. In Slave mode, this is the time SCL is held high after data is output on SDA</description>
+       <bitRange>[15:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TIMEOUT</name>
+     <description>Timeout Register</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_TO_VAL</name>
+       <description>Timeout</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>SLAVE_MULTI[%s]</name>
+     <description>Slave Address Register.</description>
+     <alternateRegister>SLAVE0</alternateRegister>
+     <addressOffset>0x4C</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Slave Address.</description>
+       <bitRange>[9:0]</bitRange>
+      </field>
+      <field>
+       <name>DIS</name>
+       <description>Slave Disable.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>EXT_ADDR_EN</name>
+       <description>Extended Address Select.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLAVE0</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE1</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x50</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE2</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x54</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE3</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x58</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2C0 Inter-Integrated Circuit.-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C1</name>
+   <description>Inter-Integrated Circuit. 1</description>
+   <baseAddress>0x4001E000</baseAddress>
+   <interrupt>
+    <name>I2C1</name>
+    <description>I2C1 IRQ</description>
+    <value>36</value>
+   </interrupt>
+  </peripheral>
+<!--I2C1 Inter-Integrated Circuit. 1-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C2</name>
+   <description>Inter-Integrated Circuit. 2</description>
+   <baseAddress>0x4001F000</baseAddress>
+   <interrupt>
+    <name>I2C2</name>
+    <description>I2C2 IRQ</description>
+    <value>62</value>
+   </interrupt>
+  </peripheral>
+<!--I2C2 Inter-Integrated Circuit. 2-->
+  <peripheral>
+   <name>I2S</name>
+   <description>Inter-IC Sound Interface.</description>
+   <groupName>I2S</groupName>
+   <baseAddress>0x40060000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2S</name>
+    <description>I2S IRQ</description>
+    <value>99</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0CH0</name>
+     <description>Global mode channel.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>LSB_FIRST</name>
+       <description>LSB Transmit Receive First.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_FILT</name>
+       <description>PDM Filter.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_EN</name>
+       <description>PDM Enable.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>USEDDR</name>
+       <description>DDR.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_INV</name>
+       <description>Invert PDM.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_MODE</name>
+       <description>SCK Select.</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>WS_POL</name>
+       <description>WS polarity select. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB_LOC</name>
+       <description>MSB location. </description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ALIGN</name>
+       <description>Align to MSB or LSB.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EXT_SEL</name>
+       <description>External SCK/WS selection.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>STEREO</name>
+       <description>Stereo mode of I2S.</description>
+       <bitRange>[13:12]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WSIZE</name>
+       <description>Data size when write to FIFO.</description>
+       <bitRange>[15:14]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable. </description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable. </description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Flushes the TX/RX FIFO buffer. </description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RST</name>
+       <description>Write 1 to reset channel. </description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_LSB</name>
+       <description>Bit Field Control. </description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>depth of receive FIFO for threshold interrupt generation. </description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1CH0</name>
+     <description>Local channel Setup.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>BITS_WORD</name>
+       <description>I2S word length.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>I2S clock enable.</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SMP_SIZE</name>
+       <description>I2S sample size length.</description>
+       <bitRange>[13:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EXTCLK_EN</name>
+       <description>Selects the clock source for master mode operations in the ME17B.</description>
+       <bitRange>[14:14]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>erfo</name>
+         <description>Use ERFO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ext</name>
+         <description>Use External Clock.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADJUST</name>
+       <description>LSB/MSB Justify.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>I2S clock frequency divisor.</description>
+       <bitRange>[31:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FILTCH0</name>
+     <description>Filter.</description>
+     <addressOffset>0x20</addressOffset>
+    </register>
+    <register>
+     <name>DMACH0</name>
+     <description>DMA Control.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DMA_TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger.</description>
+       <bitRange>[6:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA channel enable.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_THD_VAL</name>
+       <description>RX FIFO Level DMA Trigger.</description>
+       <bitRange>[14:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA channel enable.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Number of data word in the TX FIFO.</description>
+       <bitRange>[23:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Number of data word in the RX FIFO.</description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOCH0</name>
+     <description>I2S Fifo.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>ISR Status.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Status for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Status for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Status for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Status for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Enable for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Enable for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Enable for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Enable for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EXTSETUP</name>
+     <description>Ext Control.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>EXT_BITS_WORD</name>
+       <description>Word Length for ch_mode.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wakeup Enable.</description>
+     <addressOffset>0x5C</addressOffset>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wakeup Flags.</description>
+     <addressOffset>0x60</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2S Inter-IC Sound Interface.-->
+  <peripheral>
+   <name>ICC0</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x4002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x800</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>INFO</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SZ</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCH</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEM</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ICC0 Instruction Cache Controller Registers-->
+  <peripheral>
+   <name>LPCMP</name>
+   <description>Low Power Comparator</description>
+   <baseAddress>0x40088000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>LPCMP</name>
+    <description>Low Power Comparato</description>
+    <value>103</value>
+   </interrupt>
+   <registers>
+    <register>
+     <dim>3</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CTRL[%s]</name>
+     <description>Comparator Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Comparator Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>POL</name>
+       <description>Polarity Select</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTEN</name>
+       <description>IRQ Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUT</name>
+       <description>Raw Compartor Input.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTFL</name>
+       <description>IRQ Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--LPCMP Low Power Comparator-->
+  <peripheral>
+   <name>LPGCR</name>
+   <description>Low Power Global Control.</description>
+   <baseAddress>0x40080000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RST</name>
+     <description>Low Power Reset Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO2</name>
+       <description>Low Power GPIO 2 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>WDT1</name>
+       <description>Low Power Watchdog Timer 1 Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR4</name>
+       <description>Low Power Timer 4 Reset.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR5</name>
+       <description>Low Power Timer 5 Reset.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>UART3</name>
+       <description>Low Power UART 3 Reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>LPCOMP</name>
+       <description>Low Power Comparator Reset.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS</name>
+     <description>Low Power Peripheral Clock Disable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO2</name>
+       <description>Low Power GPIO 2 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>WDT1</name>
+       <description>Low Power Watchdog 1 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR4</name>
+       <description>Low Power Timer 4 Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR5</name>
+       <description>Low Power Timer 5 Clock Disable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>UART3</name>
+       <description>Low Power UART 3 Clock Disable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>LPCOMP</name>
+       <description>Low Power Comparator Clock Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--LPGCR Low Power Global Control.-->
+  <peripheral>
+   <name>MCR</name>
+   <description>Misc Control.</description>
+   <baseAddress>0x40006C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>ECCEN</name>
+     <description>ECC Enable Register</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>ECC System RAM0 Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPO_MTRIM</name>
+     <description>IPO Manual Register</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>MTRIM</name>
+       <description>Manual Trim Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>TRIM_RANGE</name>
+       <description>Trim Range Select.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>Output Enable Register</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>SQWOUT_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PDOWN_OUT_EN</name>
+       <description>Power Down Output Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP_CTRL</name>
+     <description>Comparator Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Comparator Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>POL</name>
+       <description>Polarity Select</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INT_EN</name>
+       <description>IRQ Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUT</name>
+       <description>Comparator Output State.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INT_FL</name>
+       <description>IRQ Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Miscellaneous Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>CMPHYST</name>
+       <description>Comparator hysteresis control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>INRO_EN</name>
+       <description>INRO Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>ERTCO Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_EN</name>
+       <description>IBRO Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>32KOSC_EN</name>
+       <description>Enable 32K Oscillator input.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SIMO_CLKSCL_EN</name>
+       <description>SIMO Clock Scaling Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SIMO_RSTD</name>
+       <description>SIMO System Reset Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO3_CTRL</name>
+     <description>GPIO3 Pin Control Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>P30_DO</name>
+       <description>GPIO3 Pin 0 Data Output.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P30_OE</name>
+       <description>GPIO3 Pin 0 Output Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P30_PE</name>
+       <description>GPIO3 Pin 0 Pull-up Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P30_IN</name>
+       <description>GPIO3 Pin 0 Input Status.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_DO</name>
+       <description>GPIO3 Pin 1 Data Output.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_OE</name>
+       <description>GPIO3 Pin 1 Output Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_PE</name>
+       <description>GPIO3 Pin 1 Pull-up Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_IN</name>
+       <description>GPIO3 Pin 1 Input Status.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--MCR Misc Control.-->
+  <peripheral>
+   <name>OWM</name>
+   <description>1-Wire Master Interface.</description>
+   <baseAddress>0x4003D000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>OneWire</name>
+    <value>67</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CFG</name>
+     <description>1-Wire Master Configuration.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>long_line_mode</name>
+       <description>Long Line Mode.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>force_pres_det</name>
+       <description>Force Line During Presence Detect.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_en</name>
+       <description>Bit Bang Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_mode</name>
+       <description>Provide an extra output control to control an external pullup.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_enable</name>
+       <description>Enable External Pullup.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>single_bit_mode</name>
+       <description>Enable Single Bit TX/RX Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>overdrive</name>
+       <description>Enables overdrive speed for 1-Wire operations.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>int_pullup_enable</name>
+       <description>Enable intenral pullup.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_DIV_1US</name>
+     <description>1-Wire Master Clock Divisor.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>divisor</name>
+       <description>Clock Divisor for 1Mhz.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL_STAT</name>
+     <description>1-Wire Master Control/Status.</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>start_ow_reset</name>
+       <description>Start OW Reset.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>sra_mode</name>
+       <description>SRA Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_oe</name>
+       <description>Bit Bang Output Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ow_input</name>
+       <description>OW Input State.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>od_spec_mode</name>
+       <description>Overdrive Spec Mode.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>presence_detect</name>
+       <description>Presence Pulse Detected.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>1-Wire Master Data Buffer.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>tx_rx</name>
+       <description>TX/RX Buffer.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>1-Wire Master Interrupt Flags.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>TX Data Empty Interrupt Flag.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>RX Data Ready Interrupt Flag</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Flag.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Flag.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>1-Wire Master Interrupt Enables.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>Tx Data Empty Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>Rx Data Ready Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Enable.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--OWM 1-Wire Master Interface.-->
+  <peripheral>
+   <name>PT</name>
+   <description>Pulse Train</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C020</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0010</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RATE_LENGTH</name>
+     <description>Pulse Train Configuration</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>rate_control</name>
+       <description>Pulse Train Enable and Rate Control. Set to 0 to disable the Pulse Train.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>27</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>mode</name>
+       <description>Pulse Train Output Mode/Train Length</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>32_BIT</name>
+         <description>Pulse train, 32 bit pattern.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SQUARE_WAVE</name>
+         <description>Square wave mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_BIT</name>
+         <description>Pulse train, 2 bit pattern.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_BIT</name>
+         <description>Pulse train, 3 bit pattern.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_BIT</name>
+         <description>Pulse train, 4 bit pattern.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5_BIT</name>
+         <description>Pulse train, 5 bit pattern.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_BIT</name>
+         <description>Pulse train, 6 bit pattern.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7_BIT</name>
+         <description>Pulse train, 7 bit pattern.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_BIT</name>
+         <description>Pulse train, 8 bit pattern.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9_BIT</name>
+         <description>Pulse train, 9 bit pattern.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_BIT</name>
+         <description>Pulse train, 10 bit pattern.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11_BIT</name>
+         <description>Pulse train, 11 bit pattern.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_BIT</name>
+         <description>Pulse train, 12 bit pattern.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13_BIT</name>
+         <description>Pulse train, 13 bit pattern.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14_BIT</name>
+         <description>Pulse train, 14 bit pattern.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15_BIT</name>
+         <description>Pulse train, 15 bit pattern.</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_BIT</name>
+         <description>Pulse train, 16 bit pattern.</description>
+         <value>16</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>17_BIT</name>
+         <description>Pulse train, 17 bit pattern.</description>
+         <value>17</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>18_BIT</name>
+         <description>Pulse train, 18 bit pattern.</description>
+         <value>18</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>19_BIT</name>
+         <description>Pulse train, 19 bit pattern.</description>
+         <value>19</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>20_BIT</name>
+         <description>Pulse train, 20 bit pattern.</description>
+         <value>20</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>21_BIT</name>
+         <description>Pulse train, 21 bit pattern.</description>
+         <value>21</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>22_BIT</name>
+         <description>Pulse train, 22 bit pattern.</description>
+         <value>22</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>23_BIT</name>
+         <description>Pulse train, 23 bit pattern.</description>
+         <value>23</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>24_BIT</name>
+         <description>Pulse train, 24 bit pattern.</description>
+         <value>24</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>25_BIT</name>
+         <description>Pulse train, 25 bit pattern.</description>
+         <value>25</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>26_BIT</name>
+         <description>Pulse train, 26 bit pattern.</description>
+         <value>26</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>27_BIT</name>
+         <description>Pulse train, 27 bit pattern.</description>
+         <value>27</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>28_BIT</name>
+         <description>Pulse train, 28 bit pattern.</description>
+         <value>28</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>29_BIT</name>
+         <description>Pulse train, 29 bit pattern.</description>
+         <value>29</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30_BIT</name>
+         <description>Pulse train, 30 bit pattern.</description>
+         <value>30</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>31_BIT</name>
+         <description>Pulse train, 31 bit pattern.</description>
+         <value>31</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRAIN</name>
+     <description>Write the repeating bit pattern that is shifted out, LSB first, when configured in Pulse Train mode. See PT_RATE_LENGTH.mode for setting the length.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>LOOP</name>
+     <description>Pulse Train Loop Count</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>count</name>
+       <description>Number of loops for this pulse train to repeat.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>delay</name>
+       <description>Delay between loops of the Pulse Train in PT Peripheral Clock cycles</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>12</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESTART</name>
+     <description> Pulse Train Auto-Restart Configuration.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt_x_select</name>
+       <description>Auto-Restart PT X Select</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_x_loop_exit</name>
+       <description>Enable Auto-Restart on PT X Loop Exit</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt_y_select</name>
+       <description>Auto-Restart PT Y Select</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_y_loop_exit</name>
+       <description>Enable Auto-Restart on PT Y Loop Exit</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PT Pulse Train-->
+  <peripheral derivedFrom="PT">
+   <name>PT1</name>
+   <description>Pulse Train 1</description>
+   <baseAddress>0x4003C030</baseAddress>
+  </peripheral>
+<!--PT1 Pulse Train 1-->
+  <peripheral derivedFrom="PT">
+   <name>PT2</name>
+   <description>Pulse Train 2</description>
+   <baseAddress>0x4003C040</baseAddress>
+  </peripheral>
+<!--PT2 Pulse Train 2-->
+  <peripheral derivedFrom="PT">
+   <name>PT3</name>
+   <description>Pulse Train 3</description>
+   <baseAddress>0x4003C050</baseAddress>
+  </peripheral>
+<!--PT3 Pulse Train 3-->
+  <peripheral>
+   <name>PTG</name>
+   <description>Pulse Train Generation</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0018</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>PT</name>
+    <description>Pulse Train IRQ</description>
+    <value>59</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ENABLE</name>
+     <description>Global Enable/Disable Controls for All Pulse Trains</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Enable/Disable control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Enable/Disable control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Enable/Disable control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Enable/Disable control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESYNC</name>
+     <description>Global Resync (All Pulse Trains) Control</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Resync control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Resync control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Resync control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Resync control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STOP_INTFL</name>
+     <description>Pulse Train Stop Interrupt Flags</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STOP_INTEN</name>
+     <description>Pulse Train Stop Interrupt Enable/Disable</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_EN</name>
+     <description>Pulse Train Global Safe Enable.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_DIS</name>
+     <description>Pulse Train Global Safe Disable.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTFL</name>
+     <description>Pulse Train Ready Interrupt Flags</description>
+     <addressOffset>0x0018</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Ready Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Ready Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Ready Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Ready Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTEN</name>
+     <description>Pulse Train Ready Interrupt Enable/Disable</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Ready Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Ready Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Ready Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Ready Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PTG Pulse Train Generation-->
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x40006800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>LPCN</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAMRET0</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 0 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET1</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 1 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET2</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 2 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET3</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPMCLKSEL</name>
+       <description>Low Power Mode APB Clock Select.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPMFAST</name>
+       <description>Low Power Mode Clock Select.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BG_DIS</name>
+       <description>Bandgap OFF. This controls the System Bandgap in DeepSleep mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>Bandgap is always ON.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>Bandgap is OFF in DeepSleep mode (default).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPWKST_CLR</name>
+       <description>Low Power Wakeup Status Register Clear</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST0</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO0.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN0</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register derivedFrom="LPWKST0">
+     <name>LPWKST1</name>
+     <description>Low Power I/O Wakeup Status Register 1. This register indicates the low power wakeup status for GPIO1.</description>
+     <addressOffset>0x0C</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN1</name>
+     <description>Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup functionality for GPIO1.</description>
+     <addressOffset>0x10</addressOffset>
+    </register>
+    <register derivedFrom="LPWKST0">
+     <name>LPWKST2</name>
+     <description>Low Power I/O Wakeup Status Register 2. This register indicates the low power wakeup status for GPIO2.</description>
+     <addressOffset>0x14</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN2</name>
+     <description>Low Power I/O Wakeup Enable Register 2. This register enables low power wakeup functionality for GPIO2.</description>
+     <addressOffset>0x18</addressOffset>
+    </register>
+    <register derivedFrom="LPWKST0">
+     <name>LPWKST3</name>
+     <description>Low Power I/O Wakeup Status Register 3. This register indicates the low power wakeup status for GPIO3.</description>
+     <addressOffset>0x1C</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN3</name>
+     <description>Low Power I/O Wakeup Enable Register 3. This register enables low power wakeup functionality for GPIO3.</description>
+     <addressOffset>0x20</addressOffset>
+    </register>
+    <register>
+     <name>LPPWST</name>
+     <description>Low Power Peripheral Wakeup Status Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>AINCOMP0</name>
+       <description>Analog Input Comparator Wakeup Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BACKUP</name>
+       <description>Backup Mode Wakeup Flag.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESET</name>
+       <description>Reset Detected Wakeup Flag.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWEN</name>
+     <description>Low Power Peripheral Wakeup Enable Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>AINCOMP0</name>
+       <description> AINCOMP0 Wakeup Enable. This bit allows wakeup from the AINCOMP0.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WDT0</name>
+       <description> WDT0 Wakeup Enable. This bit allows wakeup from the WDT0.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WDT1</name>
+       <description> WDT1 Wakeup Enable. This bit allows wakeup from the WDT1.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CPU1</name>
+       <description> CPU1 Wakeup Enable. This bit allows wakeup from the CPU1.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR0</name>
+       <description> TMR0 Wakeup Enable. This bit allows wakeup from the TMR0.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR1</name>
+       <description> TMR1 Wakeup Enable. This bit allows wakeup from the TMR1.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR2</name>
+       <description> TMR2 Wakeup Enable. This bit allows wakeup from the TMR2.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR3</name>
+       <description> TMR3 Wakeup Enable. This bit allows wakeup from the TMR3.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR4</name>
+       <description> TMR4 Wakeup Enable. This bit allows wakeup from the TMR4.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR5</name>
+       <description> TMR5 Wakeup Enable. This bit allows wakeup from the TMR5.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART0</name>
+       <description> UART0 Wakeup Enable. This bit allows wakeup from the UART0.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART1</name>
+       <description> UART1 Wakeup Enable. This bit allows wakeup from the UART1.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART2</name>
+       <description> UART2 Wakeup Enable. This bit allows wakeup from the UART2.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART3</name>
+       <description> UART3 Wakeup Enable. This bit allows wakeup from the UART3.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C0</name>
+       <description> I2C0 Wakeup Enable. This bit allows wakeup from the I2C0.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C1</name>
+       <description> I2C1 Wakeup Enable. This bit allows wakeup from the I2C1.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C2</name>
+       <description> I2C2 Wakeup Enable. This bit allows wakeup from the I2C2.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2S</name>
+       <description> I2S Wakeup Enable. This bit allows wakeup from the I2S.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SPI1</name>
+       <description> SPI1 Wakeup Enable. This bit allows wakeup from the SPI1.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPCMP</name>
+       <description> LPCMP Wakeup Enable. This bit allows wakeup from the LPCMP.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VBTLEPD</name>
+     <description>Low-Power VBTLE Power Down Register.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>BTLE</name>
+       <description>Power Down SIMO VREGO_D.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GP0</name>
+     <description>General Purpose Register 0</description>
+     <addressOffset>0x48</addressOffset>
+    </register>
+    <register>
+     <name>GP1</name>
+     <description>General Purpose Register 1</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--PWRSEQ Power Sequencer / Low Power Control Register.-->
+  <peripheral>
+   <name>RTC</name>
+   <description>Real Time Clock and Alarm.</description>
+   <baseAddress>0x40006000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>RTC</name>
+    <description>RTC interrupt.</description>
+    <value>3</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC</name>
+       <description>Sub-Seconds Counter (12-bit).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TODA</name>
+     <description>Time-of-day Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-day Alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSECA</name>
+     <description>RTC sub-second alarm.  This register contains the reload value for the sub-second alarm.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>This register contains the reload value for the sub-second alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>RTC Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Real Time Clock Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM_IE</name>
+       <description>Alarm Time-of-Day Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM_IE</name>
+       <description>Alarm Sub-second Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>RTC Busy. This bit is set to 1 by hardware when changes to RTC registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>RTC Ready. This bit is set to 1 by hardware when the RTC count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the RTC count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY_IE</name>
+       <description>RTC Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-Day Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>Sub-second Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_SEL</name>
+       <description>Frequency Output Selection. When SQE=1, these bits specify the output frequency on the SQW pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq1Hz</name>
+         <description>1 Hz (Compensated).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq512Hz</name>
+         <description>512 Hz (Compensated).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq4KHz</name>
+         <description>4 KHz.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clkDiv8</name>
+         <description>RTC Input Clock / 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_EN</name>
+       <description>Asynchronous Counter Read Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_EN</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical RTC bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIM</name>
+     <description>RTC Trim Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>RTC Trim. This register contains the 2's complement value that specifies the trim resolution. Each increment or decrement of the bit adds or subtracts 1ppm at each 4KHz clock value, with a maximum correction of +/- 127ppm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VRTC_TMR</name>
+       <description>VBAT Timer Value. When RTC is running off of VBAT, this field is incremented every 32 seconds.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>RTC Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>FILTER_EN</name>
+       <description>Enables analog deglitch filter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_SEL</name>
+       <description>If IBIAS_EN is 1, selects 4x,2x mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HYST_EN</name>
+       <description>Enables high current hysteresis buffer.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_EN</name>
+       <description>Enables higher 4x,2x current modes.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYPASS</name>
+       <description>RTC Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SQW_32K</name>
+       <description>RTC 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--RTC Real Time Clock and Alarm.-->
+  <peripheral>
+   <name>SEMA</name>
+   <description>The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.</description>
+   <baseAddress>0x4003E000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>SEMAPHORES[%s]</name>
+     <description>Read to test and set, returns prior value. Write 0 to clear semaphore.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>sema</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>irq0</name>
+     <description>Semaphore IRQ0 register.</description>
+     <addressOffset>0x40</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>en</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cm4_irq</name>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>mail0</name>
+     <description>Semaphore Mailbox 0 register.</description>
+     <addressOffset>0x44</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>data</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>irq1</name>
+     <description>Semaphore IRQ1 register.</description>
+     <addressOffset>0x48</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>en</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>rv32_irq</name>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>mail1</name>
+     <description>Semaphore Mailbox 1 register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>data</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>status</name>
+     <description>Semaphore status bits. 0 indicates the semaphore is free, 1 indicates taken.</description>
+     <addressOffset>0x100</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>status0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SEMA The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.-->
+  <peripheral>
+   <name>SIMO</name>
+   <description>Single Inductor Multiple Output Switching Converter</description>
+   <baseAddress>0x40004400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>VREGO_A</name>
+     <description>Buck Voltage Regulator A Control Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETA</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGEA</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGO_B</name>
+     <description>Buck Voltage Regulator B Control Register</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETB</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGEB</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGO_C</name>
+     <description>Buck Voltage Regulator C Control Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETC</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGEC</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGO_D</name>
+     <description>Buck Voltage Regulator D Control Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETD</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGED</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPKA</name>
+     <description>High Side FET Peak Current VREGO_A/VREGO_B Register</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IPKSETA</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IPKSETB</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPKB</name>
+     <description>High Side FET Peak Current VREGO_C/VREGO_D Register</description>
+     <addressOffset>0x0018</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IPKSETC</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IPKSETD</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAXTON</name>
+     <description>Maximum High Side FET Time On Register</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TONSET</name>
+       <description>Sets the maximum on time for the high side FET, each increment represents 500ns</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_A</name>
+     <description>Buck Cycle Count VREGO_A Register</description>
+     <addressOffset>0x0020</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADA</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_B</name>
+     <description>Buck Cycle Count VREGO_B Register</description>
+     <addressOffset>0x0024</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADB</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_C</name>
+     <description>Buck Cycle Count VREGO_C Register</description>
+     <addressOffset>0x0028</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADC</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_D</name>
+     <description>Buck Cycle Count VREGO_D Register</description>
+     <addressOffset>0x002C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADD</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_A</name>
+     <description>Buck Cycle Count Alert VERGO_A Register</description>
+     <addressOffset>0x0030</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRA</name>
+       <description>Threshold for ILOADA to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_B</name>
+     <description>Buck Cycle Count Alert VERGO_B Register</description>
+     <addressOffset>0x0034</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRB</name>
+       <description>Threshold for ILOADB to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_C</name>
+     <description>Buck Cycle Count Alert VERGO_C Register</description>
+     <addressOffset>0x0038</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRC</name>
+       <description>Threshold for ILOADC to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_D</name>
+     <description>Buck Cycle Count Alert VERGO_D Register</description>
+     <addressOffset>0x003C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRD</name>
+       <description>Threshold for ILOADD to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_OUT_READY</name>
+     <description>Buck Regulator Output Ready Register</description>
+     <addressOffset>0x0040</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUCKOUTRDYA</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notrdy</name>
+         <description>Output voltage not in range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rdy</name>
+         <description>Output voltage in range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="BUCKOUTRDYA">
+       <name>BUCKOUTRDYB</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BUCKOUTRDYA">
+       <name>BUCKOUTRDYC</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BUCKOUTRDYA">
+       <name>BUCKOUTRDYD</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_A</name>
+     <description>Zero Cross Calibration VERGO_A Register</description>
+     <addressOffset>0x0044</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALA</name>
+       <description>Zero Cross Calibrartion Value VREGO_A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_B</name>
+     <description>Zero Cross Calibration VERGO_B Register</description>
+     <addressOffset>0x0048</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALB</name>
+       <description>Zero Cross Calibrartion Value VREGO_B</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_C</name>
+     <description>Zero Cross Calibration VERGO_C Register</description>
+     <addressOffset>0x004C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALC</name>
+       <description>Zero Cross Calibrartion Value VREGO_C</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_D</name>
+     <description>Zero Cross Calibration VERGO_D Register</description>
+     <addressOffset>0x0050</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALD</name>
+       <description>Zero Cross Calibrartion Value VREGO_D</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIMO Single Inductor Multiple Output Switching Converter-->
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x40000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SISTAT</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>MAGIC</name>
+       <description>Magic Word Validation.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>magicNotSet</name>
+         <description>Magic word was not set (OTP has not been initialized properly).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>magicSet</name>
+         <description>Magic word was set (OTP contains valid settings).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRCERR</name>
+       <description>CRC Error Status.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No CRC errors occurred during the read of the OTP memory block.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>A CRC error occurred while reading the OTP. The address of the failure location in the OTP memory is stored in the ERRADDR register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADDR</name>
+     <description>Read-only field set by the SIB block if a CRC error occurs during the read of the OTP memory. Contains the failing address in OTP memory (when CRCERR equals 1).</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ERRADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLE_LDO_TRIM</name>
+     <description>BTLE LDO Trim register.</description>
+     <addressOffset>0x48</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RF</name>
+       <description>RF LDO trim value.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BB</name>
+       <description>BB LDO trim value.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FSTAT</name>
+     <description>funcstat register.</description>
+     <addressOffset>0x100</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>FPU</name>
+       <description>FPU Function.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADC</name>
+       <description>10-bit Sigma Delta ADC.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SMPHR</name>
+       <description>SMPHR function.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFSTAT</name>
+     <description>Security function status register.</description>
+     <addressOffset>0x104</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SECBOOT</name>
+       <description>Security Boot.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRNG</name>
+       <description> TRNG Function.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AES</name>
+       <description>AES Block.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIR System Initialization Registers.-->
+  <peripheral>
+   <name>SPI0</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x400BE000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>56</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FIFO32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>FIFO16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>FIFO8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Start Select Control. Used in Master mode to control the behavior of the Slave Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DEASSERT</name>
+         <description>SPI De-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ASSERT</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_ACTIVE</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3</name>
+         <description>SS3 is selected.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Rising_Edge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Falling_Edge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1</name>
+         <description>1 bits per character.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2</name>
+         <description>2 bits per character.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3</name>
+         <description>3 bits per character.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4</name>
+         <description>4 bits per character.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5</name>
+         <description>5 bits per character.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6</name>
+         <description>6 bits per character.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7</name>
+         <description>7 bits per character.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8</name>
+         <description>8 bits per character.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9</name>
+         <description>9 bits per character.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10</name>
+         <description>10 bits per character.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11</name>
+         <description>11 bits per character.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12</name>
+         <description>12 bits per character.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13</name>
+         <description>13 bits per character.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14</name>
+         <description>14 bits per character.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15</name>
+         <description>15 bits per character.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin (s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_POL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3_high</name>
+         <description>SS3 active high.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSTIME</name>
+     <description>Register for controlling SPI peripheral/Slave Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PRE</name>
+       <description>Slave Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POST</name>
+       <description>Slave Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPI0 SPI peripheral.-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI1</name>
+   <description>SPI peripheral. 1</description>
+   <baseAddress>0x40046000</baseAddress>
+   <interrupt>
+    <name>SPI1</name>
+    <description>SPI1 IRQ</description>
+    <value>32</value>
+   </interrupt>
+  </peripheral>
+<!--SPI1 SPI peripheral. 1-->
+  <peripheral>
+   <name>TMR</name>
+   <description>Low-Power Configurable Timer</description>
+   <baseAddress>0x40010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR</name>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Timer Counter Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>The current count value for the timer. This field increments as the timer counts.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Timer Compare Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>Timer PWM Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PWM</name>
+       <description>Timer PWM Match:
+                In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
+                In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Timer Interrupt Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ_A</name>
+       <description>Interrupt Flag for Timer A.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_A</name>
+       <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_A</name>
+       <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IRQ_B</name>
+       <description>Interrupt Flag for Timer B.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_B</name>
+       <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_B</name>
+       <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MODE_A</name>
+       <description>Mode Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_A</name>
+       <description>Clock Divider Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_A</name>
+       <description>Timer Polarity for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_A</name>
+       <description>PWM Synchronization Mode for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_A</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_A</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_A</name>
+       <description>PWM Phase A-Prime Output Disable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_A</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Write 1 to Enable CLK_TMR for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_A</name>
+       <description>Enable for Timer A</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MODE_B</name>
+       <description>Mode Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_B</name>
+       <description>Clock Divider Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_B</name>
+       <description>Timer Polarity for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_B</name>
+       <description>PWM Synchronization Mode for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_B</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_B</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_B</name>
+       <description>PWM Phase A-Prime Output Disable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_B</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Write 1 to Enable CLK_TMR for Timer B</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_B</name>
+       <description>Enable for Timer B</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO_A</name>
+       <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_A</name>
+       <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>LO_B</name>
+       <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_B</name>
+       <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Timer Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKSEL_A</name>
+       <description>Timer Clock Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Timer A Enable Status</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_A</name>
+       <description>CLK_TMR Ready Flag for Timer A</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_A</name>
+       <description>Event Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_A</name>
+       <description>Negative Edge Trigger for Event for Timer A</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_A</name>
+       <description>Interrupt Enable for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_A</name>
+       <description>Capture Event Select for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_A</name>
+       <description>Software Capture Event for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_A</name>
+       <description>Wake-Up Enable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTEN_A</name>
+       <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTBEN_A</name>
+       <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads of the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKSEL_B</name>
+       <description>Timer Clock Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Timer B Enable Status</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_B</name>
+       <description>CLK_TMR Ready Flag for Timer B</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_B</name>
+       <description>Event Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_B</name>
+       <description>Negative Edge Trigger for Event for Timer B</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_B</name>
+       <description>Interrupt Enable for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_B</name>
+       <description>Capture Event Select for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_B</name>
+       <description>Software Capture Event for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_B</name>
+       <description>Wake-Up Enable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CASCADE</name>
+       <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Timer Wakeup Status Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>A</name>
+       <description>Wake-Up Flag for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>B</name>
+       <description>Wake-Up Flag for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TMR Low-Power Configurable Timer-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR1</name>
+   <description>Low-Power Configurable Timer 1</description>
+   <baseAddress>0x40011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+<!--TMR1 Low-Power Configurable Timer 1-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR2</name>
+   <description>Low-Power Configurable Timer 2</description>
+   <baseAddress>0x40012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+<!--TMR2 Low-Power Configurable Timer 2-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR3</name>
+   <description>Low-Power Configurable Timer 3</description>
+   <baseAddress>0x40013000</baseAddress>
+   <interrupt>
+    <name>TMR3</name>
+    <description>TMR3 IRQ</description>
+    <value>8</value>
+   </interrupt>
+  </peripheral>
+<!--TMR3 Low-Power Configurable Timer 3-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR4</name>
+   <description>Low-Power Configurable Timer 4</description>
+   <baseAddress>0x40080C00</baseAddress>
+   <interrupt>
+    <name>TMR4</name>
+    <description>TMR4 IRQ</description>
+    <value>9</value>
+   </interrupt>
+  </peripheral>
+<!--TMR4 Low-Power Configurable Timer 4-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR5</name>
+   <description>Low-Power Configurable Timer 5</description>
+   <baseAddress>0x40081000</baseAddress>
+   <interrupt>
+    <name>TMR5</name>
+    <description>TMR5 IRQ</description>
+    <value>10</value>
+   </interrupt>
+  </peripheral>
+<!--TMR5 Low-Power Configurable Timer 5-->
+  <peripheral>
+   <name>TRIMSIR</name>
+   <description>Trim System Initilazation Registers</description>
+   <baseAddress>0x40005400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RTC</name>
+     <description>RTC Trim System Initialization Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>X1TRIM</name>
+       <description>RTC X1 Trim.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>X2TRIM</name>
+       <description>RTC X2 Trim.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SIMO</name>
+     <description>SIMO Trim System Initialization Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>SIMO Clock Divide.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV16</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV32</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV64</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV128</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPOLO</name>
+     <description>IPO Low Trim System Initialization Register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>IPO_LIMITLO</name>
+       <description>IPO Low Limit Trim.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Control Trim System Initialization Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>VDDA_LIMITLO</name>
+       <description>VDDA Low Trim Limit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VDDA_LIMITHI</name>
+       <description>VDDA High Trim Limit.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>IPO_LIMITHI</name>
+       <description>IPO High Trim Limit.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>INRO_SEL</name>
+       <description>INRO Clock Select.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>8KHZ</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16KHZ</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30KHZ</name>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INRO_TRIM</name>
+       <description>INRO Clock Trim.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INRO</name>
+     <description>RTC Trim System Initialization Register.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>TRIM16K</name>
+       <description>INRO 16KHz Trim.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>TRIM30K</name>
+       <description>INRO 30KHz Trim.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>LPCLKSEL</name>
+       <description>INRO Low Power Mode Clock Select.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>8KHZ</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16KHZ</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30KHZ</name>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRIMSIR Trim System Initilazation Registers-->
+  <peripheral>
+   <name>TRNG</name>
+   <description>Random Number Generator.</description>
+   <baseAddress>0x4004D000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TRNG</name>
+    <description>TRNG interrupt.</description>
+    <value>4</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>TRNG Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000003</resetValue>
+     <fields>
+      <field>
+       <name>ODHT</name>
+       <description>Start On-Demand health test.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RND_IE</name>
+       <description>To enable IRQ generation when a new 32-bit Random number is ready.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HEALTH_EN</name>
+       <description>Enable IRQ generation when a health test fails.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYGEN</name>
+       <description>AES Key Generate. When enabled, the key for securing NVSRAM is generated and transferred to the secure key register automatically without user visibility or intervention. This bit is cleared by hardware once the key has been transferred to the secure key register.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>To wipe the Battery Backed key.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>RDY</name>
+       <description>32-bit random data is ready to read from TRNG_DATA register. Reading TRNG_DATA when RND_RDY=0 will return all 0's. IRQ is generated when RND_RDY=1 if TRNG_CN.RND_IRQ_EN=1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Busy</name>
+         <description>TRNG Busy</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Ready</name>
+         <description>32 bit random data is ready</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ODHT</name>
+       <description>On-Demand health test status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HT</name>
+       <description>Health test status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRCFAIL</name>
+       <description>Entropy source has failed.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AESKGD</name>
+       <description>AESKGD.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LD_CNT</name>
+       <description>LD_CNT.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data. The content of this register is valid only when RNG_IS =1. When TNRG is disabled, read returns 0x0000 0000.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRNG Random Number Generator.-->
+  <peripheral>
+   <name>UART</name>
+   <description>UART Low Power Registers</description>
+   <baseAddress>0x40042000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control register</description>
+     <addressOffset>0x0000</addressOffset>
+     <fields>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>This field specifies the depth of receive FIFO for interrupt generation (value 0 and &gt; 16 are ignored) </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EN</name>
+       <description>Parity Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EO</name>
+       <description>when PAREN=1 selects odd or even parity odd is 1 even is 0</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_MD</name>
+       <description>Selects parity based on 1s or 0s count (when PAREN=1) </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_DIS</name>
+       <description>CTS Sampling Disable </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Flushes the TX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Flushes the RX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHAR_SIZE</name>
+       <description>Selects UART character size</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5bits</name>
+         <description>5 bits</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6bits</name>
+         <description>6 bits</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7bits</name>
+         <description>7 bits</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8bits</name>
+         <description>8 bits</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPBITS</name>
+       <description>Selects the number of stop bits that will be generated</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HFC_EN</name>
+       <description>Enables/disables hardware flow control</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RTSDC</name>
+       <description>Hardware Flow Control RTS Mode</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKEN</name>
+       <description>Baud clock enable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKSRC</name>
+       <description>To select the UART clock source for the UART engine (except APB registers). Secondary clock (used for baud rate generator) can be asynchronous from APB clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Peripheral_Clock</name>
+         <description>apb clock</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>External_Clock</name>
+         <description>Clock 1</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK2</name>
+         <description>Clock 2</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK3</name>
+         <description>Clock 3</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPFE_EN</name>
+       <description>Data/Parity bit frame error detection enable</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKRDY</name>
+       <description>Baud clock Ready read only bit</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UCAGM</name>
+       <description>UART Clock Auto Gating mode</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FDM</name>
+       <description>Fractional Division Mode</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DESM</name>
+       <description>RX Dual Edge Sampling Mode</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TX_BUSY</name>
+       <description>Read-only flag indicating the UART transmit status</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_BUSY</name>
+       <description>Read-only flag indicating the UART receiver status</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Indicates the number of bytes currently in the RX FIFO (0-RX FIFO_ELTS) </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Indicates the number of bytes currently in the TX FIFO (0-TX FIFO_ELTS) </description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interrupt Enable control register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Enable Interrupt For RX Frame Error</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Enable Interrupt For RX Parity Error</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Enable Interrupt For CTS signal change Error</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Enable Interrupt For RX FIFO Overrun Error</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Enable Interrupt For RX FIFO reaches the number of bytes configured by RXTHD</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Enable Interrupt For TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Enable Interrupt For TX FIFO has half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Interrupt status flags Control register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Flag for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Flag for RX Parity Error interrupt</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Flag for CTS signal change interrupt (hardware flow control disabled) </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Flag for RX FIFO Overrun interrupt</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Flag for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Flag for interrupt when TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Flag for interrupt when TX FIFO is half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Clock Divider register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Baud rate divisor value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSR</name>
+     <description>Over Sampling Rate register</description>
+     <addressOffset>0x0014</addressOffset>
+     <fields>
+      <field>
+       <name>OSR</name>
+       <description>OSR</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXPEEK</name>
+     <description>TX FIFO Output Peek register</description>
+     <addressOffset>0x0018</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read TX FIFO next data. Reading from this field does not affect the contents of TX FIFO. Note that the parity bit is available from this field.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PNR</name>
+     <description> Pin register</description>
+     <addressOffset>0x001C</addressOffset>
+     <fields>
+      <field>
+       <name>CTS</name>
+       <description>Current sampled value of CTS IO</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RTS</name>
+       <description>This bit controls the value to apply on the RTS IO. If set to 1, the RTS IO is set to high level. If set to 0, the RTS IO is set to low level.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Read/Write register</description>
+     <addressOffset>0x0020</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Parity error flag for next byte to be read from FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration register</description>
+     <addressOffset>0x0030</addressOffset>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger If the TX FIFO level is less than this value, then the TX FIFO DMA interface will send a signal to system DMA to notify that TX FIFO is ready to receive data from memory.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX DMA channel enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Rx FIFO Level DMA Trigger If the RX FIFO level is greater than this value, then the RX FIFO DMA interface will send a signal to the system DMA to notify that RX FIFO has characters to transfer to memory.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX DMA channel enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wake up enable Control register</description>
+     <addressOffset>0x0034</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Enable for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Enable for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Enable for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wake up Flags register</description>
+     <addressOffset>0x0038</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Flag for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Flag for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Flag for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--UART UART Low Power Registers-->
+  <peripheral derivedFrom="UART">
+   <name>UART1</name>
+   <description>UART Low Power Registers 1</description>
+   <baseAddress>0x40043000</baseAddress>
+  </peripheral>
+<!--UART1 UART Low Power Registers 1-->
+  <peripheral derivedFrom="UART">
+   <name>UART2</name>
+   <description>UART Low Power Registers 2</description>
+   <baseAddress>0x40044000</baseAddress>
+  </peripheral>
+<!--UART2 UART Low Power Registers 2-->
+  <peripheral derivedFrom="UART">
+   <name>UART3</name>
+   <description>UART Low Power Registers 3</description>
+   <baseAddress>0x40081400</baseAddress>
+  </peripheral>
+<!--UART3 UART Low Power Registers 3-->
+  <peripheral>
+   <name>WDT</name>
+   <description>Windowed Watchdog Timer</description>
+   <baseAddress>0x40003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WWDT</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INT_LATE_VAL</name>
+       <description>Windowed Watchdog Interrupt Upper Limit. Sets the number of WDTCLK cycles until a windowed watchdog timer interrupt is generated (if enabled) if the CPU does not write the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE_VAL</name>
+       <description>Windowed Watchdog Reset Upper Limit. Sets the number of WDTCLK cycles until a system reset occurs (if enabled) if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Windowed Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_LATE</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Late.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_INT_EN</name>
+       <description>Windowed Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_RST_EN</name>
+       <description>Windowed Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Soon.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY_VAL</name>
+       <description>Windowed Watchdog Interrupt Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A windowed watchdog timer interrupt is generated (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY_VAL</name>
+       <description>Windowed Watchdog Reset Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A system reset occurs (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKRDY_IE</name>
+       <description>Switch Ready Interrupt Enable. Fires an interrupt when it is safe to swithc the clock.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY</name>
+       <description>Clock Status.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WIN_EN</name>
+       <description>Enables the Windowed Watchdog Function.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Windowed Mode Disabled (i.e. Compatibility Mode).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Windowed Mode Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Soon.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Late.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Windowed Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>RESET</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD_UPPER_LIMIT then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD_UPPER_LIMIT then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKSEL</name>
+     <description>Windowed Watchdog Timer Clock Select Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SOURCE</name>
+       <description>WWDT Clock Selection Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CNT</name>
+     <description>Windowed Watchdog Timer Count Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Current Value of the Windowed Watchdog Timer Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WDT Windowed Watchdog Timer-->
+  <peripheral derivedFrom="WDT">
+   <name>WDT1</name>
+   <description>Windowed Watchdog Timer 1</description>
+   <baseAddress>0x40080800</baseAddress>
+   <interrupt>
+    <name>WDT1</name>
+    <description>WDT1 IRQ</description>
+    <value>57</value>
+   </interrupt>
+  </peripheral>
+<!--WDT1 Windowed Watchdog Timer 1-->
+  <peripheral>
+   <name>WUT</name>
+   <description>32-bit reloadable timer that can be used for timing and wakeup.</description>
+   <baseAddress>0x40006400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Wakeup_Timer</name>
+    <description>WUT IRQ</description>
+    <value>53</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Count.  This register stores the current timer count.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Timer Count Value. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Compare.  This register stores the compare value, which is used to set the maximum count value to initiate a reload of the timer to 0x0001.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x0000FFFF</resetValue>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>Timer Compare Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Clear Interrupt. Writing a value (0 or 1) to a bit in this register clears the associated interrupt.</description>
+     <addressOffset>0x0C</addressOffset>
+     <modifiedWriteValues>oneToClear</modifiedWriteValues>
+     <fields>
+      <field>
+       <name>IRQ_CLR</name>
+       <description>Clear Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>TMODE</name>
+       <description>Timer Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>oneShot</name>
+         <description>One Shot Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Continuous Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>counter</name>
+         <description>Counter Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>capture</name>
+         <description>Capture Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>compare</name>
+         <description>Compare Mode.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>gated</name>
+         <description>Gated Mode.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>captureCompare</name>
+         <description>Capture/Compare Mode.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES</name>
+       <description>Prescaler.  Set the Timer's prescaler value. The prescaler divides the PCLK input to the timer and sets the Timer's Count Clock, F_CNT_CLK = PCLK(HZ)/prescaler. The Timer's prescaler setting is a 4-bit value with pres3:pres[2:0].</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TPOL</name>
+       <description>Timer input/output polarity bit.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TEN</name>
+       <description>Timer Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES3</name>
+       <description>MSB of prescaler value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>NOLLCMP</name>
+       <description>Non-overlapping Low Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A and next rising edge of PWM output 0A'.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>NOLHCMP</name>
+       <description>Non-overlapping High Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A' and next rising edge of PWM output 0A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET</name>
+     <description>Preset register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>PRESET</name>
+       <description>Preset Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RELOAD</name>
+     <description>Reload register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>RELOAD</name>
+       <description>Rerload Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SNAPSHOT</name>
+     <description>Snapshot register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>SNAPSHOT</name>
+       <description>Snapshot Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WUT 32-bit reloadable timer that can be used for timing and wakeup.-->
+ </peripherals>
+</device>

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32657/Include/max32657.svd
@@ -1,0 +1,11884 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max32657</name>
+ <series>ARMCM33</series>
+ <version>1.0</version>
+ <description>TBD</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>AESKEYS</name>
+   <description>AES Key Registers.</description>
+   <baseAddress>0x50007800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>KEY0</name>
+     <description>AES Key 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY1</name>
+     <description>AES Key 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY2</name>
+     <description>AES Key 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY3</name>
+     <description>AES Key 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY4</name>
+     <description>AES Key 4.</description>
+     <addressOffset>0x10</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY5</name>
+     <description>AES Key 5.</description>
+     <addressOffset>0x14</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY6</name>
+     <description>AES Key 6.</description>
+     <addressOffset>0x18</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY7</name>
+     <description>AES Key 7.</description>
+     <addressOffset>0x1C</addressOffset>
+     <size>32</size>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>AES</name>
+   <description>AES Keys.</description>
+   <baseAddress>0x50007400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>AES Control Register</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>AES Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>DMA Request To Read Data Output FIFO</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>DMA Request To Write Data Input FIFO</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start AES Calculation</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FLUSH</name>
+       <description>Flush the data input FIFO</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FLUSH</name>
+       <description>Flush the data output FIFO</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_SIZE</name>
+       <description>Encryption Key Size</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AES128</name>
+         <description>128 Bits.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES192</name>
+         <description>192 Bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES256</name>
+         <description>256 Bits.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TYPE</name>
+       <description>Encryption Type Selection</description>
+       <bitRange>[9:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>AES Status Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>AES Busy Status</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_EM</name>
+       <description>Data input FIFO empty status</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FULL</name>
+       <description>Data input FIFO full status</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_EM</name>
+       <description>Data output FIFO empty status</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FULL</name>
+       <description>Data output FIFO full status</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>AES Interrupt Flag Register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>AES Interrupt Enable Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>AES Data Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>AES FIFO</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>BOOST</name>
+   <description>Boost Controller</description>
+   <baseAddress>0x50004C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>BOOST</name>
+    <value>46</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>DISABLE</name>
+     <description>Boost Disable Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DIS</name>
+       <description>This bit allows softwaree to disable the boost regulator for the VDD18 supply.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGCTRL</name>
+     <description>Boost Voltage Regulator Control Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <fields>
+      <field>
+       <name>SET</name>
+       <description>Sets the target voltage for the boost regulator output.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPEAK</name>
+     <description>Low Side FET Peak Current Register.</description>
+     <addressOffset>0x008</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SET</name>
+       <description>Sets the peak current threshold for the regulator.</description>
+       <bitRange>[2:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAXTON</name>
+     <description>Maximum Low Side FET Time-On Register.</description>
+     <addressOffset>0x00C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>THD</name>
+       <description>Sets a threshold for when time-on out toggles.</description>
+       <bitRange>[3:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD</name>
+     <description>Boost Cycle Count Register.</description>
+     <addressOffset>0x010</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Indicates the last load cycle count value.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ALERT</name>
+     <description>Boost Cycle Count Alert Register.</description>
+     <addressOffset>0x014</addressOffset>
+     <fields>
+      <field>
+       <name>THD</name>
+       <description>Determines the threshold for when the boost alert interruptis fired.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RDY</name>
+     <description>Boost Output Ready Register.</description>
+     <addressOffset>0x018</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>OUT</name>
+       <description>Indicates ready out status for boost regulator.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZXCAL</name>
+     <description>Zero Cross Calibration Register.</description>
+     <addressOffset>0x01C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>VAL</name>
+       <description>Read back of auto-calibration values.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Boost Alert Interrupt Enable Register.</description>
+     <addressOffset>0x020</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ALERT</name>
+       <description>Boost alert enable/</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Boost Alert Interrupt Status Register.</description>
+     <addressOffset>0x024</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ALERT</name>
+       <description>Boost alert has occurred.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>CRC</name>
+   <description>CRC Registers.</description>
+   <baseAddress>0x5000F000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>CRC Control</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>CRC Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_EN</name>
+       <description>DMA Request Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB</name>
+       <description>MSB Select</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BYTE_SWAP_IN</name>
+       <description>Byte Swap CRC Data Input</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BYTE_SWAP_OUT</name>
+       <description>Byte Swap CRC Value Output</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>CRC Busy</description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN32</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN16</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN8</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>POLY</name>
+     <description>CRC Polynomial</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>POLY</name>
+       <description>CRC Polynomial</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VAL</name>
+     <description>Current CRC Value</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>VALUE</name>
+       <description>Current CRC Value</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x50028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0_CH0</name>
+    <value>32</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA0_CH1</name>
+    <value>33</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA0_CH2</name>
+    <value>34</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA0_CH3</name>
+    <value>35</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>INTEN</name>
+     <description>DMA Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel 0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <description>Channel 1 Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <description>Channel 2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <description>Channel 3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>DMA Interrupt Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel Interrupt. To clear an interrupt, all active interrupt bits of the DMA_ST must be cleared. The interrupt bits are set only if their corresponding interrupt enable bits are set in DMA_CN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>4</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CTRL</name>
+      <description>DMA Channel Control Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>EN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQUEST</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPIRX</name>
+          <description>SPI RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UARTRX</name>
+          <description>UART RX</description>
+          <value>0x04</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I3CRX_CONT</name>
+          <description>I3C RX Controller</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I3CRX_TARG</name>
+          <description>I3C RX Target</description>
+          <value>0x08</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESRX</name>
+          <description>AES RX</description>
+          <value>0x10</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPITX</name>
+          <description>SPI TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UARTTX</name>
+          <description>UART TX</description>
+          <value>0x24</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I3CTX_CONT</name>
+          <description>I3C TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I3CTX_TARG</name>
+          <description>I3C TX</description>
+          <value>0x28</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>CRCTX</name>
+          <description>CRC TX</description>
+          <value>0x2C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESTX</name>
+          <description>AES TX</description>
+          <value>0x30</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_WAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_PER</name>
+        <description>Timeout Period Select.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_CLKDIV</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BURST_SIZE</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>DIS_IE</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IE</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>STATUS</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>STATUS</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IF</name>
+        <description>Count-to-Zero (CTZ) Interrupt Flag</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>RLD_IF</name>
+        <description>Reload Event Interrupt Flag.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>TO_IF</name>
+        <description>Time-Out Event Interrupt Flag.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRCRLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DSTRLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNTRLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>EN</name>
+        <description>Reload Enable. This bit should be set after the address reload registers have been programmed. This bit is automatically cleared to 0 when reload occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+
+  <peripheral derivedFrom="DMA">
+   <name>DMA1</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels. 1</description>
+   <baseAddress>0x50035000</baseAddress>
+   <interrupt>
+    <name>DMA1_CH0</name>
+    <description>DMA1_CH0</description>
+    <value>36</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1_CH1</name>
+    <description>DMA1_CH1</description>
+    <value>37</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1_CH2</name>
+    <description>DMA1_CH2</description>
+    <value>38</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1_CH3</name>
+    <description>DMA1_CH3</description>
+    <value>39</value>
+   </interrupt>
+  </peripheral>
+
+  <peripheral>
+   <name>FCR</name>
+   <description>Function Control Register.</description>
+   <baseAddress>0x50000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Function Control 0 Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>I3CDGEN0</name>
+       <description>I3C SDA Glitch Filter Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I3CDGEN1</name>
+       <description>I3C SCL Glitch Filter Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL0</name>
+     <description>Automatic Calibration 0 Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Auto-calibration Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RUN</name>
+       <description>Autocalibration Run.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOAD_TRIM</name>
+       <description>Load Trim.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GAIN_INV</name>
+       <description>Invert Gain.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ATOMIC</name>
+       <description>Atomic mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MU</name>
+       <description>MU value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>TRIM_OUT</name>
+       <description>IPO Auto Calibration Trim</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL1</name>
+     <description>Automatic Calibration 1 Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INIT_TRIM</name>
+       <description>IPO Trim Automatic Calibration Initial Trim.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL2</name>
+     <description>Automatic Calibration 2 Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RUNTIME</name>
+       <description>IPO Trim Autocal Run Time</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>DIV</name>
+       <description>IPO Trim Automatic Calibration Divide Factor.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ERFOKS</name>
+     <description>ERFO Kick Start Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Kick Start ERFO Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Kick Start ERFO Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DRVSTR</name>
+       <description>Kick Start ERFO Drive Strength.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>X2_PLEN</name>
+       <description>ERFO Kick Start Enable Double Pulse Length.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKSEL</name>
+       <description>Kick Start Clock Select for ERFO</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>NO_CLK</name>
+         <description>No kick start clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>IPO.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Interrupt Flag Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ERFO_RDY</name>
+       <description>ERFO Ready.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FRQCNT</name>
+       <description>Frequency Counter Interrupt Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ERFO_RDY</name>
+       <description>ERFO Ready Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FRQCNT</name>
+       <description>Frequency Counter Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ERFOCTRL</name>
+     <description>ERFO Control Register.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CAP_X1</name>
+       <description>Load capacitor tuning bit for X1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>CAP_X2</name>
+       <description>Load capacitor tuning bit for X2.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>CAP_BYPASS</name>
+       <description>Bypass (disable) load capacitors.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FRQCNTCTRL</name>
+     <description>Frequency Counter Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Start Compare.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMP_CLKSEL</name>
+       <description>Compared Clock Select.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>RTC</name>
+         <description>RTC.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EXT_GPIO</name>
+         <description>External GPIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INRO</name>
+         <description>INRO.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FRQCNTCMP</name>
+     <description>Frequency Counter Compared Target Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TARGET</name>
+       <description>Compared Clock Target.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REFCLK</name>
+     <description>Reference Clock Result Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RESULT</name>
+       <description>Reference Clock Result.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMPCLK</name>
+     <description>Compared Clock Result Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RESULT</name>
+       <description>Compared Clock Result.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>FLC</name>
+   <description>Flash Memory Control.</description>
+   <prependToName>FLSH_</prependToName>
+   <baseAddress>0x50029000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>FLC
+</name>
+    <description>FLC Interrupt.</description>
+    <value>23</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ADDR</name>
+     <description>Flash Write Address.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address for next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Flash Clock Divide. The clock (PLL0) is divided by this value to generate a 1 MHz clock for Flash controller.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000032</resetValue>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Flash Clock Divide. The clock is divided by this value to generate a 1MHz clock for flash controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Flash Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WR</name>
+       <description>Write.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="WR">
+       <name>ME</name>
+       <description>Mass Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="WR">
+       <name>PGE</name>
+       <description>Page Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERASE_CODE</name>
+       <description>Erase Code.  The ERASE_CODE must be set up property before erase operation can be initiated. These bits are automatically cleared after the operation is complete.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>erasePage</name>
+         <description>Enable Page Erase.</description>
+         <value>0x55</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>eraseAll</name>
+         <description>Enable Mass Erase. The debug port must be enabled.</description>
+         <value>0xAA</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PEND</name>
+       <description>Flash Pending.  When Flash operation is in progress (busy), Flash reads and writes will fail. When PEND is set, write to all Flash registers, with exception of the Flash interrupt register, are ignored.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LVE</name>
+       <description>Low Voltage enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNLOCK</name>
+       <description>Flash Unlock.  The correct unlock code must be written to these four bits before any Flash write or erase operation is allowed.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Flash Unlocked.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Flash Locked.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Flash Interrupt Register.</description>
+     <addressOffset>0x024</addressOffset>
+     <fields>
+      <field>
+       <name>DONE_IF</name>
+       <description>Flash Done Interrupt.  This bit is set to 1 upon Flash write or erase completion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AF_IF</name>
+       <description>Flash Access Fail.  This bit is set when an attempt is made to write the flash while the flash is busy or the flash is locked. This bit can only be set to 1 by hardware.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONE_IE</name>
+       <description>Flash Done Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DONE_IE">
+       <name>AF_IE</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCDATA</name>
+     <description>ECC Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>EVEN</name>
+       <description>Error Correction Code Odd Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>ODD</name>
+       <description>Error Correction Code Even Data.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA[%s]</name>
+     <description>Flash Write Data.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACTRL</name>
+     <description>Access Control Register. Writing the ACTRL register with the following values in the order shown, allows read and write access to the system and user Information block:
+    pflc-actrl = 0x3a7f5ca3;
+    pflc-actrl = 0xa1e34f20;
+    pflc-actrl = 0x9608b2c1. When unlocked, a write of any word will disable access to system and user information block. Readback of this register is always zero.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ACTRL</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x50000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SYSCTRL</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>ICC_FLUSH</name>
+       <description>Code Cache Flush. This bit is used to flush the code caches and the instruction buffer of the Cortex-M4. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CCHK</name>
+       <description>Compute ROM Checksum. This bit is self-cleared when calculation is completed. Once set, software clearing this bit is ignored and the bit will remain set until the operation is completed.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CHKRES</name>
+       <description>ROM Checksum Result. This bit is only valid when the checksum is done and CCHK0 bit is cleared..</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pass</name>
+         <description>ROM Checksum Correct.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fail</name>
+         <description>ROM Checksum Fail.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OVR</name>
+       <description>Operating Voltage Range.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA0</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>WDT</name>
+       <description>Watchdog Timer Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>TMR0</name>
+       <description>Timer0 Reset.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>TMR1</name>
+       <description>Timer1 Reset.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>TMR2</name>
+       <description>Timer2 Reset.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>TMR3</name>
+       <description>Timer3 Reset.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>TMR4</name>
+       <description>Timer4 Reset.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>TMR5</name>
+       <description>Timer5 Reset.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>UART</name>
+       <description>UART Reset.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>SPI</name>
+       <description>SPI Reset.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>I3C</name>
+       <description>I3C Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>RTC</name>
+       <description>Real Time Clock Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>TRNG</name>
+       <description>TRNG Reset.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>DMA1</name>
+       <description>DMA1 Reset.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>SOFT</name>
+       <description>Soft Reset. Setting this bit to 1 resets everything except the CPU and the watchdog timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>PERIPH</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA0">
+       <name>SYS</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>SYSCLK_DIV</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the PLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_SEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>The internal Primary oscillator is used for the system clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERFO</name>
+         <description>27MHz Crystal is used for the system clock.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INRO</name>
+         <description>8kHz Internal Nano Ring Oscillator is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBRO</name>
+         <description>The internal Baud Rate oscillator is used for the system clock.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERTCO</name>
+         <description> 32kHz is used for the system clock.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EXTCLK</name>
+         <description>External Clock.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_RDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_EN</name>
+       <description>27MHz Crystal Oscillator Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>32kHz Crystal Oscillator Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>IPO_EN</name>
+       <description>50MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>IBRO_EN</name>
+       <description>8MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_VS</name>
+       <description>7.3728MHz Internal Oscillator Voltage Source Select</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_RDY</name>
+       <description>27MHz Crystal Oscillator Ready</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>ERTCO_RDY</name>
+       <description>32kHz Crystal Oscillator Ready</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>IPO_RDY</name>
+       <description>Internal Primary Oscillator Ready.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>IBRO_RDY</name>
+       <description>Internal Baud Rate Oscillator Ready.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>INRO_RDY</name>
+       <description>Internal Nano Ring Oscillator Low Frequency Reference Clock Ready.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PM</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This two bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ACTIVE</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BACKUP</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PDM</name>
+         <description>DeepSleep Mode.</description>
+         <value>10</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO_WE</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>RTC_WE</name>
+       <description>RTC Alarm Wake Up Enable. This bit enables RTC alarm as wakeup source. If enabled, the desired RTC alarm must be configured via the RTC control registers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>WUT_WE</name>
+       <description>Enable Wakeup Timer as wakeup source.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_BP</name>
+       <description>XTAL Bypass </description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bypass</name>
+         <description>Bypass</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIV</name>
+     <description>Peripheral Clock Divider.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Clock Divide Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0</name>
+       <description>GPIO0 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>DMA0</name>
+       <description>DMA0 Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI</name>
+       <description>SPI Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART</name>
+       <description>UART Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I3C</name>
+       <description>I3C Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR0</name>
+       <description>Timer 0 Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR1</name>
+       <description>Timer 1 Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR2</name>
+       <description>Timer 2 Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR3</name>
+       <description>Timer 3 Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR4</name>
+       <description>Timer 4 Disable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR5</name>
+       <description>Timer 5 Disable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCTRL</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 2.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMZ</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>SRAM0</name>
+       <description>System RAM Block 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="SRAM0">
+       <name>SRAM1</name>
+       <description>System RAM Block 1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0">
+       <name>SRAM2</name>
+       <description>System RAM Block 2.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0">
+       <name>SRAM3</name>
+       <description>System RAM Block 3.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0">
+       <name>SRAM4</name>
+       <description>System RAM Block 4.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0">
+       <name>ICC</name>
+       <description>Internal Cache.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSST</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICELOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>CRC</name>
+       <description>CRC Reset.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CRC">
+       <name>AES</name>
+       <description>AES Reset.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CRC">
+       <name>AUTOCAL</name>
+       <description>Auto calibration Reset.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CRC">
+       <name>BTLE</name>
+       <description>BTLE Reset.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TRNG</name>
+       <description>TRNG Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="TRNG">
+       <name>CRC</name>
+       <description>CRC Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="TRNG">
+       <name>AES</name>
+       <description>AES Clock Disable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="TRNG">
+       <name>DMA1</name>
+       <description>DMA1 Clock Disable</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="TRNG">
+       <name>WDT</name>
+       <description>WDT Clock Disable</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVENTEN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>DMA0</name>
+       <description>Enable DMA0 event. When this bit is set, a DMA0 event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA1</name>
+       <description>Enable DMA1 event. When this bit is set, a DMA1 event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO[25].</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REVISION</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSINTEN</name>
+     <description>System Status Interrupt Enable Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEUNLOCK</name>
+       <description>ARM ICE Unlock Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCERR</name>
+     <description>ECC Error Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>FLASH</name>
+       <description>ECC Flash Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCCED</name>
+     <description>ECC Correctable Error Detect Register.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>FLASH</name>
+       <description>ECC Correctable Error Detect Flag for Flash. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCINTEN</name>
+     <description>ECC Interrupt Enable Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>FLASH</name>
+       <description>ECC Flash0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCADDR</name>
+     <description>ECC Error Address Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>DADDR</name>
+       <description>Address of Error in Data RAM.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>DB</name>
+       <description>Data Bank,</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DE</name>
+       <description>Data Error Flag.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TADDR</name>
+       <description>Address of Error in Tag RAM.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>TB</name>
+       <description>Tag Bank.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TE</name>
+       <description>Tag Error Flag.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLELDOCTRL</name>
+     <description>BTLE LDO Control Register</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>BB_EN</name>
+       <description>LDO BB enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BB_PD_EN</name>
+       <description>LDO BB Pull Down.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BB_VSEL</name>
+       <description>Voltage Selection for BB LDO.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_9</name>
+         <description>0.9V</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0</name>
+         <description>1.0V</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1</name>
+         <description>1.1V</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_2</name>
+         <description>1.2V</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RF_EN</name>
+       <description>LDO RF enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RF_PD_EN</name>
+       <description>LDO RF Pull DOwn.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RF_VSEL</name>
+       <description>LDO RF Voltage Setting.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_9</name>
+         <description>0.9V</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0</name>
+         <description>1.0V</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1</name>
+         <description>1.1V</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_2</name>
+         <description>1.2V</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RF_BP_EN</name>
+       <description>LDO RF Bypass Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RF_DISCH</name>
+       <description>LDO RF Discharge.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BB_BP_EN</name>
+       <description>LDO BB Bypass Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BB_DISCH</name>
+       <description>LDO BB Discharge.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BB_EN_DLY</name>
+       <description>LDO BB Enable Delay.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RF_EN_DLY</name>
+       <description>LDO RF Enable Delay.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RF_BP_EN_DLY</name>
+       <description>LDO RF Bypass Enable Delay.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BB_BP_EN_DLY</name>
+       <description>LDO BB Bypass Enable Delay.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLELDODLY</name>
+     <description>BTLE LDO Delay Register</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>BP_CNT</name>
+       <description>Bypass delay count.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>BB_CNT</name>
+       <description>BB delay count.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>RF_CNT</name>
+       <description>RF delay count.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPR</name>
+     <description>General Purpose Register 0.</description>
+     <addressOffset>0x80</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x50008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN0</name>
+     <description>GPIO Function Enable Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_SET</name>
+     <description>GPIO Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_OUT bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTMODE</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTPOL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INEN</name>
+     <description>GPIO Input Enable</description>
+     <addressOffset>0x30</addressOffset>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DUALEDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL</name>
+     <description>GPIO Pad Control. Each bit in this register configures the pad for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>The two bits in GPIO_PADCTRL0 and GPIO_PADCTRL1 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_SET</name>
+     <description>GPIO Alternate Function Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_SET</name>
+     <description>GPIO Alternate Function 2 Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN2 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_CLR</name>
+     <description>GPIO Wake Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN2 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x7C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HYSEN</name>
+     <description>GPIO Input Hysteresis Enable.</description>
+     <addressOffset>0xA8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SRSEL</name>
+     <description>GPIO Slew Rate Enable Register.</description>
+     <addressOffset>0xAC</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>FAST</name>
+         <description>Fast Slew Rate selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SLOW</name>
+         <description>Slow Slew Rate selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS0</name>
+     <description>GPIO Drive Strength 0 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ld</name>
+         <description>GPIO port pin is in low-drive mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hd</name>
+         <description>GPIO port pin is in high-drive mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PSSEL</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VSSEL</name>
+     <description>GPIO Voltage Select.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>I3C0</name>
+   <description>Improved Inter-Integrated Circuit.</description>
+   <groupName>I3C</groupName>
+   <baseAddress>0x50018000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I3C0</name>
+    <description>I3C0 IRQ</description>
+    <value>26</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CONT_CTRL0</name>
+     <description>Controller Control 0 (Configuration) Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>I3C Device Enable.</description>
+       <bitRange>[1:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>OFF</name>
+         <description>Off.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ON</name>
+         <description>On.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAP</name>
+         <description>I23 Bug Target with secondary controller capability.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_DIS</name>
+       <description>Disable Timeout error.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>HKEEP</name>
+       <description>High-keepr implementation.</description>
+       <bitRange>[5:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>OFF</name>
+         <description>No high-keeper support.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ON_CHIP</name>
+         <description>On-chip high-keeper support.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EXT_SDA</name>
+         <description>External high-keeper support for SDA.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EXT_SCL_SDA</name>
+         <description>External high-keeper support for SCL and SDA.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OD_STOP</name>
+       <description>Use open-drain speed for STOP.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PP_BAUD</name>
+       <description>SCL Frequency for push-pull drive.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1_FCLK</name>
+         <description>SCL High Period is one FCLK Period.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_FCLK</name>
+         <description>SCL High Period is two FLCK Periods.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_FCLK</name>
+         <description>SCL High Period is three FCLK Period.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_FCLK</name>
+         <description>SCL High Period is four FCLK Period.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5_FCLK</name>
+         <description>SCL High Period is five FCLK Period.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_FCLK</name>
+         <description>SCL High Period is six FCLK Period.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7_FCLK</name>
+         <description>SCL High Period is seven FCLK Period.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_FCLK</name>
+         <description>SCL High Period is eight FCLK Period.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9_FCLK</name>
+         <description>SCL High Period is nine FCLK Period.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_FCLK</name>
+         <description>SCL High Period is ten FCLK Period.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11_FCLK</name>
+         <description>SCL High Period is eleven FCLK Period.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_FCLK</name>
+         <description>SCL High Period is twelve FCLK Period.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13_FCLK</name>
+         <description>SCL High Period is thirteen FCLK Period.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14_FCLK</name>
+         <description>SCL High Period is fourteen FCLK Period.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15_FCLK</name>
+         <description>SCL High Period is fifthteen FCLK Period.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_FCLK</name>
+         <description>SCL High Period is sixteen FCLK Period.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PP_ADD_LBAUD</name>
+       <description>Number of FCLK periods to add to the base of SCL low period.</description>
+       <bitRange>[15:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_FCLK</name>
+         <description>Adds zero FCLK periods to the SCL low period.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_FCLK</name>
+         <description>Adds one FCLK period to the SCL low period.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_FCLK</name>
+         <description>Adds two FCLK periods to the SCL low period.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_FCLK</name>
+         <description>Adds three FCLK periods to the SCL low period.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_FCLK</name>
+         <description>Adds four FCLK periods to the SCL low period.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5_FCLK</name>
+         <description>Adds five FCLK periods to the SCL low period.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_FCLK</name>
+         <description>Adds six FCLK periods to the SCL low period.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7_FCLK</name>
+         <description>Adds seven FCLK periods to the SCL low period.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_FCLK</name>
+         <description>Adds eight FCLK periods to the SCL low period.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9_FCLK</name>
+         <description>Adds nine FCLK periods to the SCL low period.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_FCLK</name>
+         <description>Adds ten FCLK periods to the SCL low period.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11_FCLK</name>
+         <description>Adds eleven FCLK periods to the SCL low period.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_FCLK</name>
+         <description>Adds twelve FCLK periods to the SCL low period.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13_FCLK</name>
+         <description>Adds thirteen FCLK periods to the SCL low period.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14_FCLK</name>
+         <description>Adds fourteen FCLK periods to the SCL low period.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15_FCLK</name>
+         <description>Adds fifthteen FCLK periods to the SCL low period.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OD_LBAUD</name>
+       <description>Number of PP_BAUD periods minus 1 to make one SCL low period for I3C open-dran periods.</description>
+       <bitRange>[23:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OD_HP</name>
+       <description>Controls SCL high period for I3C oepn-drain operation.</description>
+       <bitRange>[24:24]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PP_SKEW</name>
+       <description>Number of FCLK periods to delay the SDA value change from the SCL edge for I3C push-pull operation.</description>
+       <bitRange>[27:25]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>I2C_BAUD</name>
+       <description>Detyermines SCL high and low pweriods for I2C mode, in units of OD_BAUD period.</description>
+       <bitRange>[31:28]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_CTRL0</name>
+     <description>Target Control 0 (Configuration) Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Target device enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MATCHSS</name>
+       <description>Match STOP and START.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TO_IGN</name>
+       <description>Ignore Timeout Errors.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OFFLINE</name>
+       <description>Rejoin I3C bus with existing dynamic address.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_STATUS</name>
+     <description>Target Status Register.</description>
+     <addressOffset>0x008</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>Not stopped.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>LIST_RESP</name>
+       <description>Message status - listening/responding or not.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CCCH</name>
+       <description>CCC is being handled.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_SDR</name>
+       <description>SDR Read.</description>
+       <bitRange>[3:3]</bitRange>
+      </field>
+      <field>
+       <name>TX_SDR</name>
+       <description>SDR Write.</description>
+       <bitRange>[4:4]</bitRange>
+      </field>
+      <field>
+       <name>DAA</name>
+       <description>Dynamic Address Assignment Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HDR</name>
+       <description>HDR Mode.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Detected.</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ADDRMATCH</name>
+       <description>Address Matched.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP Detected.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_RDY</name>
+       <description>Receive data ready.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_NFULL</name>
+       <description>TX FIFO is not full, ready to accept more data.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DYNADDR_CHG</name>
+       <description>Dynamic address changed.</description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CCC</name>
+       <description>CCC received.</description>
+       <bitRange>[14:14]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ERRWARN</name>
+       <description>An error or warning has occurred.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CCCH_DONE</name>
+       <description>CCC Handled.</description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EVENT_REQ</name>
+       <description>Event Requested.</description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TARG_RST</name>
+       <description>Target Reset.</description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EVENT</name>
+       <description>Event Status.</description>
+       <bitRange>[21:20]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>NONE</name>
+         <description>No event.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>REQ_PEND</name>
+         <description>Request not yet sent.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>REQ_NACK</name>
+         <description>Request was sent and NACKed and will be tried again.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>REQ_ACK</name>
+         <description>Request was sent and ACKed.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IBI_DIS</name>
+       <description>Indicates whether IBI events are disabled.</description>
+       <bitRange>[24:24]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CONTREQ_DIS</name>
+       <description>Indicates whether bus controller request events are disabled.</description>
+       <bitRange>[25:25]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HJ_DIS</name>
+       <description>Indicates whether Hot-Joinevents are disabled.</description>
+       <bitRange>[27:27]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ACTSTATE</name>
+       <description>Holds the current activity state.</description>
+       <bitRange>[29:28]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>NORMAL</name>
+         <description>No latency, normal bus operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1MS_LAT</name>
+         <description>1 ms latency.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>100MS_LAT</name>
+         <description>100 ms latency.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10S_LAT</name>
+         <description>10 s latency.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TIMECTRL</name>
+       <description>Time Control mode.</description>
+       <bitRange>[31:30]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>No timing control mode is enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SYNC</name>
+         <description>Synchronous Mode is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ASYNC</name>
+         <description>Asynchronous Mode is enabled.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BOTH</name>
+         <description>Both synchronous and asynchronous modes are enabled.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_CTRL1</name>
+     <description>Target Control 1 Register.</description>
+     <addressOffset>0x00C</addressOffset>
+     <fields>
+      <field>
+       <name>EVENT</name>
+       <description>Sets respecive I3C target event request.</description>
+       <bitRange>[1:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>NORMAL</name>
+         <description>Normal mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBI</name>
+         <description>Generate an IBI on the I3C bus.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTREQ</name>
+         <description>Request control of the I3C bus.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HJ</name>
+         <description>Generate a Hot-Join request.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTIBI</name>
+       <description>Indicates there are extended IBI data bytes.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DYNADDR_IDX</name>
+       <description>Index of dynamic address for the current IBI request.</description>
+       <bitRange>[7:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>IBIDATA</name>
+       <description>Contains the mandatory data byte to be sent when generating an IBI.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_INTEN</name>
+     <description>Target Interrupt Enable Register.</description>
+     <addressOffset>0x010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>START detected.</description>
+       <bitRange>[8:8]</bitRange>
+      </field>
+      <field>
+       <name>ADDRMATCH</name>
+       <description>Address matched interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP detected.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>RX_RDY</name>
+       <description>Receive data ready.</description>
+       <bitRange>[11:11]</bitRange>
+      </field>
+      <field>
+       <name>TX_NFULL</name>
+       <description>Ready for transmit data,</description>
+       <bitRange>[12:12]</bitRange>
+      </field>
+      <field>
+       <name>DYNADDR_CHG</name>
+       <description>Dynamic Address Changed interrupt enable.</description>
+       <bitRange>[13:13]</bitRange>
+      </field>
+      <field>
+       <name>CCC</name>
+       <description>CCC Reveived Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+      </field>
+      <field>
+       <name>ERRWARN</name>
+       <description>Error or warning interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>CCCH_DONE</name>
+       <description>CCC Handled Interrupt.</description>
+       <bitRange>[17:17]</bitRange>
+      </field>
+      <field>
+       <name>EVENT_REQ</name>
+       <description>Event Reqeusted Interrupt.</description>
+       <bitRange>[18:18]</bitRange>
+      </field>
+      <field>
+       <name>TARG_RST</name>
+       <description>I3C Target Reset Interrupt.</description>
+       <bitRange>[19:19]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_INTCLR</name>
+     <description>Target Interrupt Clear Register.</description>
+     <addressOffset>0x014</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>START detected.</description>
+       <bitRange>[8:8]</bitRange>
+      </field>
+      <field>
+       <name>ADDRMATCH</name>
+       <description>Address matched interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP detected.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>RX_RDY</name>
+       <description>Receive data ready.</description>
+       <bitRange>[11:11]</bitRange>
+      </field>
+      <field>
+       <name>TX_NFULL</name>
+       <description>Ready for transmit data,</description>
+       <bitRange>[12:12]</bitRange>
+      </field>
+      <field>
+       <name>DYNADDR_CHG</name>
+       <description>Dynamic Address Changed interrupt enable.</description>
+       <bitRange>[13:13]</bitRange>
+      </field>
+      <field>
+       <name>CCC</name>
+       <description>CCC Reveived Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+      </field>
+      <field>
+       <name>ERRWARN</name>
+       <description>Error or warning interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>CCCH_DONE</name>
+       <description>CCC Handled Interrupt.</description>
+       <bitRange>[17:17]</bitRange>
+      </field>
+      <field>
+       <name>EVENT_REQ</name>
+       <description>Event Reqeusted Interrupt.</description>
+       <bitRange>[18:18]</bitRange>
+      </field>
+      <field>
+       <name>TARG_RST</name>
+       <description>I3C Target Reset Interrupt.</description>
+       <bitRange>[19:19]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_INTFL</name>
+     <description>Target Interrupt Flag Register.</description>
+     <addressOffset>0x018</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>START detected.</description>
+       <bitRange>[8:8]</bitRange>
+      </field>
+      <field>
+       <name>ADDRMATCH</name>
+       <description>Address matched interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP detected.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>RX_RDY</name>
+       <description>Receive data ready.</description>
+       <bitRange>[11:11]</bitRange>
+      </field>
+      <field>
+       <name>TX_NFULL</name>
+       <description>Ready for transmit data,</description>
+       <bitRange>[12:12]</bitRange>
+      </field>
+      <field>
+       <name>DYNADDR_CHG</name>
+       <description>Dynamic Address Changed interrupt enable.</description>
+       <bitRange>[13:13]</bitRange>
+      </field>
+      <field>
+       <name>CCC</name>
+       <description>CCC Reveived Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+      </field>
+      <field>
+       <name>ERRWARN</name>
+       <description>Error or warning interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>CCCH_DONE</name>
+       <description>CCC Handled Interrupt.</description>
+       <bitRange>[17:17]</bitRange>
+      </field>
+      <field>
+       <name>EVENT_REQ</name>
+       <description>Event Reqeusted Interrupt.</description>
+       <bitRange>[18:18]</bitRange>
+      </field>
+      <field>
+       <name>TARG_RST</name>
+       <description>I3C Target Reset Interrupt.</description>
+       <bitRange>[19:19]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_ERRWARN</name>
+     <description>Target Error and Warning Register.</description>
+     <addressOffset>0x01C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>OVR</name>
+       <description>Internal FIFO overrun flag.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>UNR</name>
+       <description>Internal FIFO underrun flag.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>UNR_NACK</name>
+       <description>I3C or I2C mode address emitted by the IP was NACKed by the targets.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>CONT_RX_TERM</name>
+       <description>Controller terminated read in message mode.</description>
+       <bitRange>[3:3]</bitRange>
+      </field>
+      <field>
+       <name>INVSTART</name>
+       <description>Invalid START.</description>
+       <bitRange>[4:4]</bitRange>
+      </field>
+      <field>
+       <name>SDR_PAR</name>
+       <description>SDR Parity Error.</description>
+       <bitRange>[8:8]</bitRange>
+      </field>
+      <field>
+       <name>TO</name>
+       <description>Timeout Error.</description>
+       <bitRange>[11:11]</bitRange>
+      </field>
+      <field>
+       <name>RX_UNR</name>
+       <description>Read data underrun.</description>
+       <bitRange>[16:16]</bitRange>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Write data overrun.</description>
+       <bitRange>[17:17]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_DMACTRL</name>
+     <description>Target DMA Control Register.</description>
+     <addressOffset>0x020</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_EN</name>
+       <description>DMA read enable.</description>
+       <bitRange>[1:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Disable DMA.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ONE_FR</name>
+         <description>Enable DMA for one frame.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Enable DMA until disabled by setting this field to 0b00.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>DMA write enable.</description>
+       <bitRange>[3:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Disable DMA.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ONE_FR</name>
+         <description>Enable DMA for one frame.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Enable DMA until disabled by setting this field to 0b00.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WIDTH</name>
+       <description>Selects the data width for DMA transfers.</description>
+       <bitRange>[5:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>BYTE</name>
+         <description>Byte size.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HALFWORD</name>
+         <description>Halfword size.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_FIFOCTRL</name>
+     <description>Target FIFO Control Register.</description>
+     <addressOffset>0x02C</addressOffset>
+     <fields>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Flush TX FIFO.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Flush RX FIFO.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>UNLOCK</name>
+       <description>Unlock FIFO Triggers.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TX_THD_LVL</name>
+       <description>TX FIFO trigger level.</description>
+       <bitRange>[5:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EMPTY</name>
+         <description>Trigger when empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>QUARTER_FULL</name>
+         <description>Trigger when quarter full or less.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HALF_FULL</name>
+         <description>Trigger when half full or less.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ALMOST_FULL</name>
+         <description>Trigger when almost full or less.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD_LVL</name>
+       <description>RX FIFO trigger level.</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>NOT_EMPTY</name>
+         <description>Trigger when empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>QUARTER_FULL</name>
+         <description>Trigger when quarter full or less.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HALF_FULL</name>
+         <description>Trigger when half full or less.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_QUARTER_FULL</name>
+         <description>Trigger when 3 quarters full or less.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Number of messages in TX FIFO.</description>
+       <bitRange>[21:16]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Number of messages in RX FIFO.</description>
+       <bitRange>[29:24]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>TX FIFO Full flag.</description>
+       <bitRange>[30:30]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>RX FIFO Empty Flag.</description>
+       <bitRange>[31:31]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_TXFIFO8</name>
+     <description>Target Write Byte Data Register.</description>
+     <addressOffset>0x030</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data byte to send.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>END</name>
+       <description>End of data.</description>
+       <bitRange>[8:8]</bitRange>
+      </field>
+      <field>
+       <name>END2</name>
+       <description>End of data.</description>
+       <bitRange>[16:16]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_TXFIFO8E</name>
+     <description>Target Write Byte Data as End Register.</description>
+     <addressOffset>0x034</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_TXFIFO16</name>
+     <description>Target Write Half-Word Data Register.</description>
+     <addressOffset>0x038</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data halfword to send.</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+      <field>
+       <name>END</name>
+       <description>End of data.</description>
+       <bitRange>[16:16]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_TXFIFO16E</name>
+     <description>Target Write Half-Word Data as End Register.</description>
+     <addressOffset>0x03C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data halfword to send.</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_RXFIFO8</name>
+     <description>Target Read Byte Data Register.</description>
+     <addressOffset>0x040</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read data byte from RX FIFO.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_RXFIFO16</name>
+     <description>Target Read Half-Word Data Register.</description>
+     <addressOffset>0x048</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read data hyalfword from RX FIFO.</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_TXFIFO8O</name>
+     <description>Target Byte-Only Write Byte Data Register.</description>
+     <addressOffset>0x054</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data byte to send.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_CAP0</name>
+     <description>Target Capabilities 0 Register.</description>
+     <addressOffset>0x05C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>MAPCNT</name>
+       <description>Number of mapped target addresses supported.</description>
+       <bitRange>[3:0]</bitRange>
+      </field>
+      <field>
+       <name>I2C_10BADDR</name>
+       <description>I2C 10-bit address support.</description>
+       <bitRange>[4:4]</bitRange>
+      </field>
+      <field>
+       <name>I2C_SWRST</name>
+       <description>I2C Software Reset Support.</description>
+       <bitRange>[5:5]</bitRange>
+      </field>
+      <field>
+       <name>I2C_DEVID</name>
+       <description>I2C Device ID Support.</description>
+       <bitRange>[6:6]</bitRange>
+      </field>
+      <field>
+       <name>FIFO32_REG</name>
+       <description>FIFO 32 registers available.</description>
+       <bitRange>[7:7]</bitRange>
+      </field>
+      <field>
+       <name>EXTIBI</name>
+       <description>Extended IBI data support.</description>
+       <bitRange>[8:8]</bitRange>
+      </field>
+      <field>
+       <name>EXTIBI_REG</name>
+       <description>Extended IBI data register support.</description>
+       <bitRange>[9:9]</bitRange>
+      </field>
+      <field>
+       <name>HDRBT_LANES</name>
+       <description>Multi-lane support for HDR-BT mode.</description>
+       <bitRange>[13:12]</bitRange>
+      </field>
+      <field>
+       <name>CCC_V1_1</name>
+       <description>CCC V1.1 Support.</description>
+       <bitRange>[16:16]</bitRange>
+      </field>
+      <field>
+       <name>TARG_RST</name>
+       <description>Target Reset Support.</description>
+       <bitRange>[17:17]</bitRange>
+      </field>
+      <field>
+       <name>GROUPADDR</name>
+       <description>Group address support.</description>
+       <bitRange>[19:18]</bitRange>
+      </field>
+      <field>
+       <name>AASA_CCC</name>
+       <description>SETAASA CCC Support.</description>
+       <bitRange>[21:21]</bitRange>
+      </field>
+      <field>
+       <name>T2T_SUBSC</name>
+       <description>Target-to-target subscriber support.</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>T2T_WR</name>
+       <description>Target-to-target write support.</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_CAP1</name>
+     <description>TARG_Capabilities 1 Register.</description>
+     <addressOffset>0x060</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>PROVID</name>
+       <description>Provisioned ID implementation.</description>
+       <bitRange>[1:0]</bitRange>
+      </field>
+      <field>
+       <name>PROVID_REG</name>
+       <description>Provision ID, Bus Characteristics, Device Characteristics implementation.</description>
+       <bitRange>[5:2]</bitRange>
+      </field>
+      <field>
+       <name>HDR_MODES</name>
+       <description>Supported HDR modes.</description>
+       <bitRange>[8:6]</bitRange>
+      </field>
+      <field>
+       <name>CONT</name>
+       <description>Controller mode capable.</description>
+       <bitRange>[9:9]</bitRange>
+      </field>
+      <field>
+       <name>STATADDR</name>
+       <description>I2C-style static address implementation.</description>
+       <bitRange>[11:10]</bitRange>
+      </field>
+      <field>
+       <name>CCCH</name>
+       <description>CCC Handled by IP.</description>
+       <bitRange>[15:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>BASIC</name>
+         <description>Basic CCCs.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>LIMITS</name>
+         <description>CCCs related to maximum transfer lengths and speed.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INTACT</name>
+         <description>Pending Interrupt and Activity Mode fields of GETSTATUS CCC.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VENDOR</name>
+         <description>Vendor Reserved field of GETSTATUS CCC.</description>
+         <value>8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IBI_EVENTS</name>
+       <description>Supported IBI events.</description>
+       <bitRange>[20:16]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>IBI</name>
+         <description>IBI support.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAYLOAD</name>
+         <description>IBI has payload.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTREQ</name>
+         <description>Controller request support.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HJ</name>
+         <description>Hot-Join support.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BAMATCH</name>
+         <description>Use BAMATCH field of CONFIG register to measure 1us Bus Available timing.</description>
+         <value>16</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TIMECTRL</name>
+       <description>Timing Control Support.</description>
+       <bitRange>[21:21]</bitRange>
+      </field>
+      <field>
+       <name>EXTFIFO</name>
+       <description>External FIFO configuration.</description>
+       <bitRange>[25:23]</bitRange>
+      </field>
+      <field>
+       <name>TXFIFO_CFG</name>
+       <description>TX FIFO configuration.</description>
+       <bitRange>[27:26]</bitRange>
+      </field>
+      <field>
+       <name>RXFIFO_CFG</name>
+       <description>RX FIFO configuration.</description>
+       <bitRange>[29:28]</bitRange>
+      </field>
+      <field>
+       <name>INTR</name>
+       <description>Interrupt support.</description>
+       <bitRange>[30:30]</bitRange>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA support.</description>
+       <bitRange>[31:31]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_DYNADDR</name>
+     <description>Target Dynamic Address Register.</description>
+     <addressOffset>0x064</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VALID</name>
+       <description>Address valid check.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>ADDR</name>
+       <description>The assigned dynamic address.</description>
+       <bitRange>[7:1]</bitRange>
+      </field>
+      <field>
+       <name>CAUSE</name>
+       <description>Indicates how the last primary dynnamic address value change occurred.</description>
+       <bitRange>[10:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_MAXLIMITS</name>
+     <description>Maximum Limits Register.</description>
+     <addressOffset>0x068</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX</name>
+       <description>The maximum number of bytes that the I3C controller may read from this I3C target device per message.</description>
+       <bitRange>[11:0]</bitRange>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>The maximum number of bytes that the I3C controller may write from this I3C target device per message.</description>
+       <bitRange>[27:16]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_IDEXT</name>
+     <description>ID Extension Register.</description>
+     <addressOffset>0x070</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DEVCHAR</name>
+       <description>Device Characteristics Register.</description>
+       <bitRange>[15:8]</bitRange>
+      </field>
+      <field>
+       <name>BUSCHAR</name>
+       <description>Bus Characteristics Register.</description>
+       <bitRange>[23:16]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_MSGLAST</name>
+     <description>Target Matching Address Index Register.</description>
+     <addressOffset>0x07C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>IDX</name>
+       <description>Index or group number of last matched address.</description>
+       <bitRange>[3:0]</bitRange>
+      </field>
+      <field>
+       <name>STATADDR</name>
+       <description>Last matched address was a I2C static address.</description>
+       <bitRange>[4:4]</bitRange>
+      </field>
+      <field>
+       <name>GROUP</name>
+       <description>Last matched address was a group address.</description>
+       <bitRange>[5:5]</bitRange>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description>Indicates the mode of the last access.</description>
+       <bitRange>[7:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DYN_STAT_ADDR</name>
+         <description>I3C SDR or I2C</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HDR_DDR</name>
+         <description>HDR-DDR.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HDR_BT</name>
+         <description>HDR-BT.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PREV_IDX</name>
+       <description>Index or group number of previous matched address.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+      <field>
+       <name>PREV_GROUP</name>
+       <description>Last matched address was a previous group address.</description>
+       <bitRange>[13:13]</bitRange>
+      </field>
+      <field>
+       <name>PREV_MODE</name>
+       <description>Indicates the mode of the previous access.</description>
+       <bitRange>[15:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DYN_STAT_ADDR</name>
+         <description>I3C SDR or I2C</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HDR_DDR</name>
+         <description>HDR-DDR.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HDR_BT</name>
+         <description>HDR-BT.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SECPREV_IDX</name>
+       <description>Index or group number of secondary previous matched address.</description>
+       <bitRange>[19:16]</bitRange>
+      </field>
+      <field>
+       <name>SECPREV_GROUP</name>
+       <description>Last matched address was a secondary previous group address.</description>
+       <bitRange>[21:21]</bitRange>
+      </field>
+      <field>
+       <name>SECPREV_MODE</name>
+       <description>Indicates the mode of the secondary previous access.</description>
+       <bitRange>[23:22]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DYN_STAT_ADDR</name>
+         <description>I3C SDR or I2C</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HDR_DDR</name>
+         <description>HDR-DDR.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HDR_BT</name>
+         <description>HDR-BT.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_CTRL1</name>
+     <description>Controller Control 1 Register.</description>
+     <addressOffset>0x084</addressOffset>
+     <fields>
+      <field>
+       <name>REQ</name>
+       <description>Requests an I3C or I2C bus operation.</description>
+       <bitRange>[2:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>NONE</name>
+         <description>None operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EMIT_START</name>
+         <description>Emit a START with address and read-write bit from stopped state or in the middle of an SDR message.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EMIT_STOP</name>
+         <description>Emit a STOP.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBI_ACKNACK</name>
+         <description>Manually ACK or NACK an IBI.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PROCESS_DAA</name>
+         <description>Process Dynamic Address Assignment.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EXIT_RST</name>
+         <description>Emit HDR Exit Pattern or Target Reset pattern.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AUTO_IBI</name>
+         <description>Automatic IBI response.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TYPE</name>
+       <description>Controls type of operation for REQ field.</description>
+       <bitRange>[5:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>IBIRESP</name>
+       <description>Response to use when an IBI occurs.</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RDWR_DIR</name>
+       <description>Direction of the transfer.</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ADDR</name>
+       <description>Address to send with START.</description>
+       <bitRange>[15:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TERM_RD</name>
+       <description>Termination count for read.</description>
+       <bitRange>[23:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_STATUS</name>
+     <description>Controller Status Register.</description>
+     <addressOffset>0x088</addressOffset>
+     <fields>
+      <field>
+       <name>STATE</name>
+       <description>Current working state.</description>
+       <bitRange>[2:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>IDLE</name>
+         <description>Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TARG_REQ</name>
+         <description>I3C Bus i stopped and a target is holding SDA low.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDR_TXSDRMSG</name>
+         <description>SDR Message Mode using SDRMSG registers.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDR_NORM</name>
+         <description>Normal SDR message mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DDR</name>
+         <description>DDR Message mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DAA</name>
+         <description>Dynamic Address Assignment mode.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBI_ACKNACK</name>
+         <description>IP is waiting for the application to provide an ACK or NACK decision.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBI_RX</name>
+         <description>IP is receiving an IBI.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WAIT</name>
+       <description>Depending on STATE, WAIT is 1 when it's waiting in an intermediary state.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>NACK</name>
+       <description>Address was NACKed.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>IBITYPE</name>
+       <description>The type of event for which arbitration was last won.</description>
+       <bitRange>[7:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>NONE</name>
+         <description>None.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBI</name>
+         <description>In-band Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONT_REQ</name>
+         <description>Controller request.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HOTJOIN_REQ</name>
+         <description>Hot-Join request.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TARG_START</name>
+       <description>Target START detected.</description>
+       <bitRange>[8:8]</bitRange>
+      </field>
+      <field>
+       <name>REQ_DONE</name>
+       <description>CTRL1 Request completed.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DONE</name>
+       <description>Message completed.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_RDY</name>
+       <description>Receive data ready.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_NFULL</name>
+       <description>TX FIFO Not Full flag.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>IBI_WON</name>
+       <description>IBI Arbitration won.</description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ERRWARN</name>
+       <description>Error or warning status.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CONT_TRANS</name>
+       <description>IP transitioned from I3C target to controller.</description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>IBI_ADDR</name>
+       <description>The address of a received IBI or dcontroller request.</description>
+       <bitRange>[30:24]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_IBIRULES</name>
+     <description>Controller IBI Registry and Rules Register.</description>
+     <addressOffset>0x08C</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR0</name>
+       <description>Target 0 dynamic address.</description>
+       <bitRange>[5:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ADDR1</name>
+       <description>Target 1 dynamic address.</description>
+       <bitRange>[11:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ADDR2</name>
+       <description>Target 2 dynamic address.</description>
+       <bitRange>[17:12]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ADDR3</name>
+       <description>Target 3 dynamic address.</description>
+       <bitRange>[23:18]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ADDR4</name>
+       <description>Target 4 dynamic address.</description>
+       <bitRange>[29:24]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB0</name>
+       <description>Implementation of MSb for I3C dynamic addresses.</description>
+       <bitRange>[30:30]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>NOBYTE</name>
+       <description>Specifies the function of ADDR0 to ADDR4</description>
+       <bitRange>[31:31]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_INTEN</name>
+     <description>Controller Interrupt Enable Register.</description>
+     <addressOffset>0x090</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TARG_START</name>
+       <description>Target Start Detected.</description>
+       <bitRange>[8:8]</bitRange>
+      </field>
+      <field>
+       <name>REQ_DONE</name>
+       <description>CTRL request completed.</description>
+       <bitRange>[9:9]</bitRange>
+      </field>
+      <field>
+       <name>DONE</name>
+       <description>Message complete.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>RX_RDY</name>
+       <description>Receive data ready.</description>
+       <bitRange>[11:11]</bitRange>
+      </field>
+      <field>
+       <name>TX_NFULL</name>
+       <description>Ready for transmit data,</description>
+       <bitRange>[12:12]</bitRange>
+      </field>
+      <field>
+       <name>IBI_WON</name>
+       <description>IBI arbitration won.</description>
+       <bitRange>[13:13]</bitRange>
+      </field>
+      <field>
+       <name>ERRWARN</name>
+       <description>Error or warning interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>NOW_CONT</name>
+       <description>The IP transitioned from I3C bus target to I3C bus controller.</description>
+       <bitRange>[19:19]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_INTCLR</name>
+     <description>Controller Interrupt Clear Register.</description>
+     <addressOffset>0x094</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>TARG_START</name>
+       <description>Target Start Detected.</description>
+       <bitRange>[8:8]</bitRange>
+      </field>
+      <field>
+       <name>REQ_DONE</name>
+       <description>CTRL request completed.</description>
+       <bitRange>[9:9]</bitRange>
+      </field>
+      <field>
+       <name>DONE</name>
+       <description>Message complete.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>RX_RDY</name>
+       <description>Receive data ready.</description>
+       <bitRange>[11:11]</bitRange>
+      </field>
+      <field>
+       <name>TX_NFULL</name>
+       <description>Ready for transmit data,</description>
+       <bitRange>[12:12]</bitRange>
+      </field>
+      <field>
+       <name>IBI_WON</name>
+       <description>IBI arbitration won.</description>
+       <bitRange>[13:13]</bitRange>
+      </field>
+      <field>
+       <name>ERRWARN</name>
+       <description>Error or warning interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>NOW_CONT</name>
+       <description>The IP transitioned from I3C bus target to I3C bus controller.</description>
+       <bitRange>[19:19]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_INTFL</name>
+     <description>Controller Interrupt Flag Register.</description>
+     <addressOffset>0x098</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TARG_START</name>
+       <description>Target Start Detected.</description>
+       <bitRange>[8:8]</bitRange>
+      </field>
+      <field>
+       <name>REQ_DONE</name>
+       <description>CTRL request completed.</description>
+       <bitRange>[9:9]</bitRange>
+      </field>
+      <field>
+       <name>DONE</name>
+       <description>Message complete.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>RX_RDY</name>
+       <description>Receive data ready.</description>
+       <bitRange>[11:11]</bitRange>
+      </field>
+      <field>
+       <name>TX_NFULL</name>
+       <description>Ready for transmit data,</description>
+       <bitRange>[12:12]</bitRange>
+      </field>
+      <field>
+       <name>IBI_WON</name>
+       <description>IBI arbitration won.</description>
+       <bitRange>[13:13]</bitRange>
+      </field>
+      <field>
+       <name>ERRWARN</name>
+       <description>Error or warning interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>NOW_CONT</name>
+       <description>The IP transitioned from I3C bus target to I3C bus controller.</description>
+       <bitRange>[19:19]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_ERRWARN</name>
+     <description>Controller Error and Warning Register.</description>
+     <addressOffset>0x09C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>NACK</name>
+       <description>I3C or I2C mode address emitted by the IP was NACKed by the targets.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>TX_ABT</name>
+       <description>Write aborted due to data NACK.</description>
+       <bitRange>[3:3]</bitRange>
+      </field>
+      <field>
+       <name>RX_TERM</name>
+       <description>Controller terminated read in messaage mode.</description>
+       <bitRange>[4:4]</bitRange>
+      </field>
+      <field>
+       <name>HDR_PAR</name>
+       <description>HDR Parity Error.</description>
+       <bitRange>[9:9]</bitRange>
+      </field>
+      <field>
+       <name>HDR_CRC</name>
+       <description>HDR-DDR CRC Error.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>RX_UNR</name>
+       <description>Read data underrun.</description>
+       <bitRange>[16:16]</bitRange>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Write data overrun.</description>
+       <bitRange>[17:17]</bitRange>
+      </field>
+      <field>
+       <name>MSG</name>
+       <description>Message mode error.</description>
+       <bitRange>[18:18]</bitRange>
+      </field>
+      <field>
+       <name>INV_REQ</name>
+       <description>Invalid use of request from CTRL register.</description>
+       <bitRange>[19:19]</bitRange>
+      </field>
+      <field>
+       <name>TO</name>
+       <description>Timeout error.</description>
+       <bitRange>[20:20]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_DMACTRL</name>
+     <description>Controller DMA Control Register.</description>
+     <addressOffset>0x0A0</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_EN</name>
+       <description>DMA read enable.</description>
+       <bitRange>[1:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Disable DMA.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ONE_FR</name>
+         <description>Enable DMA for one frame.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Enable DMA until disabled by setting this field to 0b00.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>DMA write enable.</description>
+       <bitRange>[3:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Disable DMA.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ONE_FR</name>
+         <description>Enable DMA for one frame.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Enable DMA until disabled by setting this field to 0b00.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WIDTH</name>
+       <description>Selects the data width for DMA transfers.</description>
+       <bitRange>[5:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>BYTE</name>
+         <description>Byte size.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HALFWORD</name>
+         <description>Halfword size.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_FIFOCTRL</name>
+     <description>Controller FIFO Control Register.</description>
+     <addressOffset>0x0AC</addressOffset>
+     <fields>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Flush TX FIFO.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Flush RX FIFO.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>UNLOCK</name>
+       <description>Unlock FIFO Triggers.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TX_THD_LVL</name>
+       <description>TX FIFO trigger level.</description>
+       <bitRange>[5:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EMPTY</name>
+         <description>Trigger when empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>QUARTER_FULL</name>
+         <description>Trigger when quarter full or less.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HALF_FULL</name>
+         <description>Trigger when half full or less.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ALMOST_FULL</name>
+         <description>Trigger when almost full or less.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD_LVL</name>
+       <description>RX FIFO trigger level.</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>NOT_EMPTY</name>
+         <description>Trigger when empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>QUARTER_FULL</name>
+         <description>Trigger when quarter full or less.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HALF_FULL</name>
+         <description>Trigger when half full or less.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_QUARTER_FULL</name>
+         <description>Trigger when 3 quarters full or less.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Number of messages in TX FIFO.</description>
+       <bitRange>[21:16]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Number of messages in RX FIFO.</description>
+       <bitRange>[29:24]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>TX FIFO Full flag.</description>
+       <bitRange>[30:30]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>RX FIFO Empty Flag.</description>
+       <bitRange>[31:31]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_TXFIFO8</name>
+     <description>Controller Write Byte Data Register.</description>
+     <addressOffset>0x0B0</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data byte to send.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>END</name>
+       <description>End of data.</description>
+       <bitRange>[8:8]</bitRange>
+      </field>
+      <field>
+       <name>END2</name>
+       <description>End of data.</description>
+       <bitRange>[16:16]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_TXFIFO8E</name>
+     <description>Controller Write Byte Data as End Register.</description>
+     <addressOffset>0x0B4</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_TXFIFO16</name>
+     <description>Controller Write Half-Word Data Register.</description>
+     <addressOffset>0x0B8</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data halfword to send.</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+      <field>
+       <name>END</name>
+       <description>End of data.</description>
+       <bitRange>[16:16]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_TXFIFO16E</name>
+     <description>Controller Write Half-Word Data as End Register.</description>
+     <addressOffset>0x0BC</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data halfword to send.</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_RXFIFO8</name>
+     <description>Controller Read Byte Data Register.</description>
+     <addressOffset>0x0C0</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read data byte from RX FIFO.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_RXFIFO16</name>
+     <description>Controller Read Half-Word Data Register.</description>
+     <addressOffset>0x0C8</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read data hyalfword from RX FIFO.</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_TXFIFO8O</name>
+     <description>Controller Byte-Only Write Byte Data Register.</description>
+     <addressOffset>0x0CC</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data byte to send.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_TXSDRMSG_CTRL</name>
+     <description>Controller Start or Continue SDR Message Register.</description>
+     <addressOffset>0x0D0</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RDWR_DIR</name>
+       <description>Direction of the transfer.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>ADDR</name>
+       <description>Destination address of message.</description>
+       <bitRange>[7:1]</bitRange>
+      </field>
+      <field>
+       <name>END</name>
+       <description>Select how to end message.</description>
+       <bitRange>[8:8]</bitRange>
+      </field>
+      <field>
+       <name>I2C_EN</name>
+       <description>I2C Mode Enable.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>LEN</name>
+       <description>Message length in bytes.</description>
+       <bitRange>[15:11]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_TXSDRMSG_FIFO</name>
+     <description>Controller Start or Continue SDR Message Register.</description>
+     <addressOffset>0x0D0</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data for SDR write message after control information has been written.</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_RXSDRMSG</name>
+     <description>Controller Read SDR Message Data Register.</description>
+     <addressOffset>0x0D4</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data for SDR write message after control information has been written.</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_TXDDRMSG</name>
+     <description>Controller Start or Continue DDR Message Register.</description>
+     <addressOffset>0x0D8</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>MSG</name>
+       <description>Data, address/command, and control information.</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_RXDDR16</name>
+     <description>Controller Read DDR Message Data Register.</description>
+     <addressOffset>0x0DC</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read data (16bits).</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CONT_DYNADDR</name>
+     <description>Controller Dynamic Address Register.</description>
+     <addressOffset>0x0E4</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>The assigned dynamic address.</description>
+       <bitRange>[7:1]</bitRange>
+      </field>
+      <field>
+       <name>VALID</name>
+       <description>Address valid check.</description>
+       <bitRange>[8:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_GROUPDEF</name>
+     <description>Target Group Definition Register.</description>
+     <addressOffset>0x114</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ADDR_EN</name>
+       <description>Group Address enable.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>ADDR</name>
+       <description>Group Address .</description>
+       <bitRange>[7:1]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_MAPCTRL0</name>
+     <description>Target Primary Map Control Register.</description>
+     <addressOffset>0x11C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DYNADDR_EN</name>
+       <description>Dynamic address is enabled.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>DYNADDR</name>
+       <description>Dynamic address.</description>
+       <bitRange>[7:1]</bitRange>
+      </field>
+      <field>
+       <name>CAUSE</name>
+       <description>Indicates how the last primary dynamic address value change occurred.</description>
+       <bitRange>[10:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_MAPCTRL1</name>
+     <description>Target Map Control 1 Register.</description>
+     <addressOffset>0x120</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Mapped address slot is enabled.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>ADDR</name>
+       <description>Static or Dynamic address.</description>
+       <bitRange>[7:1]</bitRange>
+      </field>
+      <field>
+       <name>STATADDR_EN</name>
+       <description>ADDR field contains the I2C static address if enabled.</description>
+       <bitRange>[8:8]</bitRange>
+      </field>
+      <field>
+       <name>STATADDR_10B</name>
+       <description>Contains the upper 3 bits of a 10-bit I2C Static Address.</description>
+       <bitRange>[11:9]</bitRange>
+      </field>
+      <field>
+       <name>NACK</name>
+       <description>Indicates how the last primary dynamic address value change occurred.</description>
+       <bitRange>[12:12]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TARG_MAPCTRL2</name>
+     <description>Target Map Control 2 Register.</description>
+     <addressOffset>0x124</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Mapped address slot is enabled.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>ADDR</name>
+       <description>Static or Dynamic address.</description>
+       <bitRange>[7:1]</bitRange>
+      </field>
+      <field>
+       <name>STATADDR_EN</name>
+       <description>ADDR field contains the I2C static address if enabled.</description>
+       <bitRange>[8:8]</bitRange>
+      </field>
+      <field>
+       <name>NACK</name>
+       <description>Indicates how the last primary dynamic address value change occurred.</description>
+       <bitRange>[12:12]</bitRange>
+      </field>
+      <field>
+       <name>AUTO_EN</name>
+       <description>Enable slot for automatic dynamic address assignment.</description>
+       <bitRange>[13:13]</bitRange>
+      </field>
+      <field>
+       <name>PID</name>
+       <description>Indicates how the last primary dynamic address value change occurred.</description>
+       <bitRange>[31:14]</bitRange>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>ICC</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x5002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>INFO</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SZ</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>CCH</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEM</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAY</name>
+     <description>Cache Way Control Register.</description>
+     <addressOffset>0x0200</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>WAY</name>
+       <description>Number of cache way, default is always 2. Allowed values are 1,2,4.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1</name>
+         <description>1</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2</name>
+         <description>2</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4</name>
+         <description>4</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REGCTRL</name>
+     <description>Regional Control Register.</description>
+     <addressOffset>0x0204</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enable the regional high andlow bound compare, cache the data only if the TAG content between the high and low bound.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>EXC</name>
+       <description>Cache the data only if the TAG content is excluded in the high and low bound.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>4</dim>
+     <dimIncrement>8</dimIncrement>
+     <name>REGION[%s]</name>
+     <description>Regional Low and High Bound Registers.</description>
+     <headerStructName>icc_reg</headerStructName>
+     <addressOffset>0x0208</addressOffset>
+     <size>64</size>
+     <access>read-write</access>
+     <register>
+      <name>LBOUND</name>
+      <description>Regional Low Bound Register.</description>
+      <addressOffset>0x0000</addressOffset>
+      <size>32</size>
+      <fields>
+       <field>
+        <name>BOUND</name>
+        <description>Low Bound.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>HBOUND</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <size>32</size>
+      <fields>
+       <field>
+        <name>BOUND</name>
+        <description>High Bound.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+    <register>
+     <name>PFMCTRL</name>
+     <description>Performance Control Register.</description>
+     <addressOffset>0x0300</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enable performance counter. Clear to 0 when AHB access counter reach 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PFMCNT</name>
+     <description>Performance Counter Register.</description>
+     <addressOffset>0x0304</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Write the total AHB access counter. Read the current performance hit count.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>MCR</name>
+   <description>Misc Control.</description>
+   <baseAddress>0x50006C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RST</name>
+     <description>Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BOOST</name>
+       <description>Reset BOOST Controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>Output Enable Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>SQWOUT_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>CLKSEL</name>
+       <description>Clcok Select for the RTC, System, WUT, and Timer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ERTCO</name>
+         <description>ERTCO as clock source.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INRO_DIV4</name>
+         <description>INRO as clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RTC_IN_DIV8</name>
+         <description>P0.12 div 8 as clock source.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERTCO32K_EN</name>
+       <description>Enable the 32KHz ERTCO.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>Enable the ERTCO.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BYPASS0</name>
+     <description>This register is used by firmware to bypass chain of trust on a Warm Boot.</description>
+     <addressOffset>0x30</addressOffset>
+    </register>
+    <register>
+     <name>BYPASS1</name>
+     <description>This register is used by firmware to bypass chain of trust on a Warm Boot.</description>
+     <addressOffset>0x34</addressOffset>
+    </register>
+    <register>
+     <name>DATA0</name>
+     <description>Battery Back Data0 Register. Retains value in all modes.</description>
+     <addressOffset>0x40</addressOffset>
+    </register>
+    <register>
+     <name>DATA1</name>
+     <description>Battery Back Data1 Register. Retains value in all modes.</description>
+     <addressOffset>0x44</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x50006800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>LPCTRL</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>SRAMRET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>BG_DIS</name>
+       <description>Bandgap OFF. This controls the System Bandgap in DeepSleep mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>Bandgap is always ON.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>Bandgap is OFF in DeepSleep mode (default).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RETLDO_EN</name>
+       <description>Retention LDO Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDO_EN_DLY</name>
+       <description>Core LDO Enable Delay.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable delay LDO power up to smooth LDO voltage drop.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPWKFL_CLR</name>
+       <description>LP wakeup flag register clear.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKFL0</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO0.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>PINS</name>
+       <description>Wakeup Flags.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN0</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>PINS</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWST</name>
+     <description>Low Power Peripheral Wakeup Status Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>BACKUP</name>
+       <description>BACKUP Wakeful Flag.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESET</name>
+       <description>Reset Detected Wakeup Flag.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GP0</name>
+     <description>General Purpose Register 0</description>
+     <addressOffset>0x48</addressOffset>
+    </register>
+    <register>
+     <name>GP1</name>
+     <description>General Purpose Register 1</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>MPC</name>
+   <description>Memory Protection Controller.</description>
+   <baseAddress>0x50091000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>SEC_ERR</name>
+       <description>Security Error Response COnfiguration.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATAIF_REQ</name>
+       <description>Data interface gating request.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATAIF_ACK</name>
+       <description>Data interface gating acknowledged.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AUTO_INC</name>
+       <description>Auto-increment.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SEC_LOCKDOWN</name>
+       <description>Security Lockdown.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_MAX</name>
+     <description>Maximum value of block-based index register.</description>
+     <addressOffset>0x0010</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>VAL</name>
+       <description>Maximum value of block-based index register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_CFG</name>
+     <description>Block Control Register.</description>
+     <addressOffset>0x0014</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SIZE</name>
+       <description>Block Size.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>INIT_ST</name>
+       <description>Initialization in progress.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_IDX</name>
+     <description>Block Index Register.</description>
+     <addressOffset>0x0018</addressOffset>
+     <fields>
+      <field>
+       <name>IDX</name>
+       <description>Index value for accessing block-based lookup table.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_LUT</name>
+     <description>Block-based gating Look Up Table Register.</description>
+     <addressOffset>0x001C</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>Each bit indicates one block, based on the index pointed by the BLKIDX register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_STAT</name>
+     <description>Interrupt Flag Register.</description>
+     <addressOffset>0x0020</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>MPC_IRQ</name>
+       <description>MPC IRQ triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_CLEAR</name>
+     <description>Interrupt Clear Register.</description>
+     <addressOffset>0x0024</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>MPC_IRQ</name>
+       <description>MPC IRQ Clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0028</addressOffset>
+     <fields>
+      <field>
+       <name>MPC_IRQ</name>
+       <description>MPC IRQ Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_INFO1</name>
+     <description>Interrupt Info 1 Register.</description>
+     <addressOffset>0x002C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>HADDR</name>
+       <description>AHB bus signals: Address bus.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_INFO2</name>
+     <description>Interrupt Info 2 Register.</description>
+     <addressOffset>0x0030</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>HMASTER</name>
+       <description>AHB bus signals: Master Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>HNONSEC</name>
+       <description>AHB bus signals: Indicates the current transfer is either a Non-Secure or Secure transfer.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CFG_NS</name>
+       <description>Security state.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_SET</name>
+     <description>Interrupt Set Debug Register.</description>
+     <addressOffset>0x0034</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>MPC_IRQ</name>
+       <description>MPC IRQ Set.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PIDR4</name>
+     <description>Peripheral ID 4 Register.</description>
+     <addressOffset>0x0FD0</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>PIDR5</name>
+     <description>Peripheral ID 5 Register.</description>
+     <addressOffset>0x0FD4</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>PIDR6</name>
+     <description>Peripheral ID 6 Register.</description>
+     <addressOffset>0x0FD8</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>PIDR7</name>
+     <description>Peripheral ID 6 Register.</description>
+     <addressOffset>0x0FDC</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>PIDR0</name>
+     <description>Peripheral ID 0 Register.</description>
+     <addressOffset>0x0FE0</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>PIDR1</name>
+     <description>Peripheral ID 1 Register.</description>
+     <addressOffset>0x0FE4</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>PIDR2</name>
+     <description>Peripheral ID 2 Register.</description>
+     <addressOffset>0x0FE8</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>PIDR3</name>
+     <description>Peripheral ID 3 Register.</description>
+     <addressOffset>0x0FEC</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>CIDR0</name>
+     <description>Component ID register.</description>
+     <addressOffset>0x0FF0</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>CIDR1</name>
+     <description>Component ID register.</description>
+     <addressOffset>0x0FF4</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>CIDR2</name>
+     <description>Component ID register.</description>
+     <addressOffset>0x0FF8</addressOffset>
+     <access>read-only</access>
+    </register>
+    <register>
+     <name>CIDR3</name>
+     <description>Component ID register.</description>
+     <addressOffset>0x0FFC</addressOffset>
+     <access>read-only</access>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral derivedFrom="MPC">
+   <name>MPC1</name>
+   <description>Memory Protection Controller. 1</description>
+   <baseAddress>0x50092000</baseAddress>
+  </peripheral>
+
+  <peripheral derivedFrom="MPC">
+   <name>MPC2</name>
+   <description>Memory Protection Controller. 2</description>
+   <baseAddress>0x50093000</baseAddress>
+  </peripheral>
+
+  <peripheral derivedFrom="MPC">
+   <name>MPC3</name>
+   <description>Memory Protection Controller. 3</description>
+   <baseAddress>0x50094000</baseAddress>
+  </peripheral>
+
+  <peripheral derivedFrom="MPC">
+   <name>MPC4</name>
+   <description>Memory Protection Controller. 4</description>
+   <baseAddress>0x50095000</baseAddress>
+  </peripheral>
+
+  <peripheral derivedFrom="MPC">
+   <name>MPC5</name>
+   <description>Memory Protection Controller. 5</description>
+   <baseAddress>0x50096000</baseAddress>
+  </peripheral>
+
+  <peripheral>
+   <name>NSPC</name>
+   <description>Non-Secure Privilege Controller.</description>
+   <baseAddress>0x40090000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>APBPRIV</name>
+     <description>APB Tartet Privileged/Non-privileged PPC Access Register.</description>
+     <addressOffset>0x0160</addressOffset>
+     <fields>
+      <field>
+       <name>PERIPH</name>
+       <description>Each bit configures the APB PPC to enforce the security access allowed for an individual peripheral.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>GCR</name>
+         <description>Privilege setting for GCR.</description>
+         <value>0x01</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SIR</name>
+         <description>Privilege setting for SIR.</description>
+         <value>0x02</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>FCR</name>
+         <description>Privilege setting for FCR.</description>
+         <value>0x04</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>WDT</name>
+         <description>Privilege setting for WDT.</description>
+         <value>0x08</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES</name>
+         <description>Privilege setting for AES.</description>
+         <value>0x010</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AESKEYS</name>
+         <description>Privilege setting for AESKEYS.</description>
+         <value>0x020</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CRC</name>
+         <description>Privilege setting for CRC.</description>
+         <value>0x040</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO0</name>
+         <description>Privilege setting for GPIO0.</description>
+         <value>0x080</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR0</name>
+         <description>Privilege setting for TMR0.</description>
+         <value>0x0100</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR1</name>
+         <description>Privilege setting for TMR1.</description>
+         <value>0x0200</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR2</name>
+         <description>Privilege setting for TMR2.</description>
+         <value>0x0400</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR3</name>
+         <description>Privilege setting for TMR3.</description>
+         <value>0x0800</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR4</name>
+         <description>Privilege setting for TMR4.</description>
+         <value>0x01000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR5</name>
+         <description>Privilege setting for TMR5.</description>
+         <value>0x02000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>I3C</name>
+         <description>Privilege setting for I3C.</description>
+         <value>0x04000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>UART</name>
+         <description>Privilege setting for UART.</description>
+         <value>0x08000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SPI</name>
+         <description>Privilege setting for SPI.</description>
+         <value>0x010000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TRNG</name>
+         <description>Privilege setting for TRNG.</description>
+         <value>0x020000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BTLE_DBB</name>
+         <description>Privilege setting for BTLE DBB.</description>
+         <value>0x040000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BTLE_RFFE</name>
+         <description>Privilege setting for BTLE RFFE.</description>
+         <value>0x080000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RSTZ</name>
+         <description>Privilege setting for RSTZ.</description>
+         <value>0x0100000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BOOST</name>
+         <description>Privilege setting for Boost Controller.</description>
+         <value>0x0200000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TRIMSIR</name>
+         <description>Privilege setting for TRIMSIR.</description>
+         <value>0x0400000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RTC</name>
+         <description>Privilege setting for RTC.</description>
+         <value>0x01000000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>WUT0</name>
+         <description>Privilege setting for WUT0.</description>
+         <value>0x02000000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>WUT1</name>
+         <description>Privilege setting for WUT1.</description>
+         <value>0x04000000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWRSEQ</name>
+         <description>Privilege setting for Power Sequencer.</description>
+         <value>0x08000000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>MCR</name>
+         <description>Privilege setting for MCR.</description>
+         <value>0x10000000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ALL</name>
+         <description>Privilege setting for all peripherals.</description>
+         <value>0x1F7FFFFF</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AHBMPRIV</name>
+     <description>AHB Privileged/Non-Privileged Non-Secure DMA Access Register.</description>
+     <addressOffset>0x0170</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>Control access for transactions coming from the Non-Secure DMA.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>RSTZ</name>
+   <description>RSTZ Controller</description>
+   <baseAddress>0x50004800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>RSTZ Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enable channels.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SVC_EN</name>
+       <description>Enable the SVC.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_SEL</name>
+       <description>Channel Select.</description>
+       <bitRange>[4:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CAL_EN</name>
+       <description>Calibration mode enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMEASURE_EN</name>
+       <description>Direct Measure mode enable.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OFFTR_P</name>
+       <description>Offset Trim for positive comparator.</description>
+       <bitRange>[11:7]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OFFTR_N</name>
+       <description>Offset Trim for negative comparator.</description>
+       <bitRange>[16:12]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DOUT</name>
+       <description>Comparator Result.</description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CAL_DOUT_POL</name>
+       <description>Calibration DOUT Polarity.</description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>NUM_SAMP</name>
+       <description>Number of captures per sample.</description>
+       <bitRange>[27:24]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TRIP_TOL</name>
+       <description>Number of failed DOUT captures (tolerance) before corresponding RSTZ signal is tripped.</description>
+       <bitRange>[31:28]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BOOST_CLKCTRL</name>
+     <description>Boost Clock Control Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <fields>
+      <field>
+       <name>EXIT_NUM_SAMP</name>
+       <description>Defines how many samples needed of boost output channel to perform when exiting low-power mode before returning to normal active operation.</description>
+       <bitRange>[1:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_SEL</name>
+       <description>Select when channel the output of the boost converter is monitored on.</description>
+       <bitRange>[4:2]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>STATUS_CH[%s]</name>
+     <description>Channel X Status Register.</description>
+     <addressOffset>0x028</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RSTZ</name>
+       <description>Result of most recent sample result.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DOUT</name>
+       <description>Store the most recent DOUT capture for a given channel.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RSTZ_FL</name>
+       <description>RSTZ Flag indicates the RSTZ was tripped at some point since the last time being cleared.</description>
+       <bitRange>[31:31]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>RTC</name>
+   <description>Real Time Clock and Alarm.</description>
+   <baseAddress>0x50006000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>RTC</name>
+    <description>RTC interrupt.</description>
+    <value>3</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC</name>
+       <description>Sub-Seconds Counter (12-bit).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TODA</name>
+     <description>Time-of-day Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-day Alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSECA</name>
+     <description>RTC sub-second alarm.  This register contains the reload value for the sub-second alarm.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>This register contains the reload value for the sub-second alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>RTC Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Real Time Clock Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM_IE</name>
+       <description>Alarm Time-of-Day Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM_IE</name>
+       <description>Alarm Sub-second Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>RTC Busy. This bit is set to 1 by hardware when changes to RTC registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>RTC Ready. This bit is set to 1 by hardware when the RTC count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the RTC count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY_IE</name>
+       <description>RTC Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM_IF</name>
+       <description>Time-of-Day Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM_IF</name>
+       <description>Sub-second Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_SEL</name>
+       <description>Frequency Output Selection. When SQE=1, these bits specify the output frequency on the SQW pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq1Hz</name>
+         <description>1 Hz (Compensated).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq512Hz</name>
+         <description>512 Hz (Compensated).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq4KHz</name>
+         <description>4 KHz.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_EN</name>
+       <description>Asynchronous Counter Read Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>sync</name>
+         <description>Synchronous.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>async</name>
+         <description>Asynchronous.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_EN</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical RTC bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ignore</name>
+         <description>Ignored.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>allow</name>
+         <description>Allowed.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIM</name>
+     <description>RTC Trim Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>RTC Trim. This register contains the 2's complement value that specifies the trim resolution. Each increment or decrement of the bit adds or subtracts 1ppm at each 4KHz clock value, with a maximum correction of +/- 127ppm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VBAT_TMR</name>
+       <description>VBAT Timer Value. When RTC is running off of VBAT, this field is incremented every 32 seconds.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>RTC Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>FILTER_EN</name>
+       <description>Enable Filter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_SEL</name>
+       <description>IBIAS Select.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>2x</name>
+         <description>2x</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4x</name>
+         <description>4x</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HYST_EN</name>
+       <description>RTC Hysteresis Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_EN</name>
+       <description>RTC IBIAS Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYPASS</name>
+       <description>RTC Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_32K</name>
+       <description>RTC 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x50000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SISTAT</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>MAGIC</name>
+       <description>Magic Word Validation.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>magicNotSet</name>
+         <description>Magic word was not set (OTP has not been initialized properly).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>magicSet</name>
+         <description>Magic word was set (OTP contains valid settings).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRCERR</name>
+       <description>CRC Error Status.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No CRC errors occurred during the read of the OTP memory block.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>A CRC error occurred while reading the OTP. The address of the failure location in the OTP memory is stored in the ERRADDR register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADDR</name>
+     <description>Read-only field set by the SIB block if a CRC error occurs during the read of the OTP memory. Contains the failing address in OTP memory (when CRCERR equals 1).</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ERRADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLELDO_BB</name>
+     <description>BTLE LDO TRIM BB Register.</description>
+     <addressOffset>0x01C</addressOffset>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>Target 0.9V. VDDA BB Voltage Trim.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLELDO_RF</name>
+     <description>BTLE LDO TRIM RF Register.</description>
+     <addressOffset>0x002C</addressOffset>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>Target 0.9V. VDDA RF Voltage Trim.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFSTAT</name>
+     <description>Security function status register.</description>
+     <addressOffset>0x104</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SECBOOT_EN</name>
+       <description>Security Boot.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SECEXT_EN</name>
+       <description>M33 SecExt Function Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>SPC</name>
+   <description>Secure Privilege Controller.</description>
+   <baseAddress>0x50090000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>SPC Secure Configuration Control Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>LOCK</name>
+       <description>Write 1 to set, disables writes to security-related control registers in the SPC. Once set, the locked registers cannot be modified nor can this bit be cleared to 0 except through a reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESP</name>
+     <description>Security Violation Response Configuration Register.</description>
+     <addressOffset>0x0008</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>VIOLCFG</name>
+       <description>This field configures the target response in case of a secuirty violation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MPC_STATUS</name>
+     <description>Secure MPC Status Register.</description>
+     <addressOffset>0x0020</addressOffset>
+     <size>8</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SRAM0</name>
+       <description>Interrupt status for SRAM 0 Memory Protection Controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRAM1</name>
+       <description>Interrupt status for SRAM1 Memory Protection Controllers.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRAM2</name>
+       <description>Interrupt status for SRAM2 Memory Protection Controllers.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRAM3</name>
+       <description>Interrupt status for SRAM3 Memory Protection Controllers.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRAM4</name>
+       <description>Interrupt status for SRAM4 Memory Protection Controllers.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH</name>
+       <description>Interrupt status for Flash Memory Protection Controllers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MPC_INTEN</name>
+     <description>Secure MPC Interrupt Enable Register.</description>
+     <addressOffset>0x0024</addressOffset>
+     <fields>
+      <field>
+       <name>SRAM0</name>
+       <description>Interrupt enable for SRAM 0 Memory Protection Controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRAM1</name>
+       <description>Interrupt enable for SRAM1 Memory Protection Controllers.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRAM2</name>
+       <description>Interrupt enable for SRAM2 Memory Protection Controllers.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRAM3</name>
+       <description>Interrupt enable for SRAM3 Memory Protection Controllers.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRAM4</name>
+       <description>Interrupt enable for SRAM4 Memory Protection Controllers.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH</name>
+       <description>Interrupt enable for Flash Memory Protection Controllers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PPC_STATUS</name>
+     <description>Secure PPC Interrupt Status Register.</description>
+     <addressOffset>0x0030</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>APBPPC</name>
+       <description>Interrupt Status of APB PPC for targets on APB bus. Each bit ties to an individual PPC in the system.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PPC_INTCLR</name>
+     <description>Secure PPC Interrupt Clear Register.</description>
+     <addressOffset>0x0034</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>APBPPC</name>
+       <description>Interrupt Clear of APB PPC for targets on the APB bus. Each bit ties to an individual PPC in the system.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PPC_INTEN</name>
+     <description>Secure PPC Interrupt Enable Register.</description>
+     <addressOffset>0x0038</addressOffset>
+     <fields>
+      <field>
+       <name>APBPPC</name>
+       <description>Interrupt Enable for APB PPC for targets on the APB bus. Each bit ties to an individual PPC in the system.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NSCIDAU</name>
+     <description>Non-Secure Callabale IDAU Configuration Register.</description>
+     <addressOffset>0x0080</addressOffset>
+     <fields>
+      <field>
+       <name>CODE</name>
+       <description>Configures whether the CODE region is Non-secure Callable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRAM</name>
+       <description>Configures whether the RAM region is Non-secure Callable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>M33LOCK</name>
+     <description>M33 Core Register Lock Configuratrion Register.</description>
+     <addressOffset>0x0090</addressOffset>
+     <fields>
+      <field>
+       <name>AIRCR_VTOR_S</name>
+       <description>Lock VTOR_S, AIRCR.PRIS, and AIRCR.BFHFNMINS.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VTOR_NS</name>
+       <description>Lock VTOR_NS register.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MPU_S</name>
+       <description>Lock secure MPU registers.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MPU_NS</name>
+       <description>Lock non-secure MPU registers.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SAU</name>
+       <description>Lock Security Attribution Unit (SAU).</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>APBSEC</name>
+     <description>APB Target Secure/Non-secure PPC Access Register.</description>
+     <addressOffset>0x0120</addressOffset>
+     <fields>
+      <field>
+       <name>PERIPH</name>
+       <description>Each bit configures the APB PPC to enforce the security access allowed for an individual peripheral.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>GCR</name>
+         <description>Security Access for GCR.</description>
+         <value>0x01</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SIR</name>
+         <description>Security Access for SIR.</description>
+         <value>0x02</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>FCR</name>
+         <description>Security Access for FCR.</description>
+         <value>0x04</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>WDT</name>
+         <description>Security Access for WDT.</description>
+         <value>0x08</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES</name>
+         <description>Security Access for AES.</description>
+         <value>0x010</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AESKEYS</name>
+         <description>Security Access for AESKEYS.</description>
+         <value>0x020</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CRC</name>
+         <description>Security Access for CRC.</description>
+         <value>0x040</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO0</name>
+         <description>Security Access for GPIO0.</description>
+         <value>0x080</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR0</name>
+         <description>Security Access for TMR0.</description>
+         <value>0x0100</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR1</name>
+         <description>Security Access for TMR1.</description>
+         <value>0x0200</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR2</name>
+         <description>Security Access for TMR2.</description>
+         <value>0x0400</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR3</name>
+         <description>Security Access for TMR3.</description>
+         <value>0x0800</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR4</name>
+         <description>Security Access for TMR4.</description>
+         <value>0x01000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR5</name>
+         <description>Security Access for TMR5.</description>
+         <value>0x02000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>I3C</name>
+         <description>Security Access for I3C.</description>
+         <value>0x04000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>UART</name>
+         <description>Security Access for UART.</description>
+         <value>0x08000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SPI</name>
+         <description>Security Access for SPI.</description>
+         <value>0x010000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TRNG</name>
+         <description>Security Access for TRNG.</description>
+         <value>0x020000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BTLE_DBB</name>
+         <description>Security Access for BTLE DBB.</description>
+         <value>0x040000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BTLE_RFFE</name>
+         <description>Security Access for BTLE RFFE.</description>
+         <value>0x080000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RSTZ</name>
+         <description>Security Access for RSTZ.</description>
+         <value>0x0100000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BOOST</name>
+         <description>Security Access for Boost Controller.</description>
+         <value>0x0200000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TRIMSIR</name>
+         <description>Security Access for TRIMSIR.</description>
+         <value>0x0400000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RTC</name>
+         <description>Security Access for RTC.</description>
+         <value>0x01000000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>WUT0</name>
+         <description>Security Access for WUT0.</description>
+         <value>0x02000000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>WUT1</name>
+         <description>Security Access for WUT1.</description>
+         <value>0x04000000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWRSEQ</name>
+         <description>Security Access for Power Sequencer.</description>
+         <value>0x08000000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>MCR</name>
+         <description>Security Access for MCR.</description>
+         <value>0x10000000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ALL</name>
+         <description>Security Access for all peripherals.</description>
+         <value>0x1F7FFFFF</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>APBPRIV</name>
+     <description>APB Tartet Privileged/Non-privileged PPC Access Register.</description>
+     <addressOffset>0x0160</addressOffset>
+     <fields>
+      <field>
+       <name>PERIPH</name>
+       <description>Each bit configures the APB PPC to enforce the security access allowed for an individual peripheral.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>GCR</name>
+         <description>Privilege setting for GCR.</description>
+         <value>0x01</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SIR</name>
+         <description>Privilege setting for SIR.</description>
+         <value>0x02</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>FCR</name>
+         <description>Privilege setting for FCR.</description>
+         <value>0x04</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>WDT</name>
+         <description>Privilege setting for WDT.</description>
+         <value>0x08</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES</name>
+         <description>Privilege setting for AES.</description>
+         <value>0x010</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AESKEYS</name>
+         <description>Privilege setting for AESKEYS.</description>
+         <value>0x020</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CRC</name>
+         <description>Privilege setting for CRC.</description>
+         <value>0x040</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO0</name>
+         <description>Privilege setting for GPIO0.</description>
+         <value>0x080</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR0</name>
+         <description>Privilege setting for TMR0.</description>
+         <value>0x0100</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR1</name>
+         <description>Privilege setting for TMR1.</description>
+         <value>0x0200</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR2</name>
+         <description>Privilege setting for TMR2.</description>
+         <value>0x0400</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR3</name>
+         <description>Privilege setting for TMR3.</description>
+         <value>0x0800</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR4</name>
+         <description>Privilege setting for TMR4.</description>
+         <value>0x01000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TMR5</name>
+         <description>Privilege setting for TMR5.</description>
+         <value>0x02000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>I3C</name>
+         <description>Privilege setting for I3C.</description>
+         <value>0x04000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>UART</name>
+         <description>Privilege setting for UART.</description>
+         <value>0x08000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SPI</name>
+         <description>Privilege setting for SPI.</description>
+         <value>0x010000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TRNG</name>
+         <description>Privilege setting for TRNG.</description>
+         <value>0x020000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BTLE_DBB</name>
+         <description>Privilege setting for BTLE DBB.</description>
+         <value>0x040000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BTLE_RFFE</name>
+         <description>Privilege setting for BTLE RFFE.</description>
+         <value>0x080000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RSTZ</name>
+         <description>Privilege setting for RSTZ.</description>
+         <value>0x0100000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BOOST</name>
+         <description>Privilege setting for Boost Controller.</description>
+         <value>0x0200000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TRIMSIR</name>
+         <description>Privilege setting for TRIMSIR.</description>
+         <value>0x0400000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RTC</name>
+         <description>Privilege setting for RTC.</description>
+         <value>0x01000000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>WUT0</name>
+         <description>Privilege setting for WUT0.</description>
+         <value>0x02000000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>WUT1</name>
+         <description>Privilege setting for WUT1.</description>
+         <value>0x04000000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWRSEQ</name>
+         <description>Privilege setting for Power Sequencer.</description>
+         <value>0x08000000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>MCR</name>
+         <description>Privilege setting for MCR.</description>
+         <value>0x10000000</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ALL</name>
+         <description>Privilege setting for all peripherals.</description>
+         <value>0x1F7FFFFF</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AHBMPRIV</name>
+     <description>AHB Privileged/Non-privileged Secure DMA Access.</description>
+     <addressOffset>0x0170</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>Controls access of transactions coming from the Secure DMA.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO0</name>
+     <description>Secure GPIO0 Configuration Register.</description>
+     <addressOffset>0x0180</addressOffset>
+     <fields>
+      <field>
+       <name>PINS</name>
+       <description>Each bit configures a GPIO pin as secure or non-secure on GPIO Port 0. Secure GPIO pins prevent software from reading GPIO Data In pin states.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>SPI</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x500BE000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>56</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FIFO32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>FIFO16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>FIFO32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>FIFO8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>FIFO32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CONT_MODE</name>
+       <description>Controller Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Target mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Controller mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TS_IO</name>
+       <description>Target Select 0, IO direction, to support Multi-Controller mode,Target Select 0 can be input in Controller mode. This bit has no effect in target mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Target select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Target Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Controller Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Controller halts, if a transaction completes, and the TX FIFO is not empty, the Controller initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TS_CTRL</name>
+       <description>Start Select Control. Used in Controller mode to control the behavior of the Target Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DEASSERT</name>
+         <description>SPI De-asserts Target Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ATSERT</name>
+         <description>SPI leaves Target Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TS_ACTIVE</name>
+       <description>Target Select, when in Controller mode selects which Target devices are selected. More than one Target device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>TS0</name>
+         <description>TS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TS1</name>
+         <description>TS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TS2</name>
+         <description>TS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Rising_Edge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Falling_Edge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLK_FB_INV</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1</name>
+         <description>1 bits per character.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2</name>
+         <description>2 bits per character.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3</name>
+         <description>3 bits per character.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4</name>
+         <description>4 bits per character.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5</name>
+         <description>5 bits per character.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6</name>
+         <description>6 bits per character.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7</name>
+         <description>7 bits per character.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8</name>
+         <description>8 bits per character.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9</name>
+         <description>9 bits per character.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10</name>
+         <description>10 bits per character.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11</name>
+         <description>11 bits per character.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12</name>
+         <description>12 bits per character.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13</name>
+         <description>13 bits per character.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14</name>
+         <description>14 bits per character.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15</name>
+         <description>15 bits per character.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin(s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TSPOL</name>
+       <description>Target Select Polarity, each Target Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>TS0_high</name>
+         <description>TS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TS1_high</name>
+         <description>TS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TS2_high</name>
+         <description>TS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TSTIME</name>
+     <description>Register for controlling SPI peripheral/Target Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PRE</name>
+       <description>Target Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between TS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POST</name>
+       <description>Target Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and TS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INACT</name>
+       <description>Target Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write
+            pointers. This should be done when FIFO is not being accessed on the SPI side.
+          .</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TSA</name>
+       <description>Target Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TSD</name>
+       <description>Target Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Controller Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Target Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CONT_DONE</name>
+       <description>Controller Done, set when SPI Controller has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TSA</name>
+       <description>Target Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TSD</name>
+       <description>Target Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Controller Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Target Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CONT_DONE</name>
+       <description>Controller Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Controller mode, set when transaction starts, cleared when last bit of last character is acted upon and Target Select de-assertion would occur. In Target mode, set when Target Select is asserted, cleared when Target Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>TMR</name>
+   <description>Low-Power Configurable Timer</description>
+   <baseAddress>0x50010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR</name>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Timer Counter Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>The current count value for the timer. This field increments as the timer counts.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Timer Compare Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>Timer PWM Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PWM</name>
+       <description>Timer PWM Match:
+                In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
+                In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Timer Interrupt Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ_A</name>
+       <description>Interrupt Flag for Timer A.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_A</name>
+       <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_A</name>
+       <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IRQ_B</name>
+       <description>Interrupt Flag for Timer B.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_B</name>
+       <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_B</name>
+       <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MODE_A</name>
+       <description>Mode Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_A</name>
+       <description>Clock Divider Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_A</name>
+       <description>Timer Polarity for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_A</name>
+       <description>PWM Synchronization Mode for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_A</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_A</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_A</name>
+       <description>PWM Phase A-Prime Output Disable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_A</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Write 1 to Enable CLK_TMR for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_A</name>
+       <description>Enable for Timer A</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MODE_B</name>
+       <description>Mode Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_B</name>
+       <description>Clock Divider Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_B</name>
+       <description>Timer Polarity for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_B</name>
+       <description>PWM Synchronization Mode for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_B</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_B</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_B</name>
+       <description>PWM Phase A-Prime Output Disable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_B</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Write 1 to Enable CLK_TMR for Timer B</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_B</name>
+       <description>Enable for Timer B</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO_A</name>
+       <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_A</name>
+       <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>LO_B</name>
+       <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_B</name>
+       <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Timer Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKSEL_A</name>
+       <description>Timer Clock Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Timer A Enable Status</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_A</name>
+       <description>CLK_TMR Ready Flag for Timer A</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_A</name>
+       <description>Event Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_A</name>
+       <description>Negative Edge Trigger for Event for Timer A</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_A</name>
+       <description>Interrupt Enable for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_A</name>
+       <description>Capture Event Select for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_A</name>
+       <description>Software Capture Event for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_A</name>
+       <description>Wake-Up Enable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTEN_A</name>
+       <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTBEN_A</name>
+       <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads to the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKSEL_B</name>
+       <description>Timer Clock Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Timer B Enable Status</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_B</name>
+       <description>CLK_TMR Ready Flag for Timer B</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_B</name>
+       <description>Event Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_B</name>
+       <description>Negative Edge Trigger for Event for Timer B</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_B</name>
+       <description>Interrupt Enable for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_B</name>
+       <description>Capture Event Select for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_B</name>
+       <description>Software Capture Event for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_B</name>
+       <description>Wake-Up Enable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CASCADE</name>
+       <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Timer Wakeup Status Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>A</name>
+       <description>Wake-Up Flag for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>B</name>
+       <description>Wake-Up Flag for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral derivedFrom="TMR">
+   <name>TMR1</name>
+   <description>Low-Power Configurable Timer 1</description>
+   <baseAddress>0x50011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+
+  <peripheral derivedFrom="TMR">
+   <name>TMR2</name>
+   <description>Low-Power Configurable Timer 2</description>
+   <baseAddress>0x50012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+
+  <peripheral derivedFrom="TMR">
+   <name>TMR3</name>
+   <description>Low-Power Configurable Timer 3</description>
+   <baseAddress>0x50013000</baseAddress>
+   <interrupt>
+    <name>TMR3</name>
+    <description>TMR3 IRQ</description>
+    <value>8</value>
+   </interrupt>
+  </peripheral>
+
+  <peripheral derivedFrom="TMR">
+   <name>TMR4</name>
+   <description>Low-Power Configurable Timer 4</description>
+   <baseAddress>0x50080C00</baseAddress>
+   <interrupt>
+    <name>TMR4</name>
+    <description>TMR4 IRQ</description>
+    <value>9</value>
+   </interrupt>
+  </peripheral>
+
+  <peripheral derivedFrom="TMR">
+   <name>TMR5</name>
+   <description>Low-Power Configurable Timer 5</description>
+   <baseAddress>0x50081000</baseAddress>
+   <interrupt>
+    <name>TMR5</name>
+    <description>TMR5 IRQ</description>
+    <value>10</value>
+   </interrupt>
+  </peripheral>
+
+  <peripheral>
+   <name>TRIMSIR</name>
+   <description>Trim System Initilazation Registers.</description>
+   <baseAddress>0x50005400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RTCX1</name>
+     <description>RTC X1 Capacitor Setting.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>CAP</name>
+       <description>RTC X1 Load Capacitor Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RTCX2</name>
+     <description>RTC X2 Capacitor Setting.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>CAP</name>
+       <description>RTC X2 Load Capacitor Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>TRNG</name>
+   <description>Random Number Generator.</description>
+   <baseAddress>0x5004D000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TRNG</name>
+    <description>TRNG interrupt.</description>
+    <value>4</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>TRNG Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000003</resetValue>
+     <fields>
+      <field>
+       <name>OD_HEALTH</name>
+       <description>Start On-Demand health test.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RND_IE</name>
+       <description>To enable IRQ generation when a new 32-bit Random number is ready.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HEALTH_IE</name>
+       <description>Enable IRQ generation when a health test fails.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OD_ROMON</name>
+       <description>Start ring oscillator monitor on demand test.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OD_EE</name>
+       <description>Start entropy estimator on demand test.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMON_EE_FOE</name>
+       <description>Ring Oscillator Monitors and Entropy Estimator Freeze on Error.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMON_EE_FOD</name>
+       <description>Ring Oscillator Monitors and Entropy Estimator Freeze on Done.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EBLS</name>
+       <description>Entropy Bit Load Select.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GET_TERO_CNT</name>
+       <description>Get Tero Count.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EE_DONE_IE</name>
+       <description>Entropy Estimator Done Interrupt Enable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMON_DIS</name>
+       <description>Ring Oscillator Disable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>RO_0</name>
+         <description>Ring Oscillator 0.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RO_1</name>
+         <description>Ring Oscillator 1.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RO_2</name>
+         <description>Ring Oscillator 2.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROMON_DIV2</name>
+       <description>Divide ring by 2.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>RO_0</name>
+         <description>Ring Oscillator 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RO_1</name>
+         <description>Ring Oscillator 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RO_2</name>
+         <description>Ring Oscillator 2.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>RDY</name>
+       <description>32-bit random data is ready to read from TRNG_DATA register. Reading TRNG_DATA when RND_RDY=0 will return all 0's. IRQ is generated when RND_RDY=1 if TRNG_CN.RND_IRQ_EN=1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Busy</name>
+         <description>TRNG Busy</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Ready</name>
+         <description>32 bit random data is ready</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OD_HEALTH</name>
+       <description>On-Demand health test status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HEALTH</name>
+       <description>Health test status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRCFAIL</name>
+       <description>Entropy source has failed.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OD_ROMON</name>
+       <description>On demand ring oscillator test status.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OD_EE</name>
+       <description>On demand entropy estimator status.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PP_ERR</name>
+       <description>Post process error.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMON_0_ERR</name>
+       <description>Ring Oscillator 0 Monitor Error.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMON_1_ERR</name>
+       <description>Ring Oscillator 1 Monitor Error.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMON_2_ERR</name>
+       <description>Ring Oscillator 2 Monitor Error.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EE_ERR_THR</name>
+       <description>Entropy Estimator Threshold Error.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EE_ERR_OOB</name>
+       <description>Entropy Estimator Out of Bounds Error..</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EE_ERR_LOCK</name>
+       <description>Entropy Estimator Lock Error.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TERO_CNT_RDY</name>
+       <description>TERO Count Ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RC_ERR</name>
+       <description>Repetition Count Error.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AP_ERR</name>
+       <description>Adaptive Proportion Error.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_DONE</name>
+       <description>Data register has been loaded with at least 32 new entropy bits.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_NIST_DONE</name>
+       <description>Data NIST register has been loaded with at least 32 new entropy bits.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HEALTH_DONE</name>
+       <description>Health Test Done.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMON_DONE</name>
+       <description>Ring Oscillator Monitor Test Done.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EE_DONE</name>
+       <description>Entropy Estimator Test Done.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data. The content of this register is valid only when RNG_IS =1. When TNRG is disabled, read returns 0x0000 0000.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA_NIST</name>
+     <description>Data NIST Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Ring Oscillator 1 Monitor Last Ring Oscillator Count.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>UART</name>
+   <description>UART Low Power Registers</description>
+   <baseAddress>0x50042000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control register</description>
+     <addressOffset>0x0000</addressOffset>
+     <fields>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>This field specifies the depth of receive FIFO for interrupt generation (value 0 and &gt; 16 are ignored) </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EN</name>
+       <description>Parity Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EO</name>
+       <description>when PAREN=1 selects odd or even parity odd is 1 even is 0</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_MD</name>
+       <description>Selects parity based on 1s or 0s count (when PAREN=1) </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_DIS</name>
+       <description>CTS Sampling Disable </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Flushes the TX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Flushes the RX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHAR_SIZE</name>
+       <description>Selects UART character size</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5bits</name>
+         <description>5 bits</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6bits</name>
+         <description>6 bits</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7bits</name>
+         <description>7 bits</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8bits</name>
+         <description>8 bits</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPBITS</name>
+       <description>Selects the number of stop bits that will be generated</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HFC_EN</name>
+       <description>Enables/disables hardware flow control</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RTS_NEG</name>
+       <description>The condition to negate RTS in HFC mode.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLK_EN</name>
+       <description>Baud clock enable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLK_SEL</name>
+       <description>To select the UART clock source for the UART engine (except APB registers). Secondary clock (used for baud rate generator) can be asynchronous from APB clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>PERIPHERAL_CLOCK</name>
+         <description>APB Clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK1</name>
+         <description>IBRO clock.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLK_RDY</name>
+       <description>Baud clock Ready read only bit</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLK_GATE</name>
+       <description>UART Clock Auto Gating mode</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TX_BUSY</name>
+       <description>Read-only flag indicating the UART transmit status</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_BUSY</name>
+       <description>Read-only flag indicating the UART receiver status</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Indicates the number of bytes currently in the RX FIFO (0-RX FIFO_ELTS) </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Indicates the number of bytes currently in the TX FIFO (0-TX FIFO_ELTS) </description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable control register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Enable Interrupt For RX Frame Error</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Enable Interrupt For RX Parity Error</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Enable Interrupt For CTS signal change Error</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Enable Interrupt For RX FIFO Overrun Error</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Enable Interrupt For RX FIFO reaches the number of bytes configured by RXTHD</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Enable Interrupt For TX FIFO when only one byte is remaining.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>Enable Interrupt for when TX FIFO meets or passes the threshold level.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Enable for RX FIFO Full interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Interrupt status flags Control register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Flag for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Flag for RX Parity Error interrupt</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Flag for CTS signal change interrupt (hardware flow control disabled) </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Flag for RX FIFO Overrun interrupt</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Flag for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Flag for interrupt when TX FIFO has only one byte is remaining.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>Flag for interrupt when TX FIFO meets or passes the threshold level.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Flag for full RX FIFO.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Clock Divider register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Baud rate divisor value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSR</name>
+     <description>Over Sampling Rate register</description>
+     <addressOffset>0x0014</addressOffset>
+     <fields>
+      <field>
+       <name>OSR</name>
+       <description>OSR</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXPEEK</name>
+     <description>TX FIFO Output Peek register</description>
+     <addressOffset>0x0018</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read TX FIFO next data. Reading from this field does not affect the contents of TX FIFO. Note that the parity bit is available from this field.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Read/Write register</description>
+     <addressOffset>0x0020</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Parity error flag for next byte to be read from FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration register</description>
+     <addressOffset>0x0030</addressOffset>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger If the TX FIFO level is less than this value, then the TX FIFO DMA interface will send a signal to system DMA to notify that TX FIFO is ready to receive data from memory.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX DMA channel enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Rx FIFO Level DMA Trigger If the RX FIFO level is greater than this value, then the RX FIFO DMA interface will send a signal to the system DMA to notify that RX FIFO has characters to transfer to memory.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX DMA channel enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wake up enable Control register</description>
+     <addressOffset>0x0034</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Enable for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Enable for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Enable for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wake up Flags register</description>
+     <addressOffset>0x0038</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Flag for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Flag for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Flag for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>WDT</name>
+   <description>Windowed Watchdog Timer</description>
+   <baseAddress>0x50003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WWDT</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INT_LATE_VAL</name>
+       <description>Windowed Watchdog Interrupt Upper Limit. Sets the number of WDTCLK cycles until a windowed watchdog timer interrupt is generated (if enabled) if the CPU does not write the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE_VAL</name>
+       <description>Windowed Watchdog Reset Upper Limit. Sets the number of WDTCLK cycles until a system reset occurs (if enabled) if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Windowed Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_LATE</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Late.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_INT_EN</name>
+       <description>Windowed Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_RST_EN</name>
+       <description>Windowed Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Soon.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY_VAL</name>
+       <description>Windowed Watchdog Interrupt Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A windowed watchdog timer interrupt is generated (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY_VAL</name>
+       <description>Windowed Watchdog Reset Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A system reset occurs (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKRDY_IE</name>
+       <description>Switch Ready Interrupt Enable. Fires an interrupt when it is safe to swithc the clock.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY</name>
+       <description>Clock Status.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WIN_EN</name>
+       <description>Enables the Windowed Watchdog Function.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Windowed Mode Disabled (i.e. Compatibility Mode).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Windowed Mode Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Soon.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Late.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Windowed Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>RESET</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD_UPPER_LIMIT then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD_UPPER_LIMIT then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKSEL</name>
+     <description>Windowed Watchdog Timer Clock Select Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SOURCE</name>
+       <description>WWDT Clock Selection Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CNT</name>
+     <description>Windowed Watchdog Timer Count Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Current Value of the Windowed Watchdog Timer Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+  <peripheral>
+   <name>WUT</name>
+   <description>32-bit reloadable timer that can be used for timing and wakeup.</description>
+   <baseAddress>0x50006400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WUT</name>
+    <description>WUT IRQ</description>
+    <value>53</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Count.  This register stores the current timer count.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Timer Count Value. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Compare.  This register stores the compare value, which is used to set the maximum count value to initiate a reload of the timer to 0x0001.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x0000FFFF</resetValue>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>Timer Compare Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Clear Interrupt. Writing a value (0 or 1) to a bit in this register clears the associated interrupt.</description>
+     <addressOffset>0x0C</addressOffset>
+     <modifiedWriteValues>oneToClear</modifiedWriteValues>
+     <fields>
+      <field>
+       <name>CLR</name>
+       <description>Clear Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>TMODE</name>
+       <description>Timer Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>oneShot</name>
+         <description>One Shot Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Continuous Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>counter</name>
+         <description>Counter Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>capture</name>
+         <description>Capture Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>compare</name>
+         <description>Compare Mode.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>gated</name>
+         <description>Gated Mode.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>captureCompare</name>
+         <description>Capture/Compare Mode.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES</name>
+       <description>Prescaler.  Set the Timer's prescaler value. The prescaler divides the PCLK input to the timer and sets the Timer's Count Clock, F_CNT_CLK = PCLK(HZ)/prescaler. The Timer's prescaler setting is a 4-bit value with pres3:pres[2:0].</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TPOL</name>
+       <description>Timer input/output polarity bit.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TEN</name>
+       <description>Timer Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES3</name>
+       <description>MSB of prescaler value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>NOL_LO</name>
+       <description>Non-overlapping Low Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A and next rising edge of PWM output 0A'.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>NOL_HI</name>
+       <description>Non-overlapping High Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A' and next rising edge of PWM output 0A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET</name>
+     <description>Preset register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>PRESET</name>
+       <description>Preset Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RELOAD</name>
+     <description>Reload register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>RELOAD</name>
+       <description>Rerload Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SNAPSHOT</name>
+     <description>Snapshot register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>SNAPSHOT</name>
+       <description>Snapshot Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+
+ </peripherals>
+</device>

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32660/Include/max32660.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32660/Include/max32660.svd
@@ -1,0 +1,8341 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max32660</name>
+ <series>ARMCM4</series>
+ <version>1.0</version>
+ <description>MAX32660 Tiny, Ultra-Low-Power ARM Cortex-M4 Processor with FPU-Based Microcontroller with 256KB Flash and 96KB SRAM.</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0</name>
+    <value>28</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1</name>
+    <value>29</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA2</name>
+    <value>30</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA3</name>
+    <value>31</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>INT_EN</name>
+     <description>DMA Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CHIEN</name>
+       <description>Channel Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>DMA Interrupt Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>IPEND</name>
+       <description>Channel Interrupt.   To clear an interrupt, all active interrupt bits of the DMA_ST must be cleared. The interrupt bits are set only if their corresponding interrupt enable bits are set in DMA_CN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <name>ch_ipend_enum</name>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>4</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CFG</name>
+      <description>DMA Channel Configuration Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>CHEN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQSEL</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0RX</name>
+          <description>SPI0 RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1RX</name>
+          <description>SPI1 RX</description>
+          <value>0x02</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0RX</name>
+          <description>UART0 RX</description>
+          <value>0x04</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1RX</name>
+          <description>UART1 RX</description>
+          <value>0x05</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0RX</name>
+          <description>I2C0 RX</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1RX</name>
+          <description>I2C1 RX</description>
+          <value>0x08</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0TX</name>
+          <description>SPI0 TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1TX</name>
+          <description>SPI1 TX</description>
+          <value>0x22</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0TX</name>
+          <description>UART0 TX</description>
+          <value>0x24</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1TX</name>
+          <description>UART1 TX</description>
+          <value>0x25</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0TX</name>
+          <description>I2C0 TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1TX</name>
+          <description>I2C1 TX</description>
+          <value>0x28</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQWAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TOSEL</name>
+        <description>Time-Out Select. Selects the number of prescale clocks seen by the channel timer before a time-out conditions is generated for this channel. Important note: since the prescaler runs independent of the individual channel timers, the actual number of Pre-Scale clock edges seen has a margin of error equal to a single Pre-Scale clock.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PSSEL</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BRST</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>CHDIEN</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZIEN</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>STAT</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>CH_ST</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_ST</name>
+        <description>Count-to-Zero (CTZ) Status</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+        <enumeratedValues>
+         <name>ctz_st_enum_rd</name>
+         <usage>read</usage>
+         <enumeratedValue>
+          <name>noEvent</name>
+          <description>The event has not occurred.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>occurred</name>
+          <description>The event has occurred.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+        <enumeratedValues>
+         <name>ctz_st_enum_wr</name>
+         <usage>write</usage>
+         <enumeratedValue>
+          <name>Clear</name>
+          <description>Clears the interrupt flag</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLD_ST</name>
+        <description>Reload Status.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+        <enumeratedValues>
+         <usage>read</usage>
+         <enumeratedValue>
+          <name>noEvent</name>
+          <description>The event has not occurred.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>occurred</name>
+          <description>The event has occurred.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+        <enumeratedValues>
+         <usage>write</usage>
+         <enumeratedValue>
+          <name>Clear</name>
+          <description>Clears the interrupt flag</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+        <enumeratedValues>
+         <usage>read</usage>
+         <enumeratedValue>
+          <name>noEvent</name>
+          <description>The event has not occurred.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>occurred</name>
+          <description>The event has occurred.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+        <enumeratedValues>
+         <usage>write</usage>
+         <enumeratedValue>
+          <name>Clear</name>
+          <description>Clears the interrupt flag</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_ST</name>
+        <description>Time-Out Status.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+        <enumeratedValues>
+         <usage>read</usage>
+         <enumeratedValue>
+          <name>noEvent</name>
+          <description>The event has not occurred.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>occurred</name>
+          <description>The event has occurred.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+        <enumeratedValues>
+         <usage>write</usage>
+         <enumeratedValue>
+          <name>Clear</name>
+          <description>Clears the interrupt flag</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>SRC</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>DST</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC_RLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>SRC_RLD</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST_RLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>DST_RLD</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT_RLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT_RLD</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. This bit should be set after the address reload registers have been programmed. This bit is automatically cleared to 0 when reload occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+<!--DMA DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral>
+   <name>FCR</name>
+   <description>Function Control.</description>
+   <baseAddress>0x40000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>REG0</name>
+     <description>Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>I2C0_SDA_FILTER_EN</name>
+       <description>I2C0 SDA Filter Enable</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0_SCL_FILTER_EN</name>
+       <description>I2C0 SCL Filter Enable</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1_SDA_FILTER_EN</name>
+       <description>I2C1 SDA Filter Enable</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1_SCL_FILTER_EN</name>
+       <description>I2C1 SCL Filter Enable</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FCR Function Control.-->
+  <peripheral>
+   <name>FLC</name>
+   <description>Flash Memory Control.</description>
+   <prependToName>FLC_</prependToName>
+   <baseAddress>0x40029000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Flash_Controller</name>
+    <description>Flash Controller interrupt.</description>
+    <value>23</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ADDR</name>
+     <description>Flash Write Address.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address for next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Flash Clock Divide. The clock (PLL0) is divided by this value to generate a 1 MHz clock for Flash controller.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000064</resetValue>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Flash Clock Divide. The clock is divided by this value to generate a 1MHz clock for flash controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Flash Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WRITE</name>
+       <description>Write.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="WRITE">
+       <name>MASS_ERASE</name>
+       <description>Mass Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="WRITE">
+       <name>PAGE_ERASE</name>
+       <description>Page Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WIDTH</name>
+       <description>Data Width.  This bits selects write data width.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>size128</name>
+         <description>128-bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>size32</name>
+         <description>32-bit.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERASE_CODE</name>
+       <description>Erase Code.  The ERASE_CODE must be set up property before erase operation can be initiated. These bits are automatically cleared after the operation is complete.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>erasePage</name>
+         <description>Enable Page Erase.</description>
+         <value>0x55</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>eraseAll</name>
+         <description>Enable Mass Erase. The debug port must be enabled.</description>
+         <value>0xAA</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>Flash Pending.  When Flash operation is in progress (busy), Flash reads and writes will fail. When PEND is set, write to all Flash registers, with exception of the Flash interrupt register, are ignored.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LVE</name>
+       <description>Low Voltage enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNLOCK_CODE</name>
+       <description>Flash Unlock.  The correct unlock code must be written to these four bits before any Flash write or erase operation is allowed.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Flash Unlocked.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Flash Locked.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Flash Interrupt Register.</description>
+     <addressOffset>0x024</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Flash Done Interrupt.  This bit is set to 1 upon Flash write or erase completion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACCESS_FAIL</name>
+       <description>Flash Access Fail.  This bit is set when an attempt is made to write the flash while the flash is busy or the flash is locked. This bit can only be set to 1 by hardware.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONE_IE</name>
+       <description>Flash Done Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DONE_IE">
+       <name>ACCESS_FAIL_IE</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA[%s]</name>
+     <description>Flash Write Data.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACTRL</name>
+     <description>Access Control Register. Writing the ACTRL register with the following values in the order shown, allows read and write access to the system and user Information block:
+		pflc-actrl = 0x3a7f5ca3;
+		pflc-actrl = 0xa1e34f20;
+		pflc-actrl = 0x9608b2c1. When unlocked, a write of any word will disable access to system and user information block. Readback of this register is always zero.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ACTRL</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FLC Flash Memory Control.-->
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x40000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SCON</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>FLASH_PAGE_FLIP</name>
+       <description>Flips the Flash bottom and top halves. (Depending on the total flash size, each half is either 256K or 512K). Initiating a flash page flip will cause a flush of both the data buffer on the DCODE bus and the internal instruction buffer.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Physical layout matches logical layout.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>swapped</name>
+         <description>Bottom half mapped to logical top half and vice versa.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FPU_DIS</name>
+       <description>Floating Point Unit Disable </description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>enable Floating point unit</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>disable floating point unit </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICC0_FLUSH</name>
+       <description>Instruction Cache Controller Flush. Write 1 to flush the internal flash cache. This bit is cleared by hardware when the flush is complete.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SWD_DIS</name>
+       <description>Serial Wire Debug Disable </description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable JTAG SWD</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable JTAG SWD </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WDT0</name>
+       <description>Watchdog Timer Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TIMER0</name>
+       <description>Timer0 Reset. Setting this bit to 1 resets Timer 0 blocks.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TIMER1</name>
+       <description>Timer1 Reset. Setting this bit to 1 resets Timer 1 blocks.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TIMER2</name>
+       <description>Timer2 Reset. Setting this bit to 1 resets Timer 2 blocks.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART0</name>
+       <description>UART0 Reset. Setting this bit to 1 resets all UART 0 blocks.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART1</name>
+       <description>UART1 Reset. Setting this bit to 1 resets all UART 1 blocks.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SPI0</name>
+       <description>SPI0 Reset. Setting this bit to 1 resets all SPI 0 blocks.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SPI1</name>
+       <description>SPI1 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C0</name>
+       <description>I2C0 Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RTC</name>
+       <description>Real Time Clock Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SOFT</name>
+       <description>Soft Reset.Write 1 to perform a Soft Reset. A soft reset performs a Peripheral Reset and also resets the GPIO peripheral but does not reset the CPU or Watchdog Timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PERIPH</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSTEM</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_CTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>PSC</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the PLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKSEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>HIRC</name>
+         <description>The internal 96 MHz oscillator is used for the system clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nanoRing</name>
+         <description>The nano-ring output is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hfxIn</name>
+         <description>HFXIN is used for the system clock.</description>
+         <value>6</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKRDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>X32K_EN</name>
+       <description>32kHz Crystal Oscillator Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="X32K_EN">
+       <name>HIRC_EN</name>
+       <description>60MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>X32K_RDY</name>
+       <description>32kHz Crystal Oscillator Ready</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="X32K_RDY">
+       <name>HIRC_RDY</name>
+       <description>60MHz HIRC Ready.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="X32K_RDY">
+       <name>LIRC8K_RDY</name>
+       <description>8kHz Low Frequency Reference Clock Ready.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PM</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This two bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>backup</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIOWK_EN</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wake Up Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wake Up Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RTCWK_EN</name>
+       <description>RTC Alarm Wake Up Enable. This bit enables RTC alarm as wakeup source. If enabled, the desired RTC alarm must be configured via the RTC control registers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wake Up Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wake Up Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HFIOPD</name>
+       <description>HFIO DEEPSLEEP Auto Off. When set, the High-Frequency Internal Oscillator is automatically powered off when in DEEPSLEEP mode. </description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLK_DIS0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0D</name>
+       <description>GPIO0 Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>GPIODisable</name>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMAD</name>
+       <description>DMA Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>GPIODisable</name>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SPI0D</name>
+       <description>SPI 0 Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>GPIODisable</name>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SPI1D</name>
+       <description>SPI 1 Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>GPIODisable</name>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>UART0D</name>
+       <description>UART 0 Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>GPIODisable</name>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>UART1D</name>
+       <description>UART 1 Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>GPIODisable</name>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0D</name>
+       <description>I2C 0 Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>GPIODisable</name>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TIMER0D</name>
+       <description>Timer 0 Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>GPIODisable</name>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TIMER1D</name>
+       <description>Timer 1 Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>GPIODisable</name>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TIMER2D</name>
+       <description>Timer 2 Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>GPIODisable</name>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1D</name>
+       <description>I2C 1 Disable.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>GPIODisable</name>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEM_CTRL</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 2.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>RAM0_LS</name>
+       <description>System RAM 0 Light Sleep Mode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Memory is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>Memory is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM1_LS</name>
+       <description>System RAM 1 Light Sleep Mode.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Memory is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>Memory is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM2_LS</name>
+       <description>System RAM 2 Light Sleep Mode.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Memory is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>Memory is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM3_LS</name>
+       <description>System RAM 3 Light Sleep Mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Memory is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>Memory is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHE_RET</name>
+       <description>ICache RAM Light Sleep Mode.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Memory is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>Memory is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEM_ZCTRL</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>SRAM_ZERO</name>
+       <description>System RAM Block 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHE_ZERO</name>
+       <description>Instruction Cache.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYS_STAT</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICECLOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>I2C1</name>
+       <description>I2C1 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_write</name>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>RFU</name>
+         <description>Reserved. Do not use.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>Starts reset operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLK_DIS1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>FLCD</name>
+       <description>Secure Flash Controller Disable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICCD</name>
+       <description>ICache Clock Disable. </description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVTEN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>DMAEVENT</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_EVT</name>
+       <description>Enable RXEV pin event. When this bit is set, a logic high of GPIO0[24] will cause an RXEV event to wake the CPU from WFE sleep mode. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REV</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYS_IE</name>
+     <description>System Status Interrupt Enable</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEULIE</name>
+       <description>Arm ICE Unlocked Interrupt Enable. Set this bit to enable a PWRSEQ IRQ if the Arm ICE is unlocked.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCR Global Control Registers.-->
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x40008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN0</name>
+     <description>GPIO Function Enable 0 Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>alternate</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_SET</name>
+     <description>GPIO Set Function Enable 0 Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_EN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_EN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_EN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_OUT bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_IN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_MOD</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_MOD</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_POL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_POL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN_EN</name>
+     <description>GPIO Port Input Enable.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_IN_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Input Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Input Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_EN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_EN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_STAT</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_INT_STAT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WAKE_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_DUAL_EDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_DUAL_EDGE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PAD_CFG1</name>
+     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PAD_CFG1</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PAD_CFG2</name>
+     <description>GPIO Input Mode Config 2. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PAD_CFG2</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_SET</name>
+     <description>GPIO Alternate Function Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN2</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_SET</name>
+     <description>GPIO Alternate Function 2 Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN2 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_CLR</name>
+     <description>GPIO Wake Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN2 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x7C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IS</name>
+     <description>GPIO Input Hysteresis Enable.</description>
+     <addressOffset>0xA8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SR</name>
+     <description>GPIO Slew Rate Enable Register.</description>
+     <addressOffset>0xAC</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>FAST</name>
+         <description>Fast Slew Rate selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SLOW</name>
+         <description>Slow Slew Rate selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS0</name>
+     <description>GPIO Drive Strength  Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ld</name>
+         <description>GPIO port pin is in low-drive mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hd</name>
+         <description>GPIO port pin is in high-drive mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PS</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VSSEL</name>
+     <description>GPIO Voltage Select.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GPIO0 Individual I/O for each GPIO-->
+  <peripheral>
+   <name>I2C0</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>I2C</groupName>
+   <baseAddress>0x4001D000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2C0</name>
+    <description>I2C0 IRQ</description>
+    <value>13</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0</name>
+     <description>Control Register0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>I2CEN</name>
+       <description>I2C Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable I2C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable I2C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST</name>
+       <description>Master Mode Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave_mode</name>
+         <description>Slave Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master_mode</name>
+         <description>Master Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GCEN</name>
+       <description>General Call Address Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Ignore Gneral Call Address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Acknowledge general call address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Interactive Receive Mode.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interactive Receive Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interactive Receive Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACK</name>
+       <description>Data Acknowledge. This bit defines the acknowledge bit returned by the I2C receiver while IRXM = 1 HW forces ACK to 0 when IRXM = 0.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ack</name>
+         <description>return ACK (pulling SDA LOW).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>return NACK (leaving SDA HIGH).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLO</name>
+       <description>SCL Output. This bits control SCL output when SWOE =1.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_scl_low</name>
+         <description>Drive SCL low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_scl</name>
+         <description>Release SCL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDAO</name>
+       <description>SDA Output. This bits control SDA output when SWOE = 1. </description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_sda_low</name>
+         <description>Drive SDA low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_sda</name>
+         <description>Release SDA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL</name>
+       <description>SCL status. This bit reflects the logic gate of SCL signal. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDA</name>
+       <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SWOE</name>
+       <description>Software Output Enable.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>outputs_disable</name>
+         <description>I2C Outputs SCLO and SDAO disabled. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputs_enable</name>
+         <description>I2C Outputs SCLO and SDAO enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read. This bit reflects the R/W bit of an address match (AMI = 1) or general call match(GCI = 1). This bit is valid 3 cycles after the relevant interrupt bit is set.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_STRD</name>
+       <description>This bit will disable slave clock stretching when set.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Slave clock stretching enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Slave clock stretching disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_PPM</name>
+       <description>SCL Push-Pull Mode. This bit controls whether SCL is operated in a the I2C standard open-drain mode, or in a non-standard push-pull mode where the Hi-Z output isreplaced with Drive-1. The non-standard mode should only be used when operating as a master and communicating with slaves that are guaranteed to never drive SCL low. </description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Standard open-drain operation: drive low for 0, Hi-Z for 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Non-standard push-pull operation: drive low for 0, drive high for 1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HSMODE</name>
+       <description>Hs-mode Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Hs-mode disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Hs-mode enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>Bus Status.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>I2C Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>I2C Bus Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXE</name>
+       <description>RX empty.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXF</name>
+       <description>RX Full.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXE</name>
+       <description>TX Empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXF</name>
+       <description>TX Full.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CKMD</name>
+       <description>Clock Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_actively_driving_scl_clock</name>
+         <description>Device not actively driving SCL clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>actively_driving_scl_clock</name>
+         <description>Device operating as master and actively driving SCL clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STAT</name>
+       <description>Controller Status.</description>
+       <bitRange>[11:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Controller Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>mtx_addr</name>
+         <description>master Transmit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>mrx_addr_ack</name>
+         <description>Master Receive address ACK.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>mtx_ex_addr</name>
+         <description>Master Transmit extended address.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>mrx_ex_addr</name>
+         <description>Master Receive extended address ACK.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>srx_addr</name>
+         <description>Slave Receive address.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>stx_addr_ack</name>
+         <description>Slave Transmit address ACK.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>srx_ex_addr</name>
+         <description>Slave Receive extended address.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>stx_ex_addr_ack</name>
+         <description>Slave Transmit extended address ACK.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>tx</name>
+         <description>Transmit data (master or slave).</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rx_ack</name>
+         <description>Receive data ACK (master or slave).</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rx</name>
+         <description>Receive data (master or slave).</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>tx_ack</name>
+         <description>Transmit data ACK (master or slave).</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>NACK stage (master or slave).</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>by_st</name>
+         <description>Bystander state (ongoing transaction but not participant- another master addressing another slave).</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL0</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DONEI</name>
+       <description>Transfer Done Interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <name>INT_FL0_Done</name>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXMI</name>
+       <description>Interactive Receive Interrupt.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GCI</name>
+       <description>Slave General Call Address Match Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AMI</name>
+       <description>Slave Address Match Interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXTHI</name>
+       <description>Receive Threshold Interrupt. This bit is automaticcaly cleared when RX_FIFO is below the threshold level.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. RX_FIFO equal or more bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXTHI</name>
+       <description>Transmit Threshold Interrupt. This bit is automaticcaly cleared when TX_FIFO is above the threshold level.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPI</name>
+       <description>STOP Interrupt.</description>
+       <bitRange>[6:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADRACKI</name>
+       <description>Address Acknowledge Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARBERI</name>
+       <description>Arbritation error Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOERI</name>
+       <description>timeout Error Interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADRERI</name>
+       <description>Address NACK Error Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATERI</name>
+       <description>Data NACK Error Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNRERI</name>
+       <description>Do Not Respond Error Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STRTERI</name>
+       <description>Start Error Interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPERI</name>
+       <description>Stop Error Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXLOI</name>
+       <description>Transmit Lock Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Slave Address Match Interrupt.</description>
+       <bitRange>[19:16]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN0</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONEIE</name>
+       <description>Transfer Done Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when DONE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXMIE</name>
+       <description>Description not available.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when RX_MODE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GCIE</name>
+       <description>Slave mode general call address match received input enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when GEN_CTRL_ADDR = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AMIE</name>
+       <description>Slave mode incoming address match interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when ADDR_MATCH = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXTHIE</name>
+       <description>RX FIFO Above Treshold Level Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXTHIE</name>
+       <description>TX FIFO Below Treshold Level Interrupt Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPIE</name>
+       <description>Stop Interrupt Enable</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when STOP = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADRACKIE</name>
+       <description>Received Address ACK from Slave Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARBERIE</name>
+       <description>Master Mode Arbitration Lost Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOERIE</name>
+       <description>Timeout Error Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADRERIE</name>
+       <description>Master Mode Address NACK Received Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATERIE</name>
+       <description>Master Mode Data NACK Received Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNRERIE</name>
+       <description>Slave Mode Do Not Respond Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STRTERIE</name>
+       <description>Out of Sequence START condition detected interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPERIE</name>
+       <description>Out of Sequence STOP condition detected interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXLOIE</name>
+       <description>TX FIFO Locked Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when TXLOIE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MAMIE</name>
+       <description>Multiple Slave Address Match Interrupt Enable.</description>
+       <bitRange>[19:16]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL1</name>
+     <description>Interrupt Status Register 1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>RXOFI</name>
+       <description>Receiver Overflow Interrupt. When operating as a slave receiver, this bit is set when you reach the first data bit and the RX FIFO and shift register are both full.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXUFI</name>
+       <description>Transmit Underflow Interrupt. When operating as a slave transmitter, this bit is set when you reach the first data bit and the TX FIFO is empty and the master is still asking for more data (i.e the master hasn't sent a NACK yet).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN1</name>
+     <description>Interrupt Staus Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RXOFIE</name>
+       <description>Receiver Overflow Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXUFIE</name>
+       <description>Transmit Underflow Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOLEN</name>
+     <description>FIFO Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RXLEN</name>
+       <description>Receive FIFO Length.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TXLEN</name>
+       <description>Transmit FIFO Length.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL0</name>
+     <description>Receive Control Register 0.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>DNR</name>
+       <description>Do Not Respond.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Always respond to address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>not_respond_rx_fifo_empty</name>
+         <description>Do not respond to address match when RX_FIFO is not empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXFSH</name>
+       <description>Receive FIFO Flush. This bit is automatically cleared to 0 after the operation. Setting this bit to 1 will affect RX_FIFO status.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush RX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXTH</name>
+       <description>Receive FIFO Threshold. These bits define the RX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL1</name>
+     <description>Receive Control Register 1.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>RXCNT</name>
+       <description>Receive Count Bits. These bits define the number of bytes to be received in a transaction, except for the case RXCNT = 0. RXCNT = 0 means 256 bytes to be received in a transaction.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>RXFIFO</name>
+       <description>Receive FIFO Count. These bits reflect the number of byte in the RX_FIFO. These bits are flushed when I2CEN = 0.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL0</name>
+     <description>Transmit Control Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>TXPRELD</name>
+       <description>Transmit FIFO Preaload Mode. Setting this bit will allow for high speed application to preload the transmit FIFO prior to Slave Address Match.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TX_READY_MODE</name>
+       <description>Transmit FIFO Ready Manual Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW control of I2CTXRDY enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW control of I2CTXRDY disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXFSH</name>
+       <description>Transmit FIFO Flush. This bit is automatically cleared to 0 after the operation.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush TX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXTH</name>
+       <description>Transmit FIFO Threshold. These bits define the TX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL1</name>
+     <description>Transmit Control Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>TXRDY</name>
+       <description>Transmit FIFO Preload Ready.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TXLAST</name>
+       <description>Transmit Last. This bit is used in slave mod only. Do not use when preloading (cleared by hardware).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>hold_scl_low</name>
+         <description>Hold SCL low on TX_FIFO empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>end_transaction</name>
+         <description>End transaction on TX_FIFO empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLSH_GCADDR_DIS</name>
+       <description>TX FIFO Auto Flush Disable on General Call Address Match.Setting this field to 1 disables the TX FIFO Automatic Flush when a General Call Address Match occurs.
+</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>autoflush_en</name>
+         <description>The TX FIFO is automatically flushed on a General Call Address Match.
+</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>autoflush_dis</name>
+         <description> The TX FIFO is not flushed on a General Call Address Match.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLSH_SLADDR_DIS</name>
+       <description>TX FIFO Auto Flush Disable for Slave Address Match.
+Setting this field to 1 disables the TX FIFO Automatic Flush when a Slave Address
+Match occurs.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>autoflush_en</name>
+         <description>The TX FIFO is automatically flushed on a Slave Address Match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>autoflush_dis</name>
+         <description>The TX FIFO is not flushed on a Slave Address Match.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLSH_NACK_DIS</name>
+       <description>TX FIFO Auto Flush Disable for NACK.
+Setting this field to 1 disables the TX FIFO Automatic Flush when a NACK is received at the end of a slave transaction.
+</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>autoflush_en</name>
+         <description>The TX FIFO is automatically flushed if a NACK is received at the end of a slave
+transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>autoflush_dis</name>
+         <description>The TX FIFO is not flushed when a NACK is received at the end of a slave
+transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXFIFO</name>
+       <description>Transmit FIFO Count. These bits reflect the number of bytes in the TX_FIFO.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MSTR_MODE</name>
+     <description>Master Control Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Setting this bit to 1 will start a master transfer.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>RESTART</name>
+       <description>Setting this bit to 1 will generate a repeated START.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Setting this bit to 1 will generate a STOP condition.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>SEA</name>
+       <description>Slave Extend Address Select.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKLO</name>
+     <description>Clock Low Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_LO</name>
+       <description>Clock low. In master mode, these bits define the SCL low period. In slave mode, these bits define the time SCL will be held low after data is outputted.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKHI</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_HI</name>
+       <description>Clock High. In master mode, these bits define the SCL high period.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HS_CLK</name>
+     <description>HS-Mode Clock Control Register</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>HS_CLK_LO</name>
+       <description>Slave Address.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>HS_CLK_HI</name>
+       <description>Slave Address.</description>
+       <bitRange>[15:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TIMEOUT</name>
+     <description>Timeout Register</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>TO</name>
+       <description>Timeout</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLADDR</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>SLA</name>
+       <description>Slave Address.</description>
+       <bitRange>[9:0]</bitRange>
+      </field>
+      <field>
+       <name>SLADIS</name>
+       <description>Slave Address Disable.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>SLAIDX</name>
+       <description>Slave Address Index.</description>
+       <bitRange>[14:11]</bitRange>
+      </field>
+      <field>
+       <name>EA</name>
+       <description>Extended Address Select.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TXEN</name>
+       <description>TX channel enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXEN</name>
+       <description>RX channel enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2C0 Inter-Integrated Circuit.-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C1</name>
+   <description>Inter-Integrated Circuit. 1</description>
+   <baseAddress>0x4001E000</baseAddress>
+   <interrupt>
+    <name>I2C1</name>
+    <description>I2C1 IRQ</description>
+    <value>36</value>
+   </interrupt>
+  </peripheral>
+<!--I2C1 Inter-Integrated Circuit. 1-->
+  <peripheral>
+   <name>ICC0</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x4002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CACHE_ID</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CCHID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEM_SIZE</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCHSZ</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEMSZ</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CACHE_CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>ENABLE</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+    </register>
+   </registers>
+  </peripheral>
+<!--ICC0 Instruction Cache Controller Registers-->
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x40006800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x800</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>LP_CTRL</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAMRET_SEL0</name>
+       <description>System RAM 0 Data retention in BACKUP mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET_SEL1</name>
+       <description>System RAM 1 Data retention in BACKUP mode. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET_SEL2</name>
+       <description>System RAM 2 Data retention in BACKUP mode. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET_SEL3</name>
+       <description>System RAM 3 Data retention in BACKUP mode. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OVR</name>
+       <description>Operating Voltage Range</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_9V</name>
+         <description>0.9V 24MHz</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0V</name>
+         <description>1.0V 48MHz</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1V</name>
+         <description>1.1V 96MHz</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORE_DET_BYPASS</name>
+       <description>Bypass V CORE External Supply Detection</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>enabled</name>
+         <description>enable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Disable</name>
+         <description>disable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RETREG_EN</name>
+       <description>Retention Regulator Enable. This bit controls the retention regulator in BACKUP mode. </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAST_WK_EN</name>
+       <description>Fast Wake-Up Mode. This bit enables fast wake-up from DeepSleep mode. </description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BG_OFF</name>
+       <description>Band Gap Disable for DEEPSLEEP and BACKUP Mode</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>Bandgap is always ON.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>Bandgap is OFF in DeepSleep mode(default).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORE_POR_DIS</name>
+       <description>V CORE POR Disable for DEEPSLEEP and BACKUP Mode</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDO_DIS</name>
+       <description>LDO Disable</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON(default)</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORE_SVM_DIS</name>
+       <description>V CORE Supply Voltage Monitor Disable</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON(default)</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDIO_POR_DIS</name>
+       <description>VDDIO Power-On Reset Monitor Disable. This bit controls the Power-On Reset monitor on VDDIO supply in all operating mods.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LP_WAKEFL</name>
+     <description>Low Power Mode Wakeup Flags for GPIO0</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin(s) transition(s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWK_EN</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin(s) on transition(s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPMEMSD</name>
+     <description>Low Power Memory Shutdown Control.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>SRAM0_OFF</name>
+       <description>System RAM block 0 Shut Down.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM1_OFF</name>
+       <description>System RAM block 1 Shut Down.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM2_OFF</name>
+       <description>System RAM block 2 Shut Down.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM3_OFF</name>
+       <description>System RAM block 3 Shut Down.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PWRSEQ Power Sequencer / Low Power Control Register.-->
+  <peripheral>
+   <name>RTC</name>
+   <description>Real Time Clock and Alarm.</description>
+   <baseAddress>0x40006000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>RTC</name>
+    <description>RTC interrupt.</description>
+    <value>3</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>RTSS</name>
+       <description>RTC Sub-second Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RAS</name>
+     <description>Time-of-day Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>RAS</name>
+       <description>Time-of-day Alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RSSA</name>
+     <description>RTC sub-second alarm.  This register contains the reload value for the sub-second alarm.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>RSSA</name>
+       <description>This register contains the reload value for the sub-second alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>RTC Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>RTCE</name>
+       <description>Real Time Clock Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADE</name>
+       <description>Alarm Time-of-Day Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ASE</name>
+       <description>Alarm Sub-second Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>RTC Busy. This bit is set to 1 by hardware when changes to RTC registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>RTC Ready. This bit is set to 1 by hardware when the RTC count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the RTC count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDYE</name>
+       <description>RTC Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ALDF</name>
+       <description>Time-of-Day Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ALSF</name>
+       <description>Sub-second Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQE</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FT</name>
+       <description>Frequency Output Selection. When SQE=1, these bits specify the output frequency on the SQW pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq1Hz</name>
+         <description>1 Hz (Compensated).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq512Hz</name>
+         <description>512 Hz (Compensated).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq4KHz</name>
+         <description>4 KHz.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clkDiv8</name>
+         <description>RTC Input Clock / 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>X32KMD</name>
+       <description>32KHz Oscillator Mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noiseImmuneMode</name>
+         <description>Always operate in Noise Immune Mode.  Oscillator warm-up required.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>quietMode</name>
+         <description>Always operate in Quiet Mode.  No oscillator warm-up required.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>quietInStopWithWarmup</name>
+         <description>Operate in Noise Immune Mode normally, switch to Quiet Mode on Stop Mode entry.  Will wait for 32K oscillator warm-up before code execution on Stop Mode exit.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>quietInStopNoWarmup</name>
+         <description>Operate in Noise Immune Mode normally, switch to Quiet Mode on Stop Mode entry.  Will not wait for 32K oscillator warm-up before code execution on Stop Mode exit.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WE</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical RTC bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIM</name>
+     <description>RTC Trim Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>RTC Trim. This register contains the 2's complement value that specifies the trim resolution. Each increment or decrement of the bit adds or subtracts 1ppm at each 4KHz clock value, with a maximum correction of +/- 127ppm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VBATTMR</name>
+       <description>VBAT Timer Value. When RTC is running off of VBAT, this field is incremented every 32 seconds.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>RTC Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>FLITER_EN</name>
+       <description>RTC Oscillator Filter Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_SEL</name>
+       <description>RTC Oscillator 4X Bias Current Select</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>2X</name>
+         <description>Selects 2X bias current for RTC oscillator</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4X</name>
+         <description>Selects 4X bias current for RTC oscillator</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HYST_EN</name>
+       <description>RTC Oscillator Hysteresis Buffer Enable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_EN</name>
+       <description>RTC Oscillator Bias Current Enable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYPASS</name>
+       <description>RTC Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUT32K</name>
+       <description>RTC 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--RTC Real Time Clock and Alarm.-->
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x40000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>STATUS</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CFG_VALID</name>
+       <description>Configuration Valid Flag. This field is set to 1 by hardware during reset if the device configuration is valid.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>invalid</name>
+         <description>config invalid</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>valid</name>
+         <description>config valid</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CFG_ERR</name>
+       <description>Configuration Error Flag. This field is set by hardware during reset if an error in the device configuration is detected</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>valid</name>
+         <description>config valid</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>invalid</name>
+         <description>config invalid</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADDR</name>
+     <description>Read-only field set by the SIB block if a CRC error occurs during the read of the OTP memory. Contains the failing address in OTP memory (when CRCERR equals 1).</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIR System Initialization Registers.-->
+  <peripheral>
+   <name>SPI0</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x40046000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>16</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>DATA</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields />
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SPI_EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MM_EN</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Start Select Control. Used in Master mode to control the behavior of the Slave Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DEASSERT</name>
+         <description>SPI De-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ASSERT</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_SEL</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3</name>
+         <description>SS3 is selected.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLK_PHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Rising_Edge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Falling_Edge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLK_POL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUM_BITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin (s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_POL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_low</name>
+         <description>SS1 active low.</description>
+         <value>0x0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SS_TIME</name>
+     <description>Register for controlling SPI peripheral/Slave Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SSACT1</name>
+       <description>Slave Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSACT2</name>
+       <description>Slave Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSINACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_CFG</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCALE</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_FIFO_LEVEL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CLEAR</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CNT</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DMA_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_LEVEL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CLEAR</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CNT</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_DMA_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_LEVEL</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LEVEL</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_LEVEL</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LEVEL</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_FL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_LEVEL</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LEVEL</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_LEVEL</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LEVEL</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPI0 SPI peripheral.-->
+  <peripheral>
+   <name>SPIMSS</name>
+   <description>Serial Peripheral Interface.</description>
+   <prependToName>SPIMSS</prependToName>
+   <baseAddress>0x40019000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>DATA</name>
+     <description>SPI 16-bit Data Access</description>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>SPI data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>SPI Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ENABLE</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>dis_en_enum</name>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MMEN</name>
+       <description>SPI Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>slv_mst_enum</name>
+        <enumeratedValue>
+         <name>slave</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WOR</name>
+       <description>Wired OR (open drain) Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>dis_en_enum</name>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>spi_pol_enum</name>
+        <enumeratedValue>
+         <name>idleLo</name>
+         <description>SCLK idles Low (0) after character transmission/reception.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>idleHi</name>
+         <description>SCLK idles High (1) after character transmission/reception.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PHASE</name>
+       <description>Phase Select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>spi_phase_enum</name>
+        <enumeratedValue>
+         <name>activeEdge</name>
+         <description>Transmit on active edge of SCLK.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>inactiveEdge</name>
+         <description>Transmit on inactive edge of SCLK.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BIRQ</name>
+       <description>Baud Rate Generator Timer Interrupt Request.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>dis_en_enum</name>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STR</name>
+       <description>Start SPI Interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>start_op_enum</name>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRQE</name>
+       <description>Interrupt Request Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>dis_en_enum</name>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>SPI Interrupt Flag Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>SLAS</name>
+       <description>Slave Select. If the SPI is in slave mode, this bit indicates if the SPI is selected. If the SPI is in master mode this bit has no meaning.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <name>sel_enum</name>
+        <enumeratedValue>
+         <name>selected</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notSelected</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXST</name>
+       <description>Transmit Status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <name>busy_enum</name>
+        <enumeratedValue>
+         <name>idle</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TUND</name>
+       <description>Transmit Underrun.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       <enumeratedValues>
+        <name>event_flag_enum</name>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROVR</name>
+       <description>Receive Overrun.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>event_flag_enum</name>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABT</name>
+       <description>Slave Mode Transaction Abort.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>event_flag_enum</name>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>COL</name>
+       <description>Collision.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>event_flag_enum</name>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOVR</name>
+       <description>Transmit Overrun.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>event_flag_enum</name>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRQ</name>
+       <description>SPI Interrupt Request.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       <enumeratedValues>
+        <name>flag_enum</name>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MODE</name>
+     <description>SPI Mode Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>SSV</name>
+       <description>Slave Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>lo_hi_enum</name>
+        <enumeratedValue>
+         <name>lo</name>
+         <description>The SSEL pin will be driven low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hi</name>
+         <description>The SSEL pin will be driven high.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select I/O.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>input_output_enum</name>
+        <enumeratedValue>
+         <name>input</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>output</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <name>spi_bits_enum</name>
+        <enumeratedValue>
+         <name>bits16</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bits1</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bits2</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bits3</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bits4</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bits5</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bits6</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bits7</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bits8</name>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bits9</name>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bits10</name>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bits11</name>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bits12</name>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bits13</name>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bits14</name>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>bits15</name>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LJ</name>
+       <description>Transmit Left Justify.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>dis_en_enum</name>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BRG</name>
+     <description>Baud Rate Reload Value. The SPI Baud Rate register is a 16-bit reload value for the SPI Baud Rate Generator. The reload value must be greater than or equal to 0002H for proper SPI operation (maximum baud rate is PCLK frequency divided by 4).</description>
+     <addressOffset>0x14</addressOffset>
+     <resetValue>0x0000FFFF</resetValue>
+     <fields>
+      <field>
+       <name>DIV</name>
+       <description>Baud Rate Reload Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>SPI DMA Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00070007</resetValue>
+     <fields>
+      <field>
+       <name>TX_FIFO_LVL</name>
+       <description>Transmit FIFO Level. Set the number of free entries in the TxFIFO when a TxDMA request occurs.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <name>fifo_level_enum</name>
+        <enumeratedValue>
+         <name>entry1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>entries2</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>entries3</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>entries4</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>entries5</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>entries6</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>entries7</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>entries8</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CLR</name>
+       <description>Transmit FIFO Clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+       <enumeratedValues>
+        <name>start_op_enum</name>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CNT</name>
+       <description>Transmit FIFO Count.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DMA_EN</name>
+       <description>Transmit DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>dis_en_enum</name>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_LVL</name>
+       <description>Receive FIFO Level. Sets the RX FIFO DMA request threshold. This configures the number of filled RxFIFO entries before activating an RxDMA request.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <name>fifo_level_enum</name>
+        <enumeratedValue>
+         <name>entry1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>entries2</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>entries3</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>entries4</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>entries5</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>entries6</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>entries7</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>entries8</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CLR</name>
+       <description>Receive FIFO Clear.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>start_op_enum</name>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CNT</name>
+       <description>Receive FIFO Count.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_DMA_EN</name>
+       <description>Receive DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>dis_en_enum</name>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>I2S_CTRL</name>
+     <description>I2S Control Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>I2S_EN</name>
+       <description>I2S Mode Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>dis_en_enum</name>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2S_MUTE</name>
+       <description>I2S Mute transmit.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Transmit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>replaced</name>
+         <description>Transmit data is replaced with 0.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2S_PAUSE</name>
+       <description>I2S Pause transmit/receive.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Transmit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>halt</name>
+         <description>Halt transmit and receive FIFO and DMA access, transmit 0's.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2S_MONO</name>
+       <description>I2S Monophonic Audio Mode.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>stereophonic</name>
+         <description>Stereophonic audio.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>monophonic</name>
+         <description>Monophonic audio format.Each transmit data word is replicated on both left/right channels. Receive data is taken from left channel, right channel receive data is ignored.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2S_LJ</name>
+       <description>I2S Left Justify.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal I2S audio protocol.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>replaced</name>
+         <description>Audio data is synchronized with SSEL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIMSS Serial Peripheral Interface.-->
+  <peripheral>
+   <name>TMR0</name>
+   <description>Low-Power Configurable Timer</description>
+   <baseAddress>0x40010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR</name>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Timer Counter Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>The current count value for the timer. This field increments as the timer counts.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Timer Compare Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>Timer PWM Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PWM</name>
+       <description>Timer PWM Match:
+                In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
+                In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Timer Interrupt Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ</name>
+       <description>Interrupt Flag for Timer A.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CN</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TMODE</name>
+       <description>Mode Select</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES</name>
+       <description>Timer Prescaler Select</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>Prescaler Divide-By-4096</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8192</name>
+         <description>Prescaler Divide-By-8192</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TPOL</name>
+       <description>Timer Polarity</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TEN</name>
+       <description>Timer Enable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PRES3</name>
+       <description>Timer Prescale Select MSB</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC</name>
+       <description>PWM Synchronization Mode</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL</name>
+       <description>PWM Phase A-prime (Non-Overlapping Low) Polarity</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD</name>
+       <description>PWM Phase A-Prime Output Disable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TMR0 Low-Power Configurable Timer-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR1</name>
+   <description>Low-Power Configurable Timer 1</description>
+   <baseAddress>0x40011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+<!--TMR1 Low-Power Configurable Timer 1-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR2</name>
+   <description>Low-Power Configurable Timer 2</description>
+   <baseAddress>0x40012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+<!--TMR2 Low-Power Configurable Timer 2-->
+  <peripheral>
+   <name>UART0</name>
+   <description>UART</description>
+   <baseAddress>0x40042000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>UART0</name>
+    <description>UART0 IRQ</description>
+    <value>14</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0</name>
+     <description>Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ENABLE</name>
+       <description>UART enabled, to enable UART block, it is used to drive a gated clock in order to save power consumption when UART is not used. FIFOs are flushed when UART is disabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>UART disabled. FIFOs are flushed. Clock is gated off for power savings. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>UART enabled. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PARITY_EN</name>
+       <description>Enable/disable Parity bit (9th character).</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Parity </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Parity enabled as 9th bit</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PARITY_MODE</name>
+       <description>When PARITY_EN=1, selects odd, even, Mark or Space parity.
+            Mark parity = always 1; Space parity = always 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Even</name>
+         <description>Even parity selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ODD</name>
+         <description>Odd parity selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>MARK</name>
+         <description>Mark parity selected.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SPACE</name>
+         <description>Space parity selected.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PARITY_LVL</name>
+       <description>Selects parity based on 1s or 0s count (when PARITY_EN=1).</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1</name>
+         <description>Parity calculation is based on number of 1s in frame.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>0</name>
+         <description>Parity calculation is based on number of 0s in frame.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXFLUSH</name>
+       <description>Flushes the TX FIFO buffer.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXFLUSH</name>
+       <description>Flushes the RX FIFO buffer.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BITACC</name>
+       <description>If set, bit accuracy is selected, in this case the bit duration is the same for all the bits with the optimal accuracy. But the frame duration can have a significant deviation from the expected baudrate.If clear, frame accuracy is selected, therefore bits can have different duration in order to guarantee the minimum frame deviation.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>FRAME</name>
+         <description>Frame accuracy.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BIT</name>
+         <description>Bit accuracy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SIZE</name>
+       <description>Selects UART character size.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5</name>
+         <description>5 bits.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6</name>
+         <description>6 bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7</name>
+         <description>7 bits.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8</name>
+         <description>8 bits.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Selects the number of stop bits that will be generated.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1</name>
+         <description>1 stop bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_5</name>
+         <description>1.5 stop bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLOW</name>
+       <description>Enables/disables hardware flow control.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW Flow Control with RTS/CTS enabled</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW Flow Control disabled</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLOWPOL</name>
+       <description>RTS/CTS polarity.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0</name>
+         <description>RTS/CTS asserted is logic 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1</name>
+         <description>RTS/CTS asserted is logic 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NULLMOD</name>
+       <description>NULL Modem Support (RTS/CTS and TXD/RXD swap).</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Direct convention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Null Modem Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>Break control bit. It causes a break condition to be transmitted to receiving UART.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Break characters are not generated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Break characters are sent(all the bits are at '0' including start/parity/stop).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLK_SEL</name>
+       <description>Baud Rate Clock Source Select.  Selects the baud rate clock.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SYSTEM</name>
+         <description>System clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate 7.3727MHz internal clock.  Useful in low power modes when the system clock is slow.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_CNT</name>
+       <description>RX Time Out. RX time out interrupt will occur after RXTO Uart
+              characters if RX-FIFO is not empty and RX FIFO has not been read.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Threshold Control register.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>RX_FIFO_LVL</name>
+       <description>RX FIFO Threshold Level.When the RX FIFO reaches this many bytes or higher, UARTn_INFTL.rx_fifo_level is set.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_LVL</name>
+       <description>TX FIFO Threshold Level. When the TX FIFO reaches this many bytes or higher, UARTn_INTFL.tx_fifo_level is set.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RTS_FIFO_LVL</name>
+       <description>RTS threshold control. When the RX FIFO reaches this many bytes or higher, the RTS output signal is deasserted, informing the transmitting UART to stop sending data to this UART.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TX_BUSY</name>
+       <description>Read-only flag indicating the UART transmit status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_BUSY</name>
+       <description>Read-only flag indicating the UARTreceiver status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>PARITY</name>
+       <description>9th Received bit state. This bit identifies the state of the 9th bit of received data. Only available for UART_CTRL.SIZE[1:0]=3.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>Received BREAK status. BREAKS is cleared when UART_STAT register is read. Received data input is held in spacing (logic 0) state for longer than a full word transmission time (that is, the total time of Start bit + data bits + Parity + Stop bits).</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_EMPTY</name>
+       <description>Read-only flag indicating the RX FIFO state.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Read-only flag indicating the RX FIFO state.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Read-only flag indicating the TX FIFO state.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>Read-only flag indicating the TX FIFO state.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_NUM</name>
+       <description>Indicates the number of bytes currently in the RX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_NUM</name>
+       <description>Indicates the number of bytes currently in the TX FIFO.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_TO</name>
+       <description>RX Timeout status.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>RX_FRAME_ERROR</name>
+       <description>Enable for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PARITY_ERROR</name>
+       <description>Enable for RX Parity Error interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS</name>
+       <description>Enable for CTS signal change interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OVERRUN</name>
+       <description>Enable for RX FIFO OVerrun interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_LVL</name>
+       <description>Enable for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_AE</name>
+       <description>Enable for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_LVL</name>
+       <description>Enable for interrupt when TX FIFO reaches the number of bytes configured by the TXTHD field.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>Enable for received BREAK character interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_TO</name>
+       <description>Enable for RX Timeout Interrupt. Trigger if there is no RX communication during n UART characters (n=UART_CN.RXTO).</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LAST_BREAK</name>
+       <description>Enable for Last break character interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Interrupt Status Flags.</description>
+     <addressOffset>0x10</addressOffset>
+     <size>32</size>
+     <modifiedWriteValues>oneToClear</modifiedWriteValues>
+     <fields>
+      <field>
+       <name>FRAME</name>
+       <description>FLAG for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PARITY</name>
+       <description>FLAG for RX Parity Error interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS</name>
+       <description>FLAG for CTS signal change interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>FLAG for RX FIFO Overrun interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_LVL</name>
+       <description>FLAG for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_AE</name>
+       <description>FLAG for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_LVL</name>
+       <description>FLAG for interrupt when TX FIFO reaches the number of bytes configured by the TXTHD field.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>FLAG for received BREAK character interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_TO</name>
+       <description>FLAG for RX Timeout Interrupt. Trigger if there is no RX communication during n UART characters (n=UART_CN.RXTO).</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LAST_BREAK</name>
+       <description>FLAG for Last break character interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BAUD0</name>
+     <description>Baud rate register. Integer portion.</description>
+     <addressOffset>0x14</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>IBAUD</name>
+       <description>Integer portion of baud rate divisor value. IBAUD = InputClock / (factor * Baud Rate Frequency).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>FACTOR must be chosen to have IDIV&gt;0. factor used in calculation = 128 &gt;&gt; FACTOR.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>128</name>
+         <description>Baud Factor 128</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>64</name>
+         <description>Baud Factor 64</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>32</name>
+         <description>Baud Factor 32</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16</name>
+         <description>Baud Factor 16</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8</name>
+         <description>Baud Factor 8</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BAUD1</name>
+     <description>Baud rate register. Decimal Setting.</description>
+     <addressOffset>0x18</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DBAUD</name>
+       <description>Decimal portion of baud rate divisor value. DIV = InputClock/(factor*Baud Rate Frequency). DDIV=(DIV-IDIV)*128.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Data buffer.</description>
+     <addressOffset>0x1C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>FIFO</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration.</description>
+     <addressOffset>0x20</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>TXDMA_EN</name>
+       <description>TX DMA channel enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>DMA is disabled </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>DMA is enabled </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXDMA_EN</name>
+       <description>RX DMA channel enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>DMA is disabled </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>DMA is enabled </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXDMA_LVL</name>
+       <description>TX threshold for DMA transmission.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RXDMA_LVL</name>
+       <description>RX threshold for DMA transmission.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXFIFO</name>
+     <description>Transmit FIFO Status register.</description>
+     <addressOffset>0x24</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Reading from this field returns the next character available at the
+              output of the TX FIFO (if one is available, otherwise 00h is returned).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--UART0 UART-->
+  <peripheral derivedFrom="UART0">
+   <name>UART1</name>
+   <description>UART 1</description>
+   <baseAddress>0x40043000</baseAddress>
+   <interrupt>
+    <name>UART1</name>
+    <description>UART1 IRQ</description>
+    <value>15</value>
+   </interrupt>
+  </peripheral>
+<!--UART1 UART 1-->
+  <peripheral>
+   <name>WDT0</name>
+   <description>Watchdog Timer 0</description>
+   <baseAddress>0x40003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WDT0</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x7FFFF000</resetMask>
+     <fields>
+      <field>
+       <name>INT_PERIOD</name>
+       <description>Watchdog Interrupt Period. The watchdog timer will assert an interrupt, if enabled, if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_PERIOD</name>
+       <description>Watchdog Reset Period. The watchdog timer will assert a reset, if enabled, if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_EN</name>
+       <description>Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_FLAG</name>
+       <description>Watchdog Timer Interrupt Flag.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EN</name>
+       <description>Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EN</name>
+       <description>Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_FLAG</name>
+       <description>Watchdog Timer Reset Flag.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>WDT_RST</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WDT0 Watchdog Timer 0-->
+ </peripherals>
+</device>

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32662/Include/max32662.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32662/Include/max32662.svd
@@ -1,0 +1,12497 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max32662</name>
+ <series>ARMCM4</series>
+ <version>1.0</version>
+ <description>MAX32662 32-bit ARM Cortex-M4 microcontroller.</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>ADC</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>ADC</groupName>
+   <baseAddress>0x40034000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>ADC</name>
+    <description>ADC IRQ</description>
+    <value>20</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0</name>
+     <description>Control Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADC_EN</name>
+       <description>ADC Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable ADC.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable ADC.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BIAS_EN</name>
+       <description>Bias Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Bias.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Bias.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SKIP_CAL</name>
+       <description>Skip Calibration Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no_skip</name>
+         <description>Do not skip calibration.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>skip</name>
+         <description>Skip calibration.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CHOP_FORCE</name>
+       <description>Chop Force Control.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Do not force chop mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Force chop Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RESETB</name>
+       <description>Reset ADC.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>reset ADC.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activate</name>
+         <description>activate ADC.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Control Register 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Start conversion control.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>stop</name>
+         <description>Stop conversions.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start conversions.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TRIG_MODE</name>
+       <description>Trigger mode control.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>software</name>
+         <description>software trigger mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hardware</name>
+         <description>hardware trigger mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CNV_MODE</name>
+       <description>Conversion mode control.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>atomic</name>
+         <description>Do one conversion sequence.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Do continuous conversion sequences.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SAMP_CK_OFF</name>
+       <description>Sample clock off control.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>always</name>
+         <description>Sample clock always generated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cnv_only</name>
+         <description>Sample clock generated only when converting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TRIG_SEL</name>
+       <description>Hardware trigger source select.</description>
+       <bitRange>[6:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TS_SEL</name>
+       <description>Temp sensor select.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Temp sensor is not one of the slots in the sequence.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Temp sensor is one of the slots in the sequence.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AVG</name>
+       <description>Number of samples to average for each output data code.</description>
+       <bitRange>[10:8]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>avg1</name>
+         <description>1 Sample per output code.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg2</name>
+         <description>2 Samples per output code.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg4</name>
+         <description>4 Samples per output code.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg8</name>
+         <description>8 Samples per output code.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg16</name>
+         <description>16 Samples per output code.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg32</name>
+         <description>32 Samples per output code.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUM_SLOTS</name>
+       <description>Number of slots enabled for the conversion sequence</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>CLKSEL</name>
+       <description>Clock source select.</description>
+       <bitRange>[1:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>HCLK</name>
+         <description>Select HCLK.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK_ADC0</name>
+         <description>Select CLK_ADC0.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK_ADC1</name>
+         <description>Select CLK_ADC1.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK_ADC2</name>
+         <description>Select CLK_ADC2.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>Clock divider control.</description>
+       <bitRange>[6:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <description>Divide by 2.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <description>Divide by 4.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV8</name>
+         <description>Divide by 8.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV16</name>
+         <description>Divide by 16.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <description>Divide by 1.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAMPCLKCTRL</name>
+     <description>Sample Clock Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TRACK_CNT</name>
+       <description>Number of cycles for SAMPLE_CLK high time.</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>IDLE_CNT</name>
+       <description>Number of cycles for SAMPLE_CLK low time.</description>
+       <bitRange>[31:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL0</name>
+     <description>Channel Select Register 0.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>slot0_id</name>
+       <description>channel assignment for slot 0.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot1_id</name>
+       <description>channel assignment for slot 1.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot2_id</name>
+       <description>channel assignment for slot 2.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot3_id</name>
+       <description>channel assignment for slot 3.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL1</name>
+     <description>Channel Select Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>slot4_id</name>
+       <description>channel assignment for slot 4.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot5_id</name>
+       <description>channel assignment for slot 5.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot6_id</name>
+       <description>channel assignment for slot 6.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot7_id</name>
+       <description>channel assignment for slot 7.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL2</name>
+     <description>Channel Select Register 2.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>slot8_id</name>
+       <description>channel assignment for slot 8.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot9_id</name>
+       <description>channel assignment for slot 9.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot10_id</name>
+       <description>channel assignment for slot 10.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot11_id</name>
+       <description>channel assignment for slot 11.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL3</name>
+     <description>Channel Select Register 3.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>slot12_id</name>
+       <description>channel assignment for slot 12.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot13_id</name>
+       <description>channel assignment for slot 13.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot14_id</name>
+       <description>channel assignment for slot 14.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot15_id</name>
+       <description>channel assignment for slot 15.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESTART</name>
+     <description>Restart Count Control Register</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Number of sample periods to skip before restarting a continuous mode sequence</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAFMT</name>
+     <description>Channel Data Format Register</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Data format control</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFODMACTRL</name>
+     <description>FIFO and DMA control</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>DMA_EN</name>
+       <description>DMA Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable DMA.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable DMA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>FIFO Flush.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal FIFO operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_FORMAT</name>
+       <description>DATA format control.</description>
+       <bitRange>[3:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>data_status</name>
+         <description>Data and Status in FIFO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>data_only</name>
+         <description>Only Data in FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>raw_data_only</name>
+         <description>Only Raw Data in FIFO.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THRESH</name>
+       <description>FIFO Threshold. These bits define the FIFO interrupt threshold.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data Register (FIFO).</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Conversion data.</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CHAN</name>
+       <description>Channel for the data.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>INVALID</name>
+       <description>Invalid status for the data.</description>
+       <bitRange>[24:24]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLIPPED</name>
+       <description>Clipped status for the data.</description>
+       <bitRange>[31:31]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>READY</name>
+       <description>Indication that the ADC is in ON power state</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EMPTY</name>
+       <description>FIFO Empty</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>FULL</name>
+       <description>FIFO full</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>FIFO_LEVEL</name>
+       <description>Number of entries in FIFO available to read</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSTATUS</name>
+     <description>Channel Status</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>CLIPPED</name>
+       <description />
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>READY</name>
+       <description>ADC is ready.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Conversion start is aborted.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>START_DET</name>
+       <description>Conversion start is detected.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SEQ_STARTED</name>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SEQ_DONE</name>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CONV_DONE</name>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLIPPED</name>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_LVL</name>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_UFL</name>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_OFL</name>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Interrupt Flags Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>READY</name>
+       <description>ADC is ready.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Conversion start is aborted.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>START_DET</name>
+       <description>Conversion start is detected.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>SEQ_STARTED</name>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>SEQ_DONE</name>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>CONV_DONE</name>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>CLIPPED</name>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>FIFO_LVL</name>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>FIFO_UFL</name>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>FIFO_OFL</name>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRADDROFFSET</name>
+     <description>SFR Address Offset Register</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>OFFSET</name>
+       <description>Address Offset for SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRADDR</name>
+     <description>SFR Address Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address to SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRWRDATA</name>
+     <description>SFR Write Data Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>DATA to SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRRDDATA</name>
+     <description>SFR Read Data Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>DATA from SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRSTATUS</name>
+     <description>SFR Status Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>NACK</name>
+       <description>NACK status for SAR Digital SFR communication</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ADC Inter-Integrated Circuit.-->
+  <peripheral>
+   <name>AESKEYS</name>
+   <description>AES Key Registers.</description>
+   <baseAddress>0x40205000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>KEY0</name>
+     <description>AES Key 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY1</name>
+     <description>AES Key 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY2</name>
+     <description>AES Key 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY3</name>
+     <description>AES Key 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY4</name>
+     <description>AES Key 4.</description>
+     <addressOffset>0x10</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY5</name>
+     <description>AES Key 5.</description>
+     <addressOffset>0x14</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY6</name>
+     <description>AES Key 6.</description>
+     <addressOffset>0x18</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY7</name>
+     <description>AES Key 7.</description>
+     <addressOffset>0x1C</addressOffset>
+     <size>32</size>
+    </register>
+   </registers>
+  </peripheral>
+<!--AESKEYS AES Key Registers.-->
+  <peripheral>
+   <name>AES</name>
+   <description>AES Keys.</description>
+   <baseAddress>0x40207400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>AES Control Register</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>AES Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>DMA Request To Read Data Output FIFO</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>DMA Request To Write Data Input FIFO</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start AES Calculation</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FLUSH</name>
+       <description>Flush the data input FIFO</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FLUSH</name>
+       <description>Flush the data output FIFO</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_SIZE</name>
+       <description>Encryption Key Size</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AES128</name>
+         <description>128 Bits.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES192</name>
+         <description>192 Bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES256</name>
+         <description>256 Bits.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TYPE</name>
+       <description>Encryption Type Selection</description>
+       <bitRange>[9:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>AES Status Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>AES Busy Status</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_EM</name>
+       <description>Data input FIFO empty status</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FULL</name>
+       <description>Data input FIFO full status</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_EM</name>
+       <description>Data output FIFO empty status</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FULL</name>
+       <description>Data output FIFO full status</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>AES Interrupt Flag Register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>AES Interrupt Enable Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>AES Data Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>AES FIFO</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--AES AES Keys.-->
+  <peripheral>
+   <name>CAN0</name>
+   <description>Controller Area Network Registers</description>
+   <baseAddress>0x40064000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>MODE</name>
+     <description>Mode Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>AFM</name>
+       <description>Hardware acceptance filter scheme.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LOM</name>
+       <description>Listen Only Mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST</name>
+       <description>Reset Mode.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXTRIG</name>
+       <description>Receive FIFO trigger in 32bit word.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1W</name>
+         <description>1 word</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4W</name>
+         <description>4 word</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8W</name>
+         <description>8 word</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16W</name>
+         <description>16 word</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>32W</name>
+         <description>32 word</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>64W</name>
+         <description>64 word</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>Enable DMA mode.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SLP</name>
+       <description>Sleep mode.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>enter</name>
+         <description>Enter sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>leave</name>
+         <description>Leave sleep mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMD</name>
+     <description>Command Register.</description>
+     <addressOffset>0x0001</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ABORT</name>
+       <description>Abort Transmission</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXREQ</name>
+       <description>Transmit Request.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>Status Register.</description>
+     <addressOffset>0x0002</addressOffset>
+     <size>8</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUS_OFF</name>
+       <description>Bus off Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERR</name>
+       <description>Error Status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Transmit Status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Receive Status.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXBUF</name>
+       <description>Transmit Buffer Status.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DOR</name>
+       <description>Data Overrun Status.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXBUF</name>
+       <description>Receive Buffer Status.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x0003</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DOR</name>
+       <description>Data Overrun Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BERR</name>
+       <description>Bus Error Interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Transmission Interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Receive Interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERPSV</name>
+       <description>Error Passive Interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERWARN</name>
+       <description>Error Warning Interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AL</name>
+       <description>Arbitration Lost Interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WU</name>
+       <description>Wake-up Interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DOR</name>
+       <description>Data Overrun Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BERR</name>
+       <description>Bus Error Interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Transmit Interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Receive Interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERPSV</name>
+       <description>Error Passive Interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERWARN</name>
+       <description>Error Warning Interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AL</name>
+       <description>Arbitration Lost Interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WU</name>
+       <description>Wakeup interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RMC</name>
+     <description>Receive Message Counter Register.</description>
+     <addressOffset>0x0005</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>NUM_MSGS</name>
+       <description>Number of stored message frames.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUSTIM0</name>
+     <description>Bus Timing Register 0.</description>
+     <addressOffset>0x0006</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BR_CLKDIV</name>
+       <description>Baud Rate Prescaler.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>SJW</name>
+       <description>Synchronization Jump Width.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUSTIM1</name>
+     <description>Bus Timing Register 1.</description>
+     <addressOffset>0x0007</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TSEG1</name>
+       <description>Number of clock cycles per Time Segment 1</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TSEG2</name>
+       <description>Number of clock cycles per Time Segment 2</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>SAM</name>
+       <description>Number of bus level samples.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXFIFO32</name>
+     <description>Transmit FIFO Register.</description>
+     <addressOffset>0x0008</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>TXFIFO16[%s]</name>
+     <description>Transmit FIFO Register.</description>
+     <addressOffset>0x0008</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>TXFIFO8[%s]</name>
+     <description>Transmit FIFO Register.</description>
+     <addressOffset>0x0008</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXFIFO32</name>
+     <description>Receive FIFO Register.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read from RX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>RXFIFO16[%s]</name>
+     <description>Receive FIFO Register.</description>
+     <addressOffset>0x000C</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read from RX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>RXFIFO8[%s]</name>
+     <description>Receive FIFO Register.</description>
+     <addressOffset>0x000C</addressOffset>
+     <size>8</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read from RX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACR32</name>
+     <description>Acceptance Code Register.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ACR</name>
+       <description>Acceptance Code.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>ACR16[%s]</name>
+     <description>Acceptance Code Register.</description>
+     <addressOffset>0x0010</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ACR</name>
+       <description>Acceptance Code.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>ACR8[%s]</name>
+     <description>Acceptance Code Register.</description>
+     <addressOffset>0x0010</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ACR</name>
+       <description>Acceptance Code.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AMR32</name>
+     <description>Acceptance Mask Register.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>AMR</name>
+       <description>Acceptance Mask.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>AMR16[%s]</name>
+     <description>Acceptance Mask Register.</description>
+     <addressOffset>0x0014</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>AMR</name>
+       <description>Acceptance Mask.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>AMR8[%s]</name>
+     <description>Acceptance Mask Register.</description>
+     <addressOffset>0x0014</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>AMR</name>
+       <description>Acceptance Mask.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECC</name>
+     <description>Error Code Capture Register.</description>
+     <addressOffset>0x0018</addressOffset>
+     <size>8</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BER</name>
+       <description>Bit Error Occurred.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>STFER</name>
+       <description>Stuff Error Occurred.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRCER</name>
+       <description>CRC Error Occurred.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FRMER</name>
+       <description>Form Error Occurred.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ACKER</name>
+       <description>ACK Error Occurred.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EDIR</name>
+       <description>Direction of transfer while error occurred.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>TX</name>
+         <description>Transmission</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RX</name>
+         <description>Reception</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXWRN</name>
+       <description>Set when TXERR counter is greater than or equal to 96.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXWRN</name>
+       <description>Set when RXERR counter is greater than or equal to 96.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXERR</name>
+     <description>Receive Error Counter.</description>
+     <addressOffset>0x0019</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RXERR</name>
+       <description>Receive Error Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXERR</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x001A</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TXERR</name>
+       <description>Transmit Error Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ALC</name>
+     <description>Arbitration Lost Code Capture Register.</description>
+     <addressOffset>0x001B</addressOffset>
+     <size>8</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ALC</name>
+       <description>Arbitration Lost Capture.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NBT</name>
+     <description>Nominal Bit Timing Register.</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>NBRP</name>
+       <description>Baudrate Prescaler Used in Arbitration Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+      <field>
+       <name>NSEG1</name>
+       <description>The time segment before the sample point in Abritration Phase.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>NSEG2</name>
+       <description>The time segment after the sample point in Abritration Phase.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>NSJW</name>
+       <description>Synchronization Jump Width in Arbitration Phase.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DBT_SSPP</name>
+     <description>Data Bit Timing Register.</description>
+     <addressOffset>0x0020</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DBRP</name>
+       <description>Baudrate Prescaler in Data Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+      <field>
+       <name>DSEG1</name>
+       <description>The time segment before the sample point in Data Phase.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>DSEG2</name>
+       <description>The time segment before the sample point in Data Phase.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>DSJW</name>
+       <description>Synchronization Jump Width in Data Phase</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>SSPP</name>
+       <description>Position of the secondary sample point.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FDCTRL</name>
+     <description>FD Control Register.</description>
+     <addressOffset>0x0024</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>FDEN</name>
+       <description>FD Frame format/ Extended data length. This bit indicates CAN FD frame format.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>fd</name>
+         <description>CAN FD Frame Format</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>classic</name>
+         <description>Classic CAN Frame Format.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BRSEN</name>
+       <description>This bit indicates whether the bit rate is switched in Data phase.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>NOSW</name>
+         <description>Bit rate is not switced inside of CAN FD frame.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SW</name>
+         <description>Bit rate is switched from nominal bit rate of the arbitration phase to alternate bit rate of data phase.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTBT</name>
+       <description>This bit configure the Bit Time prescaler in Arbitration phase.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>BT</name>
+         <description>Use contents of BT register to configure bit time in arbitration phase.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>NBT</name>
+         <description>Use contents of NBT register to configure bit time in arbitration phase.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ISO</name>
+       <description>ISO CAN FD Format Selection.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>BOSCH</name>
+         <description>Frame format according to Bosch CAN FD specification.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ISO</name>
+         <description>Frame format according to ISO 11898 1, 2015.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DAR</name>
+       <description>Disable Auto Retransmission</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Automatic retransmission enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Automatic retransmission disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>REOM</name>
+       <description>Restricted Operation Mode.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PED</name>
+       <description>Protocol Exception Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FDSTAT</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0025</addressOffset>
+     <size>8</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BITERR</name>
+       <description>Bit Error Indicator. When this bit is set the inconsistency occurs between the transmitted and the received bit in CAN FD frame.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRCERR</name>
+       <description>Cyclic Redundancy Check Error indicator. This indicates that calculated CRC is different from received in CAN FD frame</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FRMERR</name>
+       <description>Form Error indicator. This bit indicates, that a fixed form bit field contains at least one illegal bit in Data phase of CAN FD frame with the BRS 
+bit set</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>STFERR</name>
+       <description>Stuff Error Indicator. This bit indicates stuff error occurred in Data phase in CAN FD frame with the BRS bit set
+</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PEE</name>
+       <description>Protocol Exception Event indicator. Indicates that core detects recessive state on res position and enter to Bus integration state.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>STATE</name>
+       <description>Operation state.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>INT</name>
+         <description>Waiting for 11 recessive bit after reset or bus off</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IDLE</name>
+         <description>Waiting for Start of Frame.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RX</name>
+         <description>Node operating as Receiver.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TX</name>
+         <description>Node operating as Transmitter.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DPERR</name>
+     <description>Data Phase Error Counter Register.</description>
+     <addressOffset>0x0026</addressOffset>
+     <size>8</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DPERR</name>
+       <description>Data Phase Error Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>APERR</name>
+     <description>Arbitration Phase Error Counter Register.</description>
+     <addressOffset>0x0027</addressOffset>
+     <size>8</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>APERR</name>
+       <description>Arbitration Error Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TEST</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0028</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LBEN</name>
+       <description>Loopback mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXC</name>
+       <description>Transmitted frame.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WUPCLKDIV</name>
+     <description>Wake-up timer prescaler.</description>
+     <addressOffset>0x0029</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WUPDIV</name>
+       <description>Wake-up timer prescaler.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WUPFT</name>
+     <description>Wake up Filter Time Register.</description>
+     <addressOffset>0x002A</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WUPFT</name>
+       <description>Wake-up pattern filter time.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WUPET</name>
+     <description>Wake-up Expire Time Register.</description>
+     <addressOffset>0x002C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WUPET</name>
+       <description>Wake up patter expire time.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXDCNT</name>
+     <description>RX FIFO Data Counter Register.</description>
+     <addressOffset>0x0030</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RXDCNT</name>
+       <description>RX FIFO data counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXSCNT</name>
+     <description>TX FIFO Space Counter.</description>
+     <addressOffset>0x0032</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TXSCNT</name>
+       <description>TX FIFO Space Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXDECMP</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0033</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TDCO</name>
+       <description>Transceiver Delay Compensation Offset. This bit field contains the offset value added to the measured transceiver loop delay</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>TDCEN</name>
+       <description>Transceiver Delay Compensation Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EINTFL</name>
+     <description>Extended Interrupt Flag Register.</description>
+     <addressOffset>0x0034</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO reach programmed trigger level, it is set when the RX FIFO reaches programmed trigger level (RT[2:0] in MR register). To clear the 
+RXFT interrupt, write this bit 1</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_TO</name>
+       <description>RX FIFO Timeout Indicator. It is set when there is no write or read from/in to RX FIFO for the user defined time (RXFTO register) and there is at 
+least 1 entry in RX FIFO during this time, this bit is clear by write 1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EINTEN</name>
+     <description>Extended Interrupt Enable Register.</description>
+     <addressOffset>0x0035</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO reach programmed trigger level, it is set when the RX FIFO reaches programmed trigger level (RT[2:0] in MR register). To clear the 
+RXFT interrupt, write this bit 1</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_TO</name>
+       <description>RX FIFO Timeout Indicator. It is set when there is no write or read from/in to RX FIFO for the user defined time (RXFTO register) and there is at 
+least 1 entry in RX FIFO during this time, this bit is clear by write 1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXTO</name>
+     <description>RX FIFO Timeout Register.</description>
+     <addressOffset>0x0036</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_TO</name>
+       <description>RX FIFO Timeout</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CAN0 Controller Area Network Registers-->
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0</name>
+    <value>28</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1</name>
+    <value>29</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA2</name>
+    <value>30</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA3</name>
+    <value>31</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>INTEN</name>
+     <description>DMA Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel 0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <description>Channel 1 Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <description>Channel 2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <description>Channel 3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>DMA Interrupt Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel Interrupt. To clear an interrupt, all active interrupt bits of the DMA_ST must be cleared. The interrupt bits are set only if their corresponding interrupt enable bits are set in DMA_CN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>4</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CTRL</name>
+      <description>DMA Channel Control Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>EN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQUEST</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0RX</name>
+          <description>SPI0 RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1RX</name>
+          <description>SPI1 RX</description>
+          <value>0x02</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0RX</name>
+          <description>UART0 RX</description>
+          <value>0x04</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1RX</name>
+          <description>UART1 RX</description>
+          <value>0x05</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>CANRX</name>
+          <description>CAN RX</description>
+          <value>0x06</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0RX</name>
+          <description>I2C0 RX</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1RX</name>
+          <description>I2C1 RX</description>
+          <value>0x08</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>ADC</name>
+          <description>ADC</description>
+          <value>0x09</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESRX</name>
+          <description>AES RX</description>
+          <value>0x10</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2SRX</name>
+          <description>I2S RX</description>
+          <value>0x1E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0TX</name>
+          <description>SPI0 TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1TX</name>
+          <description>SPI1 TX</description>
+          <value>0x22</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0TX</name>
+          <description>UART0 TX</description>
+          <value>0x24</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1TX</name>
+          <description>UART1 TX</description>
+          <value>0x25</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>CANTX</name>
+          <description>CAN TX</description>
+          <value>0x26</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0TX</name>
+          <description>I2C0 TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1TX</name>
+          <description>I2C1 TX</description>
+          <value>0x28</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESTX</name>
+          <description>AES TX</description>
+          <value>0x30</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2STX</name>
+          <description>I2S TX</description>
+          <value>0x3E</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_WAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_PER</name>
+        <description>Timeout Period Select.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_CLKDIV</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BURST_SIZE</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>DIS_IE</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IE</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>STATUS</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>STATUS</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IF</name>
+        <description>Count-to-Zero (CTZ) Interrupt Flag</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>RLD_IF</name>
+        <description>Reload Event Interrupt Flag.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>TO_IF</name>
+        <description>Time-Out Event Interrupt Flag.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRCRLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DSTRLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNTRLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>EN</name>
+        <description>Reload Enable. This bit should be set after the address reload registers have been programmed. This bit is automatically cleared to 0 when reload occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+<!--DMA DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral>
+   <name>FCR</name>
+   <description>Function Control Register.</description>
+   <baseAddress>0x40000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>FCTRL0</name>
+     <description>Function Control 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ERFO_RANGE_SEL</name>
+       <description>ERFO Frequency Range Select. Control ibias_gm_stage.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>KEYWIPE_SYS</name>
+       <description>Wipe System AES Key Register.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C0DGEN0</name>
+       <description>I2C0 SDA Pad Deglitcher enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0DGEN1</name>
+       <description>I2C0 SCL Pad Deglitcher enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN0</name>
+       <description>I2C1 SDA Pad Deglitcher enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN1</name>
+       <description>I2C1 SCL Pad Deglitcher enable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL0</name>
+     <description>Automatic Calibration 0.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ACEN</name>
+       <description>Auto-calibration Enable for HIRC96M.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACRUN</name>
+       <description>Autocalibration Run.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOAD</name>
+       <description>Load Trim.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GAIN_INV</name>
+       <description>Invert Gain.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not inverted.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>invert</name>
+         <description>Inverted.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ATOMIC</name>
+       <description>Start atomic autocal.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MU</name>
+       <description>Adaptation Gain Value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>TRIM</name>
+       <description>HIRC96M Trim Value determinged by Auto Calibration.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL1</name>
+     <description>Automatic Calibration 1.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INITTRIM</name>
+       <description>Initial Trim Setting fir HIRC96M Auto Calibration procedure.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL2</name>
+     <description>Automatic Calibration 2</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONECNT</name>
+       <description>Auto-callibration Done Counter Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>ACDIV</name>
+       <description>Auto-callibration Divide Factor.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCREFTRIM0</name>
+     <description>ADC Reference Trim 0 Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VREFP</name>
+       <description>Trimming code for VREFP output of reference buffer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VREFM</name>
+       <description>Trimming code for VREFM output of reference buffer.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VCM</name>
+       <description>Trimming code for VCM output of reference buffer.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>VX2_TUNE</name>
+       <description>COntrols tuning capacitor in fine DAC, offset binary.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCREFTRIM1</name>
+     <description>ADC Reference Trim 1 Control Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VREFP</name>
+       <description>Trimming code for VREFP output of reference buffer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VREFM</name>
+       <description>Trimming code for VREFM output of reference buffer.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VCM</name>
+       <description>Trimming code for VCM output of reference buffer.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>VX2_TUNE</name>
+       <description>COntrols tuning capacitor in fine DAC, offset binary.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCREFTRIM2</name>
+     <description>ADC Reference Trim 2 Control Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IDRV_1P25</name>
+       <description>Trimming code for reference buffer drive strength, 1.25V Reference.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IBOOST_1P25</name>
+       <description>Trimming value for extra drive current in reference buffer outputsm 1.25V Reference.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IDRV_2P048</name>
+       <description>Trimming code for reference buffer drive strength, 2.048V Reference.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IBOOST_2P048</name>
+       <description>Trimming value for extra drive current in reference buffer outputs, 2.048V Reference.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VCM</name>
+       <description>Trimming code for VCM output of reference buffer.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>VX2_TUNE</name>
+       <description>Controls tuning capacitor in fine DAC, offset binary.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ERFOKS</name>
+     <description>ERFO Kick Start Control Register.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CTRL</name>
+       <description>Kickstart Control for ERFO (XO32M)</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FCR Function Control Register.-->
+  <peripheral>
+   <name>FLC</name>
+   <description>Flash Memory Control.</description>
+   <prependToName>FLSH_</prependToName>
+   <baseAddress>0x40029000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Flash_Controller</name>
+    <description>Flash Controller interrupt.</description>
+    <value>23</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ADDR</name>
+     <description>Flash Write Address.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address for next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Flash Clock Divide. The clock (PLL0) is divided by this value to generate a 1 MHz clock for Flash controller.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000064</resetValue>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Flash Clock Divide. The clock is divided by this value to generate a 1MHz clock for flash controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Flash Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WR</name>
+       <description>Write.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="WR">
+       <name>ME</name>
+       <description>Mass Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="WR">
+       <name>PGE</name>
+       <description>Page Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WDTH</name>
+       <description>TBD</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERASE_CODE</name>
+       <description>Erase Code.  The ERASE_CODE must be set up property before erase operation can be initiated. These bits are automatically cleared after the operation is complete.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>erasePage</name>
+         <description>Enable Page Erase.</description>
+         <value>0x55</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>eraseAll</name>
+         <description>Enable Mass Erase. The debug port must be enabled.</description>
+         <value>0xAA</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PEND</name>
+       <description>Flash Pending.  When Flash operation is in progress (busy), Flash reads and writes will fail. When PEND is set, write to all Flash registers, with exception of the Flash interrupt register, are ignored.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LVE</name>
+       <description>Low Voltage enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNLOCK</name>
+       <description>Flash Unlock.  The correct unlock code must be written to these four bits before any Flash write or erase operation is allowed.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Flash Unlocked.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Flash Locked.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Flash Interrupt Register.</description>
+     <addressOffset>0x024</addressOffset>
+     <fields>
+      <field>
+       <name>DONE_IF</name>
+       <description>Flash Done Interrupt.  This bit is set to 1 upon Flash write or erase completion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AF_IF</name>
+       <description>Flash Access Fail.  This bit is set when an attempt is made to write the flash while the flash is busy or the flash is locked. This bit can only be set to 1 by hardware.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noerr</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PROG_PROT_ERR_IF</name>
+       <description>Program Protection Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noerr</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MASS_ER_PROT_ERR_IF</name>
+       <description>TBD</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noerr</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PAGE_ER_PROT_ERR_IF</name>
+       <description>TBD</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noerr</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PROT_AREA_PROT_ERR_IF</name>
+       <description>TBD</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noerr</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONE_IE</name>
+       <description>Flash Done Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AF_IE</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PROT_IE</name>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA[%s]</name>
+     <description>Flash Write Data.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACTRL</name>
+     <description>Access Control Register. Writing the ACNTL register with the following values in the order shown, allows read and write access to the system and user Information block: pflc-acntl = 0x3a7f5ca3; pflc-acntl = 0xa1e34f20; pflc-acntl = 0x9608b2c1. When unlocked, a write of any word will disable access to system and user information block. Readback of this register is always zero.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ACTRL</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR0</name>
+     <description>Access control.</description>
+     <addressOffset>0x80</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WELR0</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR0</name>
+     <description>Access control.</description>
+     <addressOffset>0x84</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RLR0</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR1</name>
+     <description>Access control.</description>
+     <addressOffset>0x88</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WELR1</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR1</name>
+     <description>Access control.</description>
+     <addressOffset>0x8C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RLR1</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR2</name>
+     <description>Access control.</description>
+     <addressOffset>0x90</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WELR2</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR2</name>
+     <description>Access control.</description>
+     <addressOffset>0x94</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RLR2</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR3</name>
+     <description>Access control.</description>
+     <addressOffset>0x98</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WELR3</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR3</name>
+     <description>Access control.</description>
+     <addressOffset>0x9C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RLR3</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR4</name>
+     <description>Access control.</description>
+     <addressOffset>0xA0</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WELR4</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR4</name>
+     <description>Access control.</description>
+     <addressOffset>0xA4</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RLR4</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR5</name>
+     <description>Access control.</description>
+     <addressOffset>0xA8</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WELR5</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR5</name>
+     <description>Access control.</description>
+     <addressOffset>0xAC</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RLR5</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FLC Flash Memory Control.-->
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x40000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SYSCTRL</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>SBUSARB</name>
+       <description>System bus arbitration scheme. These bits are used to select between Fixed burst arbitration and Round Robin scheme. The Round Robin scheme is selected by default.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>FPUS_DIS</name>
+       <description>Cortex M4 Floating Point Disable This bit is used to disable the floating-point unit of the Cortex-M4.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0_FLUSH</name>
+       <description>Code Cache Flush. This bit is used to flush the code caches and the instruction buffer of the Cortex-M4. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CCHK</name>
+       <description>Compute ROM Checksum. This bit is self-cleared when calculation is completed. Once set, software clearing this bit is ignored and the bit will remain set until the operation is completed.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SWD_DIS</name>
+       <description> Serial Wire Debug Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHKRES</name>
+       <description>ROM Checksum Result. This bit is valid when the checksum is done and the CCHK bit is cleared.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pass</name>
+         <description>ROM Checksum Correct.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fail</name>
+         <description>ROM Checksum Fail.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA">
+       <name>WDT</name>
+       <description>Watchdog Timer 0 Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR0</name>
+       <description>Timer 0 Reset. Setting this bit to 1 resets Timer 0 blocks.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR1</name>
+       <description>Timer 1 Reset. Setting this bit to 1 resets Timer 1 blocks.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR2</name>
+       <description>Timer 2 Reset. Setting this bit to 1 resets Timer 2 blocks.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART0</name>
+       <description>UART 0 Reset. Setting this bit to 1 resets all UART 0 blocks.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART1</name>
+       <description>UART 1 Reset. Setting this bit to 1 resets all UART 1 blocks.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI0</name>
+       <description>SPI 0 Reset. Setting this bit to 1 resets all SPI 0 blocks.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI1</name>
+       <description>SPI 1 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>I2C0</name>
+       <description>I2C 0 Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>CAN</name>
+       <description>CAN Reset.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TRNG</name>
+       <description>TRNG Reset. This reset is only available during the manufacture testing phase.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>ADC</name>
+       <description>ADC Reset.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SOFT</name>
+       <description>Soft Reset. Setting this bit to 1 resets everything except the CPU and the watchdog timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>PERIPH</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SYS</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>SYSCLK_DIV</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the PLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_SEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ERFO</name>
+         <description>The external 32 MHz input is used for the system clock.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INRO</name>
+         <description>8 kHz LIRC is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>The internal 100 MHz oscillator is used for the system clock.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBRO</name>
+         <description>The internal 7.3725 MHz oscillator is used for the system clock.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERTCO</name>
+         <description>External 32 kHz input is used for the system clock.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EXTCLK</name>
+         <description>External clock input is used for the system clock.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_RDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IPO_DIV</name>
+       <description>HIRC96M Source Clock Divider.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <description>Div 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <description>Div 2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <description>Div 4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV8</name>
+         <description>Div 8</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_EN</name>
+       <description>32 MHz Crystal Oscillator Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERFO_EN">
+       <name>IPO_EN</name>
+       <description>100 MHz Clock Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_EN">
+       <name>IBRO_EN</name>
+       <description>7.3725 MHz Clock Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_VS</name>
+       <description>7.3725 MHz High Frequency Internal Reference Clock Voltage Select. This register bit is used to select the power supply to the IBRO.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Vcor</name>
+         <description>VCore Supply</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1V</name>
+         <description>Dedicated 1V regulated supply.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_RDY</name>
+       <description>32 MHz Oscillator Ready</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>ERTCO_RDY</name>
+       <description>32 kHz Crystal Oscillator Ready</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>IPO_RDY</name>
+       <description>100 MHz Clock Ready.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>IBRO_RDY</name>
+       <description>7.3725 MHz HIRC Ready.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>INRO_RDY</name>
+       <description>8 kHz Low Frequency Reference Clock Ready.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>EXTCLK_RDY</name>
+       <description>External Clock GPIO0_28 AF2 Ready. Clock is ready when AF2 is enabled for GPIO0_28
+</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PM</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This three bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>backup</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO_WE</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wake Up Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wake Up Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>RTC_WE</name>
+       <description>RTC Alarm Wake Up Enable. This bit enables RTC alarm as wakeup source. If enabled, the desired RTC alarm must be configured via the RTC control registers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>TMR3_WE</name>
+       <description>TMR3 (LPTMR0) Wake Up Enable. This bit enables TMR3 IRQ as wakeup source</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>AINCOMP_WE</name>
+       <description>AINCOMP Wake Up Enable. This bit enables the AINCOMP Timer as wakeup source. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_BP</name>
+       <description>ERFO Bypass</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIV</name>
+     <description>Peripheral Clock Divider.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>AON_CLKDIV</name>
+       <description>Always-ON (AON) domain Clock Divider. These bits define the AON 
+domain clock divider.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <description>div4</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV8</name>
+         <description>div8</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV16</name>
+         <description>div16</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV32</name>
+         <description>div8</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0</name>
+       <description>GPIO0 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>DMA</name>
+       <description>DMA Clock Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI0</name>
+       <description>SPI 0 Clock Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI1</name>
+       <description>SPI 1 Clock Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART0</name>
+       <description>UART 0 Clock Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART1</name>
+       <description>UART 1 Clock Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C0</name>
+       <description>I2C 0 Clock Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR0</name>
+       <description>Timer 0 Clock Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR1</name>
+       <description>Timer 1 Clock Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR2</name>
+       <description>Timer 2 Clock Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>ADC</name>
+       <description>ADC Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C1</name>
+       <description>I2C 1 Clock Disable.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>PT</name>
+       <description>Pluse Train Clock Disable.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCTRL</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 2.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>RAMWS_EN</name>
+       <description>System RAM Wait State enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM0LS_EN</name>
+       <description>System RAM 0 Light Sleep mode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM1LS_EN</name>
+       <description>System RAM 1 Light Sleep mode.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2LS_EN</name>
+       <description>System RAM 2 Light Sleep mode.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3LS_EN</name>
+       <description>System RAM 3 Light Sleep mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0LS_EN</name>
+       <description>Internal Cache Controller RAM Light Sleep mode.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMLS_EN</name>
+       <description>ROM Light Sleep mode.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMZ</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM Block 0 Zeroization.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM1</name>
+       <description>System RAM Block 1 Zeroization.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM2</name>
+       <description>System RAM Block 2 Zeroization.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAMCB</name>
+       <description>System RAM Check Bit Block Zeroization.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICC0</name>
+       <description>Internal Cache Controller Data and Tag RAM Zeroization.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSST</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICELOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>I2C1</name>
+       <description>I2C1 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>PT</name>
+       <description>PT Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AES</name>
+       <description>AES Reset.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AC</name>
+       <description>AC Reset.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2S</name>
+       <description>I2S Reset.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TRNG</name>
+       <description>TRNG Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="TRNG">
+       <name>WDT</name>
+       <description>Watchdog Timer 0 Disable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="TRNG">
+       <name>CAN</name>
+       <description>CAN Clock Disable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="TRNG">
+       <name>AES</name>
+       <description>AES Clock Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="TRNG">
+       <name>AES_KEY</name>
+       <description>AES Keys Clock Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="TRNG">
+       <name>I2S</name>
+       <description>I2S Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVENTEN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Enable RXEV pin event. When this bit is set, RXEV event from the CPU is output to GPIO1.9.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO1.9.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REVISION</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSIE</name>
+     <description>System Status Interrupt Enable Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEUNLOCK</name>
+       <description>ARM ICE Unlock Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCERR</name>
+     <description>ECC Error Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0_1</name>
+       <description>ECC System RAM0 or RAM1 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>ECC System RAM2 Error Flag. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>ECC System RAM3 Error Flag. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0</name>
+       <description>ECC ICACHE Error Flag. Write 1 to clear.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH0</name>
+       <description>ECC Flash 0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH1</name>
+       <description>ECC Flash 1 Error Flag. Write 1 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCCED</name>
+     <description>ECC Not Double Error Detect Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0_1</name>
+       <description>ECC System RAM0 or RAM1 Not Double Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>ECC System RAM2 Not Double Error Flag. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>ECC System RAM3 Not Double Error Flag. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0</name>
+       <description>ECC ICACHE Not Double Error Flag. Write 1 to clear.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH0</name>
+       <description>ECC Flash 0 Not Double Error Flag. Write 1 to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH1</name>
+       <description>ECC Flash 1 Not Double Error Flag. Write 1 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCIE</name>
+     <description>ECC IRQ Enable Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0_1</name>
+       <description>System RAM0 or RAM1 ECC Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>System RAM2 ECC Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>System RAM3 ECC Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0</name>
+       <description>ICACHE ECC Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH0</name>
+       <description>Flash 0 ECC Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH1</name>
+       <description>Flash 1 ECC Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCADDR</name>
+     <description>ECC Error Address Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ERRADDR</name>
+       <description>Error Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCR Global Control Registers.-->
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x40008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN0</name>
+     <description>GPIO Function Enable Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_SET</name>
+     <description>GPIO Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_OUT bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_IN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTMODE</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTMODE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTPOL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTPOL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INEN</name>
+     <description>GPIO Input Enable</description>
+     <addressOffset>0x30</addressOffset>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_INTFL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WKEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DUALEDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DUALEDGE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL0</name>
+     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL0</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL1</name>
+     <description>GPIO Input Mode Config 2. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL1</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_SET</name>
+     <description>GPIO Alternate Function Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN2</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_SET</name>
+     <description>GPIO Alternate Function 2 Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN2 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_CLR</name>
+     <description>GPIO Wake Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN2 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x7C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN3</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN3</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN3_SET</name>
+     <description>GPIO Alternate Function 3 Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN3 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x84</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN3_CLR</name>
+     <description>GPIO Wake Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN3 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x88</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HYSEN</name>
+     <description>GPIO Input Hysteresis Enable.</description>
+     <addressOffset>0xA8</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_HYSEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SRSEL</name>
+     <description>GPIO Slew Rate Enable Register.</description>
+     <addressOffset>0xAC</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_SRSEL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>FAST</name>
+         <description>Fast Slew Rate selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SLOW</name>
+         <description>Slow Slew Rate selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS0</name>
+     <description>GPIO Drive Strength  Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS0</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ld</name>
+         <description>GPIO port pin is in low-drive mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hd</name>
+         <description>GPIO port pin is in high-drive mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PS</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VSSEL</name>
+     <description>GPIO Voltage Select.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GPIO0 Individual I/O for each GPIO-->
+  <peripheral>
+   <name>I2C0</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>I2C</groupName>
+   <baseAddress>0x4001D000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2C0</name>
+    <description>I2C0 IRQ</description>
+    <value>13</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>I2C Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable I2C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable I2C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave_mode</name>
+         <description>Slave Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master_mode</name>
+         <description>Master Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_EN</name>
+       <description>General Call Address Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Ignore Gneral Call Address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Acknowledge general call address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_EN</name>
+       <description>Interactive Receive Mode.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interactive Receive Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interactive Receive Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_ACK</name>
+       <description>Data Acknowledge. This bit defines the acknowledge bit returned by the I2C receiver while IRXM = 1 HW forces ACK to 0 when IRXM = 0.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ack</name>
+         <description>return ACK (pulling SDA LOW).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>return NACK (leaving SDA HIGH).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_OUT</name>
+       <description>SCL Output. This bits control SCL output when SWOE =1.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_scl_low</name>
+         <description>Drive SCL low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_scl</name>
+         <description>Release SCL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDA_OUT</name>
+       <description>SDA Output. This bits control SDA output when SWOE = 1. </description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_sda_low</name>
+         <description>Drive SDA low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_sda</name>
+         <description>Release SDA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL</name>
+       <description>SCL status. This bit reflects the logic gate of SCL signal. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDA</name>
+       <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BB_MODE</name>
+       <description>Software Output Enable.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>outputs_disable</name>
+         <description>I2C Outputs SCLO and SDAO disabled. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputs_enable</name>
+         <description>I2C Outputs SCLO and SDAO enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read. This bit reflects the R/W bit of an address match (AMI = 1) or general call match (GCI = 1). This bit is valid 3 cycles after the relevant interrupt bit is set.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKSTR_DIS</name>
+       <description>This bit will disable slave clock stretching when set.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Slave clock stretching enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Slave clock stretching disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ONE_MST_MODE</name>
+       <description>SCL Push-Pull Mode. This bit controls whether SCL is operated in a the I2C standard open-drain mode, or in a non-standard push-pull mode where the Hi-Z output isreplaced with Drive-1. The non-standard mode should only be used when operating as a master and communicating with slaves that are guaranteed to never drive SCL low. </description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Standard open-drain operation:
+					drive low for 0, Hi-Z for 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Non-standard push-pull operation:
+					drive low for 0, drive high for 1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HS_EN</name>
+       <description>High speed mode enable</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>Bus Status.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>I2C Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>I2C Bus Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>RX empty.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX Full.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX Empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>TX Full.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_BUSY</name>
+       <description>Clock Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_actively_driving_scl_clock</name>
+         <description>Device not actively driving SCL clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>actively_driving_scl_clock</name>
+         <description>Device operating as master and actively driving SCL clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL0</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <name>INT_FL0_Done</name>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Interactive Receive Interrupt.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave General Call Address Match Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave Address Match Interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Receive Threshold Interrupt. This bit is automaticcaly cleared when RX_FIFO is below the threshold level.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. RX_FIFO equal or more bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>Transmit Threshold Interrupt. This bit is automaticcaly cleared when TX_FIFO is above the threshold level.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP Interrupt.</description>
+       <bitRange>[6:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Address Acknowledge Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Arbritation error Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>timeout Error Interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Address NACK Error Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Data NACK Error Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Do Not Respond Error Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Start Error Interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Stop Error Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>Transmit Lock Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN0</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when DONE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Description not available.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when RX_MODE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave mode general call address match received input enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when GEN_CTRL_ADDR = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave mode incoming address match interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when ADDR_MATCH = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Above Treshold Level Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Below Treshold Level Interrupt Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Stop Interrupt Enable</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when STOP = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Received Address ACK from Slave Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Master Mode Arbitration Lost Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>Timeout Error Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Master Mode Address NACK Received Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Master Mode Data NACK Received Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Slave Mode Do Not Respond Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Out of Sequence START condition detected interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Out of Sequence STOP condition detected interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>TX FIFO Locked Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL1</name>
+     <description>Interrupt Status Register 1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt. When operating as a slave receiver, this bit is set when you reach the first data bit and the RX FIFO and shift register are both full.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt. When operating as a slave transmitter, this bit is set when you reach the first data bit and the TX FIFO is empty and the master is still asking for more data (i.e the master hasn't sent a NACK yet).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Status Flag.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN1</name>
+     <description>Interrupt Staus Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOLEN</name>
+     <description>FIFO Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RX_DEPTH</name>
+       <description>Receive FIFO Length.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DEPTH</name>
+       <description>Transmit FIFO Length.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL0</name>
+     <description>Receive Control Register 0.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>DNR</name>
+       <description>Do Not Respond.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Always respond to address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>not_respond_rx_fifo_empty</name>
+         <description>Do not respond to address match when RX_FIFO is not empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Receive FIFO Flush. This bit is automatically cleared to 0 after the operation. Setting this bit to 1 will affect RX_FIFO status.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush RX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_LVL</name>
+       <description>Receive FIFO Threshold. These bits define the RX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL1</name>
+     <description>Receive Control Register 1.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Receive Count Bits. These bits define the number of bytes to be received in a transaction, except for the case RXCNT = 0. RXCNT = 0 means 256 bytes to be received in a transaction.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Receive FIFO Count. These bits reflect the number of byte in the RX_FIFO. These bits are flushed when I2CEN = 0.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL0</name>
+     <description>Transmit Control Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_MODE</name>
+       <description>Transmit FIFO Preaload Mode. Setting this bit will allow for high speed application to preload the transmit FIFO prior to Slave Address Match.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TX_READY_MODE</name>
+       <description>Transmit FIFO Ready Manual Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW control of I2CTXRDY enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW control of I2CTXRDY disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO General Call Address Match Auto Flush Disable.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Write Auto Flush Disable.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Read Auto Flush Disable.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NACK_FLUSH_DIS</name>
+       <description>TX FIFO received NACK Auto Flush Disable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Transmit FIFO Flush. This bit is automatically cleared to 0 after the operation.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush TX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_VAL</name>
+       <description>Transmit FIFO Threshold. These bits define the TX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL1</name>
+     <description>Transmit Control Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_RDY</name>
+       <description>Transmit FIFO Preload Ready.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Transmit FIFO Count. These bits reflect the number of bytes in the TX_FIFO.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MSTCTRL</name>
+     <description>Master Control Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Setting this bit to 1 will start a master transfer.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>RESTART</name>
+       <description>Setting this bit to 1 will generate a repeated START.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Setting this bit to 1 will generate a STOP condition.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>EX_ADDR_EN</name>
+       <description>Slave Extend Address Select.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKLO</name>
+     <description>Clock Low Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock low. In master mode, these bits define the SCL low period. In slave mode, these bits define the time SCL will be held low after data is outputted.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKHI</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>HI</name>
+       <description>Clock High. In master mode, these bits define the SCL high period.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HSCLK</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock Low. This field sets the Hs-Mode clock low count. In Slave mode, this is the time SCL is held low after data is output on SDA.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Clock High. This field sets the Hs-Mode clock high count. In Slave mode, this is the time SCL is held high after data is output on SDA</description>
+       <bitRange>[15:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TIMEOUT</name>
+     <description>Timeout Register</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_TO_VAL</name>
+       <description>Timeout</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>SLAVE_MULTI[%s]</name>
+     <description>Slave Address Register.</description>
+     <alternateRegister>SLAVE0</alternateRegister>
+     <addressOffset>0x4C</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Slave Address.</description>
+       <bitRange>[9:0]</bitRange>
+      </field>
+      <field>
+       <name>DIS</name>
+       <description>Slave Disable.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>EXT_ADDR_EN</name>
+       <description>Extended Address Select.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLAVE0</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE1</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x50</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE2</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x54</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE3</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x58</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2C0 Inter-Integrated Circuit.-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C1</name>
+   <description>Inter-Integrated Circuit. 1</description>
+   <baseAddress>0x4001E000</baseAddress>
+   <interrupt>
+    <name>I2C1</name>
+    <description>I2C1 IRQ</description>
+    <value>36</value>
+   </interrupt>
+  </peripheral>
+<!--I2C1 Inter-Integrated Circuit. 1-->
+  <peripheral>
+   <name>I2S</name>
+   <description>Inter-IC Sound Interface.</description>
+   <groupName>I2S</groupName>
+   <baseAddress>0x40060000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2S</name>
+    <description>I2S IRQ</description>
+    <value>99</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0CH0</name>
+     <description>Global mode channel.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>LSB_FIRST</name>
+       <description>LSB Transmit Receive First.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_FILT</name>
+       <description>PDM Filter.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_EN</name>
+       <description>PDM Enable.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>USEDDR</name>
+       <description>DDR.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_INV</name>
+       <description>Invert PDM.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_MODE</name>
+       <description>SCK Select.</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>WS_POL</name>
+       <description>WS polarity select. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB_LOC</name>
+       <description>MSB location. </description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ALIGN</name>
+       <description>Align to MSB or LSB.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EXT_SEL</name>
+       <description>External SCK/WS selection.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>STEREO</name>
+       <description>Stereo mode of I2S.</description>
+       <bitRange>[13:12]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WSIZE</name>
+       <description>Data size when write to FIFO.</description>
+       <bitRange>[15:14]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable. </description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable. </description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Flushes the TX/RX FIFO buffer. </description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RST</name>
+       <description>Write 1 to reset channel. </description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_LSB</name>
+       <description>Bit Field Control. </description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>depth of receive FIFO for threshold interrupt generation. </description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1CH0</name>
+     <description>Local channel Setup.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>BITS_WORD</name>
+       <description>I2S word length.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>I2S clock enable.</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SMP_SIZE</name>
+       <description>I2S sample size length.</description>
+       <bitRange>[13:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLKSEL</name>
+       <description>I2S Clock Select.</description>
+       <bitRange>[14:14]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ADJUST</name>
+       <description>LSB/MSB Justify.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>I2S clock frequency divisor.</description>
+       <bitRange>[31:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FILTCH0</name>
+     <description>Filter.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>FILTER</name>
+       <description>Filter</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMACH0</name>
+     <description>DMA Control.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DMA_TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger.</description>
+       <bitRange>[6:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA channel enable.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_THD_VAL</name>
+       <description>RX FIFO Level DMA Trigger.</description>
+       <bitRange>[14:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA channel enable.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Number of data word in the TX FIFO.</description>
+       <bitRange>[23:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Number of data word in the RX FIFO.</description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOCH0</name>
+     <description>I2S Fifo.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>ISR Status.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Status for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Status for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Status for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Status for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Enable for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Enable for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Enable for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Enable for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EXTSETUP</name>
+     <description>Ext Control.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>EXT_BITS_WORD</name>
+       <description>Word Length for ch_mode.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wakeup Enable.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>CH</name>
+       <description>Enable wake for each channel.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wakeup Flags.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>CH</name>
+       <description>Wake flag for each channel.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2S Inter-IC Sound Interface.-->
+  <peripheral>
+   <name>ICC0</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x4002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x800</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>INFO</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SZ</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCH</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEM</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ICC0 Instruction Cache Controller Registers-->
+  <peripheral>
+   <name>MCR</name>
+   <description>Misc Control.</description>
+   <baseAddress>0x40106C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RST</name>
+     <description>Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>TMR3</name>
+       <description>TMR3 (LPTMR0) Reset. Setting this bit to 1 resets TMR3 (LPTMR0) block.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RTC</name>
+       <description>Real Time Clock Reset.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>System CLock Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ERTCO_PD</name>
+       <description>32kHz Crystal Oscillator Power Down. Setting this bit powers down the ERTCO analog circuitry.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>32kHz Crystal Oscillator Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AINCOMP</name>
+     <description>AIN Comparator Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>PD</name>
+       <description>AIN Compatator Power Down control. Before AIN Comparator is powered on, the positive and negative inputs selects for the comparator should be configured.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>HYST</name>
+       <description>AIN Comparator Hysteresis control.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>NSEL_COMP0</name>
+       <description>Negative input select for Comparator 0. No more than 1 input channel can be selected at any time. Corresponding GPIO must be configured for AF4.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>PSEL_COMP0</name>
+       <description>Positive input select for AIN Comparator 0. No more than 1 input channel can be selected at any time. Corresponding GPIO must be configured for AF4.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>NSEL_COMP1</name>
+       <description>Negative input select for Comparator 1. No more than 1 input channel can be selected at any time. Corresponding GPIO must be configured for AF4.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>PSEL_COMP1</name>
+       <description>Positive input select for AIN Comparator 1. No more than 1 input channel can be selected at any time. Corresponding GPIO must be configured for AF4.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPIOCTRL</name>
+     <description>Low Power Peripheral IO Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>TMR3_IN</name>
+       <description>Enable control for TMR3 (LPTMR0) input. If enabled, the associated GPIO 
+input is connected to the peripheral; otherwise the input to the 
+peripheral is forced low.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR3_OUT</name>
+       <description>Enable control for LPTMR0 output. If enabled and peripheral clock 
+also enabled (PCLKDIS.LPTMR0), the peripheral output controls the 
+associated GPIO in output mode; otherwise GPIO control comes 
+from GPIO control module.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR3_OUT_N</name>
+       <description>Enable control for TMR3 (LPTMR0) complementary output. If enabled and 
+peripheral clock also enabled (PCLKDIS.TMR3), the peripheral 
+output controls the associated GPIO in output mode; otherwise GPIO 
+control comes from GPIO control module</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS</name>
+     <description>Peripheral Clock Disable Register.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>TMR3</name>
+       <description>TMR3 (LPTMR0) Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AESKEY</name>
+     <description>AES Key Pointer and Status Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>PTR</name>
+       <description>AES Key Pointer/Status</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCCFG0</name>
+     <description>ADC Config Register 0.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>LP_EXTCLK_EN</name>
+       <description>Enable input driver for LP External Clock.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EXT_REF</name>
+       <description>External Reference Select.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INT_REF</name>
+       <description>Internal Reference Select Option, when not using External Reference.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCCFG1</name>
+     <description>ADC Config Register 1.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>THRU_PAD_SW_EN</name>
+       <description>Enable the MUX switch, switch placed in padring, used in the buffer path. Each pad has a separate THRU_PAD_SW_EN signal.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>AIN_INP_EN</name>
+       <description>AIN Input Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>THRU_EN</name>
+       <description>Enable the MUX switches, switch placed in analog_sys, used in the buffer path.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AMP_EN</name>
+       <description>Enable the buffer amplifier used in the buffer path.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AMP_RRI_EN</name>
+       <description>Enable the buffer amplifier to operatore for Rail to Rail Input, Active High. If it is low, only NMOS Input pair will be operating which would restrict the range,</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DIVSEL</name>
+       <description>Select one of the three different signal paths.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCCFG2</name>
+     <description>ADC Config Register 2.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>VREFM</name>
+       <description>Trimming code for VREFM output of reference buffer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VREFP</name>
+       <description>Trimming code for VREFP output of reference buffer.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>IDRV</name>
+       <description>Trimming code for reference buffer drive strength.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>VCM</name>
+       <description>Trimming code for VCM output of reference buffer.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>D_IBOOST</name>
+       <description>Trimming value for extra drive current in reference buffer outputs</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--MCR Misc Control.-->
+  <peripheral>
+   <name>PT</name>
+   <description>Pulse Train</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C020</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0010</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RATE_LENGTH</name>
+     <description>Pulse Train Configuration</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>rate_control</name>
+       <description>Pulse Train Enable and Rate Control. Set to 0 to disable the Pulse Train.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>27</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>mode</name>
+       <description>Pulse Train Output Mode/Train Length</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>32_BIT</name>
+         <description>Pulse train, 32 bit pattern.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SQUARE_WAVE</name>
+         <description>Square wave mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_BIT</name>
+         <description>Pulse train, 2 bit pattern.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_BIT</name>
+         <description>Pulse train, 3 bit pattern.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_BIT</name>
+         <description>Pulse train, 4 bit pattern.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5_BIT</name>
+         <description>Pulse train, 5 bit pattern.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_BIT</name>
+         <description>Pulse train, 6 bit pattern.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7_BIT</name>
+         <description>Pulse train, 7 bit pattern.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_BIT</name>
+         <description>Pulse train, 8 bit pattern.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9_BIT</name>
+         <description>Pulse train, 9 bit pattern.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_BIT</name>
+         <description>Pulse train, 10 bit pattern.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11_BIT</name>
+         <description>Pulse train, 11 bit pattern.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_BIT</name>
+         <description>Pulse train, 12 bit pattern.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13_BIT</name>
+         <description>Pulse train, 13 bit pattern.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14_BIT</name>
+         <description>Pulse train, 14 bit pattern.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15_BIT</name>
+         <description>Pulse train, 15 bit pattern.</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_BIT</name>
+         <description>Pulse train, 16 bit pattern.</description>
+         <value>16</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>17_BIT</name>
+         <description>Pulse train, 17 bit pattern.</description>
+         <value>17</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>18_BIT</name>
+         <description>Pulse train, 18 bit pattern.</description>
+         <value>18</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>19_BIT</name>
+         <description>Pulse train, 19 bit pattern.</description>
+         <value>19</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>20_BIT</name>
+         <description>Pulse train, 20 bit pattern.</description>
+         <value>20</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>21_BIT</name>
+         <description>Pulse train, 21 bit pattern.</description>
+         <value>21</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>22_BIT</name>
+         <description>Pulse train, 22 bit pattern.</description>
+         <value>22</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>23_BIT</name>
+         <description>Pulse train, 23 bit pattern.</description>
+         <value>23</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>24_BIT</name>
+         <description>Pulse train, 24 bit pattern.</description>
+         <value>24</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>25_BIT</name>
+         <description>Pulse train, 25 bit pattern.</description>
+         <value>25</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>26_BIT</name>
+         <description>Pulse train, 26 bit pattern.</description>
+         <value>26</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>27_BIT</name>
+         <description>Pulse train, 27 bit pattern.</description>
+         <value>27</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>28_BIT</name>
+         <description>Pulse train, 28 bit pattern.</description>
+         <value>28</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>29_BIT</name>
+         <description>Pulse train, 29 bit pattern.</description>
+         <value>29</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30_BIT</name>
+         <description>Pulse train, 30 bit pattern.</description>
+         <value>30</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>31_BIT</name>
+         <description>Pulse train, 31 bit pattern.</description>
+         <value>31</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRAIN</name>
+     <description>Write the repeating bit pattern that is shifted out, LSB first, when configured in Pulse Train mode. See PT_RATE_LENGTH.mode for setting the length.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>LOOP</name>
+     <description>Pulse Train Loop Count</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>count</name>
+       <description>Number of loops for this pulse train to repeat.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>delay</name>
+       <description>Delay between loops of the Pulse Train in PT Peripheral Clock cycles</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>12</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESTART</name>
+     <description> Pulse Train Auto-Restart Configuration.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt_x_select</name>
+       <description>Auto-Restart PT X Select</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_x_loop_exit</name>
+       <description>Enable Auto-Restart on PT X Loop Exit</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt_y_select</name>
+       <description>Auto-Restart PT Y Select</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_y_loop_exit</name>
+       <description>Enable Auto-Restart on PT Y Loop Exit</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PT Pulse Train-->
+  <peripheral derivedFrom="PT">
+   <name>PT1</name>
+   <description>Pulse Train 1</description>
+   <baseAddress>0x4003C030</baseAddress>
+  </peripheral>
+<!--PT1 Pulse Train 1-->
+  <peripheral derivedFrom="PT">
+   <name>PT2</name>
+   <description>Pulse Train 2</description>
+   <baseAddress>0x4003C040</baseAddress>
+  </peripheral>
+<!--PT2 Pulse Train 2-->
+  <peripheral derivedFrom="PT">
+   <name>PT3</name>
+   <description>Pulse Train 3</description>
+   <baseAddress>0x4003C050</baseAddress>
+  </peripheral>
+<!--PT3 Pulse Train 3-->
+  <peripheral>
+   <name>PTG</name>
+   <description>Pulse Train Generation</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0018</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>PT</name>
+    <description>Pulse Train IRQ</description>
+    <value>59</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ENABLE</name>
+     <description>Global Enable/Disable Controls for All Pulse Trains</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Enable/Disable control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Enable/Disable control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Enable/Disable control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Enable/Disable control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESYNC</name>
+     <description>Global Resync (All Pulse Trains) Control</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Resync control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Resync control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Resync control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Resync control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STOP_INTFL</name>
+     <description>Pulse Train Stop Interrupt Flags</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STOP_INTEN</name>
+     <description>Pulse Train Stop Interrupt Enable/Disable</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_EN</name>
+     <description>Pulse Train Global Safe Enable.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_DIS</name>
+     <description>Pulse Train Global Safe Disable.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTFL</name>
+     <description>Pulse Train Ready Interrupt Flags</description>
+     <addressOffset>0x0018</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Ready Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Ready Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Ready Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Ready Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTEN</name>
+     <description>Pulse Train Ready Interrupt Enable/Disable</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Ready Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Ready Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Ready Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Ready Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PTG Pulse Train Generation-->
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x40106800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>LPCTRL</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0RET_EN</name>
+       <description>System RAM 0 retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 0 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM1RET_EN</name>
+       <description>System RAM 1 retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 1 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM2RET_EN</name>
+       <description>System RAM 2 retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 2 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM3RET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OVR</name>
+       <description>Operating Voltage Range. The Operating Voltage Range 
+bits (OVR) determine the operating range for VCORE 
+domain.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_9V</name>
+         <description>0.9V</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0V</name>
+         <description>1.0V</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1V</name>
+         <description>1.1V</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORE_DET_BYPASS</name>
+       <description>Block Auto Detect. Prevent the power sequencer from taking time to detect whether an external power source exists on the VCORE pin. Should always be set to 1 if VCORE is not provided from an external source.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable auto detection.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable auto detection.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FVDD_EN</name>
+       <description>Flash VDD Enable. FOrce the flash VDD to remain enabled during LP modes.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Flash VDDIO Not Forced.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Flash VDDIO Force on.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RETREG_EN</name>
+       <description>Retention Regulator Enable. This bit controls the retention regulator in BACKUP mode. This bit should be 1 all the time if user wants to use retention regulator.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STORAGE_EN</name>
+       <description>STORAGE mode enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FASTWK_EN</name>
+       <description>Fast Wake-Up Mode. This bit enables fast wake-up from DeepSleep mode.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BG_DIS</name>
+       <description>Bandgap OFF. This controls the System Bandgap in DeepSleep mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>Bandgap is always ON.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>Bandgap is OFF in DeepSleep mode (default).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREPOR_DIS</name>
+       <description>VCORE Power-On Reset Monitor Disable. This bit controls the Power-On Reset monitor on VDDC supply in DeepSleep and BACKUP mode.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDO_DIS</name>
+       <description>Disable Main LDO. This bit initializes to 1 until the power sequencer determines that no external power source exists on the VCORE pin. At that time, this bit is automatically cleared to 0. If an external power source is detected on the VCORE pin, then this bit will remain at 1. </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VCORE_EXT</name>
+       <description>Use external VCORE for 1V supply.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VCOREMON_DIS</name>
+       <description>VCORE Monitor Disable. This bit controls the power monitor on the VCORE supply in all operating modes.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VDDAMON_DIS</name>
+       <description>VDDA Monitor Disable. This bit controls the power monitor on the Analog supply in all operating modes.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PORVDDMON_DIS</name>
+       <description>VCORE Power-On Reset Monitor Disable. This bit controls the Power-On Reset monitor on VCORE supply in all operating modes.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VBBMON_DIS</name>
+       <description>VDDA Monitor Disable. This bit controls the power monitor on the Analog supply in all operating modes.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INRO_EN</name>
+       <description>Allow LIRC80K to remain on in all Power modes. If STORAGE is set, this bit has no effect.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>Allow LIRC32K to remain on in all Power modes. If STORAGE is set, this bit has no effect.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKFL0</name>
+     <description>Low Power I/O Wakeup Status Flag Register 0. This register indicates the low power wakeup status for GPIO0.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEFL</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN0</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWKFL</name>
+     <description>Low Power Peripheral Wakeup Status Flag Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>TMR3</name>
+       <description>TMR3 (LPTMR0) Wakeup Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP0</name>
+       <description>Analog Input Comparator 0 Wakeup Flag.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP1</name>
+       <description>Analog Input Comparator 1 Wakeup Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP0_ST</name>
+       <description>Analog Input Comparator 0 Status.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP1_ST</name>
+       <description>Analog Input Comparator 1 Status.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BACKUP</name>
+       <description>Backup Mode Wakeup Flag.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWKEN</name>
+     <description>Low Power Peripheral Wakeup Enable Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>LPTMR0</name>
+       <description>LPTMR0 Wakeup Enable. This bit allows wakeup from the LPTIMER0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP0</name>
+       <description> AINCOMP0 Wakeup Enable. This bit allows wakeup from the AINCOMP0.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP1</name>
+       <description> AINCOMP1 Wakeup Enable. This bit allows wakeup from the AINCOMP1.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPMEMSD</name>
+     <description>Low Power Memory Shutdown Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM block 0 Shut Down.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>Systen RAM block 1 Shut Down.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>System RAM block 2 Shut Down.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>System RAM block 2 Shut Down.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PWRSEQ Power Sequencer / Low Power Control Register.-->
+  <peripheral>
+   <name>RTC</name>
+   <description>Real Time Clock and Alarm.</description>
+   <baseAddress>0x40106000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>RTC</name>
+    <description>RTC interrupt.</description>
+    <value>3</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC</name>
+       <description>Sub-Seconds Counter (12-bit).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TODA</name>
+     <description>Time-of-day Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-day Alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSECA</name>
+     <description>RTC sub-second alarm.  This register contains the reload value for the sub-second alarm.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>This register contains the reload value for the sub-second alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>RTC Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Real Time Clock Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM_IE</name>
+       <description>Alarm Time-of-Day Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM_IE</name>
+       <description>Alarm Sub-second Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>RTC Busy. This bit is set to 1 by hardware when changes to RTC registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>RTC Ready. This bit is set to 1 by hardware when the RTC count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the RTC count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY_IE</name>
+       <description>RTC Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-Day Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>Sub-second Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_SEL</name>
+       <description>Frequency Output Selection. When SQE=1, these bits specify the output frequency on the SQW pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq1Hz</name>
+         <description>1 Hz (Compensated).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq512Hz</name>
+         <description>512 Hz (Compensated).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq4KHz</name>
+         <description>4 KHz.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clkDiv8</name>
+         <description>RTC Input Clock / 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_EN</name>
+       <description>Asynchronous Counter Read Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_EN</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical RTC bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIM</name>
+     <description>RTC Trim Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>RTC Trim. This register contains the 2's complement value that specifies the trim resolution. Each increment or decrement of the bit adds or subtracts 1ppm at each 4KHz clock value, with a maximum correction of +/- 127ppm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VRTC_TMR</name>
+       <description>VBAT Timer Value. When RTC is running off of VBAT, this field is incremented every 32 seconds.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>RTC Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>FILTER_EN</name>
+       <description>Enables analog deglitch filter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_SEL</name>
+       <description>If IBIAS_EN is 1, selects 4x,2x mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HYST_EN</name>
+       <description>Enables high current hysteresis buffer.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_EN</name>
+       <description>Enables higher 4x,2x current modes.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYPASS</name>
+       <description>RTC Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SQW_32K</name>
+       <description>RTC 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--RTC Real Time Clock and Alarm.-->
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x40000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SISTAT</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>MAGIC</name>
+       <description>Magic Word Validation. This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>magicNotSet</name>
+         <description>Magic word was not set (OTP has not been initialized properly).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>magicSet</name>
+         <description>Magic word was set (OTP contains valid settings).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRCERR</name>
+       <description>CRC Error Status. This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No CRC errors occurred during the read of the OTP memory block.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>A CRC error occurred while reading the OTP. The address of the failure location in the OTP memory is stored in the ERRADDR register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USER_MAGIC</name>
+       <description>User Magic Word Validation. This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>userMagicNotSet</name>
+         <description>User magic word was not set (OTP has not been initialized properly).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>userMagicSet</name>
+         <description>User magic word was set (OTP contains valid settings).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SIADDR</name>
+     <description>System Initialization Address Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ERRADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIR System Initialization Registers.-->
+  <peripheral>
+   <name>SPI0</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x40046000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>16</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FIFO32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>FIFO16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>FIFO8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Start Select Control. Used in Master mode to control the behavior of the Slave Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DEASSERT</name>
+         <description>SPI De-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ASSERT</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_ACTIVE</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3</name>
+         <description>SS3 is selected.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Rising_Edge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Falling_Edge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLK_FB_INV</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1</name>
+         <description>1 bits per character.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2</name>
+         <description>2 bits per character.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3</name>
+         <description>3 bits per character.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4</name>
+         <description>4 bits per character.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5</name>
+         <description>5 bits per character.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6</name>
+         <description>6 bits per character.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7</name>
+         <description>7 bits per character.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8</name>
+         <description>8 bits per character.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9</name>
+         <description>9 bits per character.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10</name>
+         <description>10 bits per character.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11</name>
+         <description>11 bits per character.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12</name>
+         <description>12 bits per character.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13</name>
+         <description>13 bits per character.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14</name>
+         <description>14 bits per character.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15</name>
+         <description>15 bits per character.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin (s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_POL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3_high</name>
+         <description>SS3 active high.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSTIME</name>
+     <description>Register for controlling SPI peripheral/Slave Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PRE</name>
+       <description>Slave Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POST</name>
+       <description>Slave Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>AFP_FCD</name>
+       <description>AFP FCD.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPI0 SPI peripheral.-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI1</name>
+   <description>SPI peripheral. 1</description>
+   <baseAddress>0x40047000</baseAddress>
+   <interrupt>
+    <name>SPI1</name>
+    <description>SPI1 IRQ</description>
+    <value>17</value>
+   </interrupt>
+  </peripheral>
+<!--SPI1 SPI peripheral. 1-->
+  <peripheral>
+   <name>TMR</name>
+   <description>Low-Power Configurable Timer</description>
+   <baseAddress>0x40010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR</name>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Timer Counter Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>The current count value for the timer. This field increments as the timer counts.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Timer Compare Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>Timer PWM Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PWM</name>
+       <description>Timer PWM Match:
+                In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
+                In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Timer Interrupt Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ_A</name>
+       <description>Interrupt Flag for Timer A.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_A</name>
+       <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_A</name>
+       <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IRQ_B</name>
+       <description>Interrupt Flag for Timer B.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_B</name>
+       <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_B</name>
+       <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MODE_A</name>
+       <description>Mode Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_A</name>
+       <description>Clock Divider Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_A</name>
+       <description>Timer Polarity for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_A</name>
+       <description>PWM Synchronization Mode for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_A</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_A</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_A</name>
+       <description>PWM Phase A-Prime Output Disable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_A</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Write 1 to Enable CLK_TMR for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_A</name>
+       <description>Enable for Timer A</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MODE_B</name>
+       <description>Mode Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_B</name>
+       <description>Clock Divider Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_B</name>
+       <description>Timer Polarity for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_B</name>
+       <description>PWM Synchronization Mode for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_B</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_B</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_B</name>
+       <description>PWM Phase A-Prime Output Disable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_B</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Write 1 to Enable CLK_TMR for Timer B</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_B</name>
+       <description>Enable for Timer B</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO_A</name>
+       <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_A</name>
+       <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>LO_B</name>
+       <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_B</name>
+       <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Timer Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKSEL_A</name>
+       <description>Timer Clock Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Timer A Enable Status</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_A</name>
+       <description>CLK_TMR Ready Flag for Timer A</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_A</name>
+       <description>Event Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_A</name>
+       <description>Negative Edge Trigger for Event for Timer A</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_A</name>
+       <description>Interrupt Enable for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_A</name>
+       <description>Capture Event Select for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_A</name>
+       <description>Software Capture Event for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_A</name>
+       <description>Wake-Up Enable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTEN_A</name>
+       <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTBEN_A</name>
+       <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKSEL_B</name>
+       <description>Timer Clock Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Timer B Enable Status</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_B</name>
+       <description>CLK_TMR Ready Flag for Timer B</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_B</name>
+       <description>Event Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_B</name>
+       <description>Negative Edge Trigger for Event for Timer B</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_B</name>
+       <description>Interrupt Enable for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_B</name>
+       <description>Capture Event Select for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_B</name>
+       <description>Software Capture Event for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_B</name>
+       <description>Wake-Up Enable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CASCADE</name>
+       <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Timer Wakeup Status Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>A</name>
+       <description>Wake-Up Flag for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>B</name>
+       <description>Wake-Up Flag for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TMR Low-Power Configurable Timer-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR1</name>
+   <description>Low-Power Configurable Timer 1</description>
+   <baseAddress>0x40011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+<!--TMR1 Low-Power Configurable Timer 1-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR2</name>
+   <description>Low-Power Configurable Timer 2</description>
+   <baseAddress>0x40012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+<!--TMR2 Low-Power Configurable Timer 2-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR3</name>
+   <description>Low-Power Configurable Timer 3</description>
+   <baseAddress>0x40013000</baseAddress>
+   <interrupt>
+    <name>TMR3</name>
+    <description>TMR3 IRQ</description>
+    <value>8</value>
+   </interrupt>
+  </peripheral>
+<!--TMR3 Low-Power Configurable Timer 3-->
+  <peripheral>
+   <name>TRIMSIR</name>
+   <description>Trim System Initilazation Registers</description>
+   <baseAddress>0x40105400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>BB_SIR2</name>
+     <description>System Init. Configuration Register 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TRIM_IBRO_RBIAS</name>
+       <description>HIRC8M Trim</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RAM0_1ECCEN</name>
+       <description>RAM 0 and RAM 1 ECC Enable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>ECC Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>ECC Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0_1ECCEN">
+       <name>RAM2ECCEN</name>
+       <description>RAM 2 ECC Enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0_1ECCEN">
+       <name>RAM3ECCEN</name>
+       <description>RAM 3 ECC Enable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0_1ECCEN">
+       <name>ICC0ECCEN</name>
+       <description>ICC 0 ECC Enable</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0_1ECCEN">
+       <name>FL0ECCEN</name>
+       <description>Flash 0 ECC Enable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0_1ECCEN">
+       <name>FL1ECCEN</name>
+       <description>Flash 1 ECC Enable</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRIM_IBRO</name>
+       <description>HIRC8M Trim</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BB_SIR3</name>
+     <description>System Init. Configuration Register 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>BB_SIR6</name>
+     <description>System Init. Configuration Register 6.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RTCX1TRIM</name>
+       <description>RTCX1 Trim</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RTCX2TRIM</name>
+       <description>RTCX2 Trim</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRIMSIR Trim System Initilazation Registers-->
+  <peripheral>
+   <name>TRNG</name>
+   <description>Random Number Generator.</description>
+   <baseAddress>0x4004D000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TRNG</name>
+    <description>TRNG interrupt.</description>
+    <value>4</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>TRNG Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000003</resetValue>
+     <fields>
+      <field>
+       <name>RND_IE</name>
+       <description>To enable IRQ generation when a new 32-bit Random number is ready.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEYGEN</name>
+       <description>AES Key Generate. When enabled, the key for securing NVSRAM is generated and transferred to the secure key register automatically without user visibility or intervention. This bit is cleared by hardware once the key has been transferred to the secure key register.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>To wipe the Battery Backed key.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>RDY</name>
+       <description>32-bit random data is ready to read from TRNG_DATA register. Reading TRNG_DATA when RND_RDY=0 will return all 0's. IRQ is generated when RND_RDY=1 if TRNG_CN.RND_IRQ_EN=1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Busy</name>
+         <description>TRNG Busy</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Ready</name>
+         <description>32 bit random data is ready</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data. The content of this register is valid only when RNG_IS =1. When TNRG is disabled, read returns 0x0000 0000.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRNG Random Number Generator.-->
+  <peripheral>
+   <name>UART</name>
+   <description>UART Low Power Registers</description>
+   <baseAddress>0x40042000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control register</description>
+     <addressOffset>0x0000</addressOffset>
+     <fields>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>This field specifies the depth of receive FIFO for interrupt generation (value 0 and &gt; 16 are ignored) </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EN</name>
+       <description>Parity Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EO</name>
+       <description>when PAREN=1 selects odd or even parity odd is 1 even is 0</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_MD</name>
+       <description>Selects parity based on 1s or 0s count (when PAREN=1) </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_DIS</name>
+       <description>CTS Sampling Disable </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Flushes the TX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Flushes the RX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHAR_SIZE</name>
+       <description>Selects UART character size</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5bits</name>
+         <description>5 bits</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6bits</name>
+         <description>6 bits</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7bits</name>
+         <description>7 bits</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8bits</name>
+         <description>8 bits</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPBITS</name>
+       <description>Selects the number of stop bits that will be generated</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HFC_EN</name>
+       <description>Enables/disables hardware flow control</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RTSDC</name>
+       <description>Hardware Flow Control RTS Mode</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKEN</name>
+       <description>Baud clock enable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKSRC</name>
+       <description>To select the UART clock source for the UART engine (except APB registers). Secondary clock (used for baud rate generator) can be asynchronous from APB clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Peripheral_Clock</name>
+         <description>apb clock</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>External_Clock</name>
+         <description>Clock 1</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK2</name>
+         <description>Clock 2</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK3</name>
+         <description>Clock 3</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPFE_EN</name>
+       <description>Data/Parity bit frame error detection enable</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKRDY</name>
+       <description>Baud clock Ready read only bit</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UCAGM</name>
+       <description>UART Clock Auto Gating mode</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FDM</name>
+       <description>Fractional Division Mode</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DESM</name>
+       <description>RX Dual Edge Sampling Mode</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TX_BUSY</name>
+       <description>Read-only flag indicating the UART transmit status</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_BUSY</name>
+       <description>Read-only flag indicating the UART receiver status</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Indicates the number of bytes currently in the RX FIFO (0-RX FIFO_ELTS) </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Indicates the number of bytes currently in the TX FIFO (0-TX FIFO_ELTS) </description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable control register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Enable Interrupt For RX Frame Error</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Enable Interrupt For RX Parity Error</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Enable Interrupt For changeCTS signal change Error</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Enable Interrupt For RX FIFO Overrun Error</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Enable Interrupt For RX FIFO reaches the number of bytes configured by RXTHD</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Enable Interrupt For TX FIFO has one byte remaning</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Enable Interrupt For TX FIFO has half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Interrupt status flags Control register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Flag for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Flag for RX Parity Error interrupt</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Flag for CTS signal change interrupt (hardware flow control disabled) </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Flag for RX FIFO Overrun interrupt</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Flag for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Flag for interrupt when TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Flag for interrupt when TX FIFO is half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Clock Divider register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Baud rate divisor value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSR</name>
+     <description>Over Sampling Rate register</description>
+     <addressOffset>0x0014</addressOffset>
+     <fields>
+      <field>
+       <name>OSR</name>
+       <description>OSR</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXPEEK</name>
+     <description>TX FIFO Output Peek register</description>
+     <addressOffset>0x0018</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read TX FIFO next data. Reading from this field does not affect the contents of TX FIFO. Note that the parity bit is available from this field.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PNR</name>
+     <description> Pin register</description>
+     <addressOffset>0x001C</addressOffset>
+     <fields>
+      <field>
+       <name>CTS</name>
+       <description>Current sampled value of CTS IO</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RTS</name>
+       <description>This bit controls the value to apply on the RTS IO. If set to 1, the RTS IO is set to high level. If set to 0, the RTS IO is set to low level.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Read/Write register</description>
+     <addressOffset>0x0020</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Parity error flag for next byte to be read from FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration register</description>
+     <addressOffset>0x0030</addressOffset>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger If the TX FIFO level is less than this value, then the TX FIFO DMA interface will send a signal to system DMA to notify that TX FIFO is ready to receive data from memory.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX DMA channel enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Rx FIFO Level DMA Trigger If the RX FIFO level is greater than this value, then the RX FIFO DMA interface will send a signal to the system DMA to notify that RX FIFO has characters to transfer to memory.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX DMA channel enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wake up enable Control register</description>
+     <addressOffset>0x0034</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Enable for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Enable for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Enable for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wake up Flags register</description>
+     <addressOffset>0x0038</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Flag for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Flag for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Flag for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--UART UART Low Power Registers-->
+  <peripheral derivedFrom="UART">
+   <name>UART1</name>
+   <description>UART Low Power Registers 1</description>
+   <baseAddress>0x40043000</baseAddress>
+  </peripheral>
+<!--UART1 UART Low Power Registers 1-->
+  <peripheral>
+   <name>WDT</name>
+   <description>Windowed Watchdog Timer</description>
+   <baseAddress>0x40003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WWDT</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INT_LATE_VAL</name>
+       <description>Windowed Watchdog Interrupt Upper Limit. Sets the number of WDTCLK cycles until a windowed watchdog timer interrupt is generated (if enabled) if the CPU does not write the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE_VAL</name>
+       <description>Windowed Watchdog Reset Upper Limit. Sets the number of WDTCLK cycles until a system reset occurs (if enabled) if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Windowed Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_LATE</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Late.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_INT_EN</name>
+       <description>Windowed Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_RST_EN</name>
+       <description>Windowed Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Soon.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY_VAL</name>
+       <description>Windowed Watchdog Interrupt Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A windowed watchdog timer interrupt is generated (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY_VAL</name>
+       <description>Windowed Watchdog Reset Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A system reset occurs (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKRDY_IE</name>
+       <description>Switch Ready Interrupt Enable. Fires an interrupt when it is safe to swithc the clock.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY</name>
+       <description>Clock Status.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WIN_EN</name>
+       <description>Enables the Windowed Watchdog Function.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Windowed Mode Disabled (i.e. Compatibility Mode).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Windowed Mode Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Soon.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Late.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Windowed Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>RESET</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD_UPPER_LIMIT then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD_UPPER_LIMIT then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKSEL</name>
+     <description>Windowed Watchdog Timer Clock Select Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SOURCE</name>
+       <description>WWDT Clock Selection Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CNT</name>
+     <description>Windowed Watchdog Timer Count Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Current Value of the Windowed Watchdog Timer Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WDT Windowed Watchdog Timer-->
+ </peripherals>
+</device>

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32665/Include/max32665.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32665/Include/max32665.svd
@@ -1,0 +1,23348 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max32665</name>
+ <series>ARMCM3</series>
+ <version>1.0</version>
+ <description>MAX32665 32-bit ARM Cortex-M4 microcontroller, 128KB of system RAM, 4KB of One-Time-Programmable (OTP) memory, 64KB of Boot ROM, 8KB of battery-backed and AES self-encrypted SRAM.</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>ADC</name>
+   <description>10-bit Analog to Digital Converter</description>
+   <baseAddress>0x40034000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>ADC</name>
+    <description>ADC IRQ</description>
+    <value>20</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>ADC Control</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>start</name>
+       <description>Start ADC Conversion</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pwr</name>
+       <description>ADC Power Up</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>refbuf_pwr</name>
+       <description>ADC Reference Buffer Power Up</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ref_sel</name>
+       <description>ADC Reference Select</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ref_scale</name>
+       <description>ADC Reference Scale</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>scale</name>
+       <description>ADC Scale</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>clk_en</name>
+       <description>ADC Clock Enable</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_sel</name>
+       <description>ADC Channel Select</description>
+       <bitRange>[16:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AIN0</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN1</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN2</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN3</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN4</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN5</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN6</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN7</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VcoreA</name>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VcoreB</name>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vrxout</name>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vtxout</name>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VddA</name>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VddB</name>
+         <description>VddB/4</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vddio</name>
+         <description>Vddio/4</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vddioh</name>
+         <description>Vddioh/4</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VregI</name>
+         <description>VregI/4</description>
+         <value>16</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>adc_divsel</name>
+       <description>Scales the external inputs, all inputs are scaled the same</description>
+       <bitRange>[18:17]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV3</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>data_align</name>
+       <description>ADC Data Alignment Select</description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>ADC Status</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>active</name>
+       <description>ADC Conversion In Progress</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>afe_pwr_up_active</name>
+       <description>AFE Power Up Delay Active</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>overflow</name>
+       <description>ADC Overflow</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>ADC Output Data</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>data</name>
+       <description>ADC Converted Sample Data Output</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>ADC Interrupt Control Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>done_ie</name>
+       <description>ADC Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ref_ready_ie</name>
+       <description>ADC Reference Ready Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>hi_limit_ie</name>
+       <description>ADC Hi Limit Monitor Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>lo_limit_ie</name>
+       <description>ADC Lo Limit Monitor Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>overflow_ie</name>
+       <description>ADC Overflow Interrupt Enable</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>done_if</name>
+       <description>ADC Done Interrupt Flag</description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>ref_ready_if</name>
+       <description>ADC Reference Ready Interrupt Flag</description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>hi_limit_if</name>
+       <description>ADC Hi Limit Monitor Interrupt Flag</description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>lo_limit_if</name>
+       <description>ADC Lo Limit Monitor Interrupt Flag</description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>overflow_if</name>
+       <description>ADC Overflow Interrupt Flag</description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>pending</name>
+       <description>ADC Interrupt Pending Status</description>
+       <bitRange>[22:22]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>LIMIT[%s]</name>
+     <description>ADC Limit</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ch_lo_limit</name>
+       <description>Low Limit Threshold</description>
+       <bitRange>[9:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_hi_limit</name>
+       <description>High Limit Threshold</description>
+       <bitRange>[21:12]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_sel</name>
+       <description>ADC Channel Select</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_lo_limit_en</name>
+       <description>Low Limit Monitoring Enable</description>
+       <bitRange>[29:29]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_hi_limit_en</name>
+       <description>High Limit Monitoring Enable</description>
+       <bitRange>[30:30]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ADC 10-bit Analog to Digital Converter-->
+  <peripheral>
+   <name>AESKEYS</name>
+   <description>AES Key Registers.</description>
+   <baseAddress>0x40005000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>KEY0</name>
+     <description>AES Key 0.</description>
+     <addressOffset>0x000</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY1</name>
+     <description>AES Key 1.</description>
+     <addressOffset>0x080</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY2</name>
+     <description>AES Key 2.</description>
+     <addressOffset>0x100</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY3</name>
+     <description>AES Key 3.</description>
+     <addressOffset>0x180</addressOffset>
+     <size>32</size>
+    </register>
+   </registers>
+  </peripheral>
+<!--AESKEYS AES Key Registers.-->
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0_CH0</name>
+    <value>28</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA0_CH1</name>
+    <value>29</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA0_CH2</name>
+    <value>30</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA0_CH3</name>
+    <value>31</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA0_CH4</name>
+    <value>68</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA0_CH5</name>
+    <value>69</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA0_CH6</name>
+    <value>70</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA0_CH7</name>
+    <value>71</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CN</name>
+     <description>DMA Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CH0_IEN</name>
+       <description>Channel 0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0_IEN">
+       <name>CH1_IEN</name>
+       <description>Channel 1 Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IEN">
+       <name>CH2_IEN</name>
+       <description>Channel 2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IEN">
+       <name>CH3_IEN</name>
+       <description>Channel 3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IEN">
+       <name>CH4_IEN</name>
+       <description>Channel 4 Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IEN">
+       <name>CH5_IEN</name>
+       <description>Channel 5 Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IEN">
+       <name>CH6_IEN</name>
+       <description>Channel 6 Interrupt Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IEN">
+       <name>CH7_IEN</name>
+       <description>Channel 7 Interrupt Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>DMA Interrupt Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CH0_IPEND</name>
+       <description>Channel 0 Interrupt Pending.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0_IPEND">
+       <name>CH1_IPEND</name>
+       <description>Channel 1 Interrupt Pending.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IPEND">
+       <name>CH2_IPEND</name>
+       <description>Channel 2 Interrupt Pending.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IPEND">
+       <name>CH3_IPEND</name>
+       <description>Channel 3 Interrupt Pending.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IPEND">
+       <name>CH4_IPEND</name>
+       <description>Channel 4 Interrupt Pending.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IPEND">
+       <name>CH5_IPEND</name>
+       <description>Channel 5 Interrupt Pending.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IPEND">
+       <name>CH6_IPEND</name>
+       <description>Channel 6 Interrupt Pending.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_IPEND">
+       <name>CH7_IPEND</name>
+       <description>Channel 7 Interrupt Pending.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>8</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CFG</name>
+      <description>DMA Channel Configuration Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>CHEN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQSEL</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1RX</name>
+          <description>SPI1 RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI2RX</name>
+          <description>SPI2 RX</description>
+          <value>0x02</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0RX</name>
+          <description>UART0 RX</description>
+          <value>0x04</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1RX</name>
+          <description>UART1 RX</description>
+          <value>0x05</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0RX</name>
+          <description>I2C0 RX</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1RX</name>
+          <description>I2C1 RX</description>
+          <value>0x08</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>ADC</name>
+          <description>Analog-to-Digital Converter Channel</description>
+          <value>0x09</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2RX</name>
+          <description>I2C2 RX</description>
+          <value>0x0A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2RX</name>
+          <description>UART2 RX</description>
+          <value>0x0E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0RX</name>
+          <description>SPI0 RX</description>
+          <value>0x0F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP1</name>
+          <description>USB Endpoint 1 RX</description>
+          <value>0x11</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP2</name>
+          <description>USB Endpoint 2 RX</description>
+          <value>0x12</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP3</name>
+          <description>USB Endpoint 3 RX</description>
+          <value>0x13</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP4</name>
+          <description>USB Endpoint 4 RX</description>
+          <value>0x14</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP5</name>
+          <description>USB Endpoint 5 RX</description>
+          <value>0x15</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP6</name>
+          <description>USB Endpoint 6 RX</description>
+          <value>0x16</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP7</name>
+          <description>USB Endpoint 7 RX</description>
+          <value>0x17</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP8</name>
+          <description>USB Endpoint 8 RX</description>
+          <value>0x18</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP9</name>
+          <description>USB Endpoint 9 RX</description>
+          <value>0x19</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP10</name>
+          <description>USB Endpoint 10 RX</description>
+          <value>0x1A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRXEP11</name>
+          <description>USB Endpoint 11 RX</description>
+          <value>0x1B</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1TX</name>
+          <description>SPI1 TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI2TX</name>
+          <description>SPI2 TX</description>
+          <value>0x22</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0TX</name>
+          <description>UART0 TX</description>
+          <value>0x24</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1TX</name>
+          <description>UART1 TX</description>
+          <value>0x25</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0TX</name>
+          <description>I2C0 TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1TX</name>
+          <description>I2C1 TX</description>
+          <value>0x28</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2TX</name>
+          <description>I2C2 TX</description>
+          <value>0x2A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2TX</name>
+          <description>UART2 TX</description>
+          <value>0x2E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0TX</name>
+          <description>SPI0 TX</description>
+          <value>0x2F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP1</name>
+          <description>USB Endpoint 1 TX</description>
+          <value>0x31</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP2</name>
+          <description>USB Endpoint 2 TX</description>
+          <value>0x32</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP3</name>
+          <description>USB Endpoint 3 TX</description>
+          <value>0x33</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP4</name>
+          <description>USB Endpoint 4 TX</description>
+          <value>0x34</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP5</name>
+          <description>USB Endpoint 5 TX</description>
+          <value>0x35</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP6</name>
+          <description>USB Endpoint 6 TX</description>
+          <value>0x36</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP7</name>
+          <description>USB Endpoint 7 TX</description>
+          <value>0x37</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP8</name>
+          <description>USB Endpoint 8 TX</description>
+          <value>0x38</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP9</name>
+          <description>USB Endpoint 9 TX</description>
+          <value>0x39</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP10</name>
+          <description>USB Endpoint 10 TX</description>
+          <value>0x3A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTXEP11</name>
+          <description>USB Endpoint 11 TX</description>
+          <value>0x3B</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQWAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TOSEL</name>
+        <description>Time-Out Select. Selects the number of prescale clocks seen by the channel timer before a time-out conditions is generated for this channel. Important note: since the prescaler runs independent of the individual channel timers, the actual number of Pre-Scale clock edges seen has a margin of error equal to a single Pre-Scale clock.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PSSEL</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DISTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BRST</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>CHDIEN</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZIEN</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>ST</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>CH_ST</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_ST</name>
+        <description>Count-to-Zero (CTZ) Status</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+        <enumeratedValues>
+         <name>ctz_st_enum_rd</name>
+         <usage>read</usage>
+         <enumeratedValue>
+          <name>noEvent</name>
+          <description>The event has not occurred.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>occurred</name>
+          <description>The event has occurred.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+        <enumeratedValues>
+         <name>ctz_st_enum_wr</name>
+         <usage>write</usage>
+         <enumeratedValue>
+          <name>Clear</name>
+          <description>Clears the interrupt flag</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLD_ST</name>
+        <description>Reload Status.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+        <enumeratedValues>
+         <usage>read</usage>
+         <enumeratedValue>
+          <name>noEvent</name>
+          <description>The event has not occurred.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>occurred</name>
+          <description>The event has occurred.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+        <enumeratedValues>
+         <usage>write</usage>
+         <enumeratedValue>
+          <name>Clear</name>
+          <description>Clears the interrupt flag</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+        <enumeratedValues>
+         <usage>read</usage>
+         <enumeratedValue>
+          <name>noEvent</name>
+          <description>The event has not occurred.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>occurred</name>
+          <description>The event has occurred.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+        <enumeratedValues>
+         <usage>write</usage>
+         <enumeratedValue>
+          <name>Clear</name>
+          <description>Clears the interrupt flag</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_ST</name>
+        <description>Time-Out Status.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+        <enumeratedValues>
+         <usage>read</usage>
+         <enumeratedValue>
+          <name>noEvent</name>
+          <description>The event has not occurred.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>occurred</name>
+          <description>The event has occurred.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+        <enumeratedValues>
+         <usage>write</usage>
+         <enumeratedValue>
+          <name>Clear</name>
+          <description>Clears the interrupt flag</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC_RLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>SRC_RLD</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST_RLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>DST_RLD</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT_RLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT_RLD</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. This bit should be set after the address reload registers have been programmed. This bit is automatically cleared to 0 when reload occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+<!--DMA DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral derivedFrom="DMA">
+   <name>DMA1</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40035000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA1_CH0</name>
+    <value>72</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1_CH1</name>
+    <value>73</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1_CH2</name>
+    <value>74</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1_CH3</name>
+    <value>75</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1_CH4</name>
+    <value>76</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1_CH5</name>
+    <value>77</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1_CH6</name>
+    <value>78</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1_CH7</name>
+    <value>79</value>
+   </interrupt>
+  </peripheral>
+<!--DMA1 DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral>
+   <name>DVS</name>
+   <description>Dynamic Voltage Scaling</description>
+   <prependToName>DVS_</prependToName>
+   <baseAddress>0x40004800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0030</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DVS</name>
+    <description>Dynamic Voltage Scaling Interrupt</description>
+    <value>83</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTL</name>
+     <description>Control Register</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>MON_ENA</name>
+       <description>Enable the DVS monitoring circuit</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ENA</name>
+       <description>Enable the power supply adjustment based on measurements</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PS_FB_DIS</name>
+       <description>Power Supply Feedback Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTRL_TAP_ENA</name>
+       <description>Use the TAP Select for automatic adjustment or monitoring</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PROP_DLY</name>
+       <description>Additional delay to monitor lines</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>MON_ONESHOT</name>
+       <description>Measure delay once</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GO_DIRECT</name>
+       <description>Operate in automatic mode or move directly</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DIRECT_REG</name>
+       <description>Step incrementally to target voltage</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PRIME_ENA</name>
+       <description>Include a delay line priming signal before monitoring</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LIMIT_IE</name>
+       <description>Enable Limit Error Interrupt</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RANGE_IE</name>
+       <description>Enable Range Error Interrupt</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_IE</name>
+       <description>Enable Adjustment Error Interrupt</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>REF_SEL</name>
+       <description>Select TAP used for voltage adjustment</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>INC_VAL</name>
+       <description>Step size to increment voltage when in automatic mode</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>DVS_PS_APB_DIS</name>
+       <description>Prevent the application code from adjusting Vcore</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DVS_HI_RANGE_ANY</name>
+       <description>Any high range signal from a delay line will cause a voltage adjustment</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FB_TO_IE</name>
+       <description>Enable Voltage Adjustment Timeout Interrupt</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FC_LV_IE</name>
+       <description>Enable Low Voltage Interrupt</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PD_ACK_ENA</name>
+       <description>Prevent DVS from ack'ing a request to enter a low power mode until in the idle state</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ABORT</name>
+       <description>Causes the DVS to enter the idle state immediately on a request to enter a low power mode</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>Status Fields</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000000</resetValue>
+     <fields>
+      <field>
+       <name>DVS_STATE</name>
+       <description>State machine state</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_UP_ENA</name>
+       <description>DVS Raising voltage</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_DWN_ENA</name>
+       <description>DVS Lowering voltage</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ACTIVE</name>
+       <description>Adjustment to a Direct Voltage</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTR_TAP_OK</name>
+       <description>Tap Enabled and the Tap is withing Hi/Low limits</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTR_TAP_SEL</name>
+       <description>Status of selected center tap delay line detect output</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SLOW_TRIP_DET</name>
+       <description>Provides the current combined status of all selected Low Range delay lines</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FAST_TRIP_DET</name>
+       <description>Provides the current combined status of all selected High Range delay lines</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PS_IN_RANGE</name>
+       <description>Indicates if the power supply is in range</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PS_VCNTR</name>
+       <description>Voltage Count value sent to the power supply</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>MON_DLY_OK</name>
+       <description>Indicates the monitor delay count is at 0</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_DLY_OK</name>
+       <description>Indicates the adjustment delay count is at 0</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LO_LIMIT_DET</name>
+       <description>Power supply voltage counter is at low limit</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HI_LIMIT_DET</name>
+       <description>Power supply voltage counter is at high limit</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VALID_TAP</name>
+       <description>At least one delay line has been enabled</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LIMIT_ERR</name>
+       <description>Interrupt flag that indicates a voltage count is at/beyond manufacturer limits</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RANGE_ERR</name>
+       <description>Interrupt flag that indicates a tap has an invalid value</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ERR</name>
+       <description>Interrupt flag that indicates up and down adjustment requested simultaneously</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>REF_SEL_ERR</name>
+       <description>Indicates the ref select register  bit is out of range</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FB_TO_ERR</name>
+       <description>Interrupt flag that indicates a timeout while adjusting the voltage</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FB_TO_ERR_S</name>
+       <description>Interrupt flag that mirror FB_TO_ERR and is write one clear</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FC_LV_DET_INT</name>
+       <description>Interrupt flag that indicates the power supply voltage requested is below the low threshold</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FC_LV_DET_S</name>
+       <description>Interrupt flag that mirrors FC_LV_DET_INT</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DIRECT</name>
+     <description>Direct control of target voltage</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>VOLTAGE</name>
+       <description>Sets the target power supply value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MON</name>
+     <description>Monitor Delay</description>
+     <addressOffset>0x00C</addressOffset>
+     <fields>
+      <field>
+       <name>DLY</name>
+       <description>Number of prescaled clocks between delay line samples</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+      <field>
+       <name>PRE</name>
+       <description>Number of clocks before DVS_MON_DLY is decremented</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADJ_UP</name>
+     <description>Up Delay Register</description>
+     <addressOffset>0x010</addressOffset>
+     <fields>
+      <field>
+       <name>DLY</name>
+       <description>Number of prescaled clocks between updates of the adjustment delay counter</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PRE</name>
+       <description>Number of clocks before DVS_ADJ_UP_DLY is decremented</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADJ_DWN</name>
+     <description>Down Delay Register</description>
+     <addressOffset>0x014</addressOffset>
+     <fields>
+      <field>
+       <name>DLY</name>
+       <description>Number of prescaled clocks between updates of the adjustment delay counter</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PRE</name>
+       <description>Number of clocks before DVS_ADJ_DWN_DLY is decremented</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>THRES_CMP</name>
+     <description>Up Delay Register</description>
+     <addressOffset>0x018</addressOffset>
+     <fields>
+      <field>
+       <name>VCNTR_THRES_CNT</name>
+       <description>Value used to determine 'low voltage' range</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VCNTR_THRES_MASK</name>
+       <description>Mask applied to threshold and vcount to determine if the device is in a low voltage range</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>5</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>TAP_SEL[%s]</name>
+     <description>DVS Tap Select Register</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Select delay line tap for lower bound of auto adjustment</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>LO_TAP_STAT</name>
+       <description>Returns last delay line tap value</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTR_TAP_STAT</name>
+       <description>Returns last delay line tap value</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HI_TAP_STAT</name>
+       <description>Returns last delay line tap value</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Selects delay line tap for high point of auto adjustment</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>CTR</name>
+       <description>Selects delay line tap for center point of auto adjustment</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>COARSE</name>
+       <description>Selects delay line tap for coarse or fixed delay portion of the line</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>DET_DLY</name>
+       <description>Number of HCLK between delay line launch and sampling</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>DELAY_ACT</name>
+       <description>Set if the delay is active</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--DVS Dynamic Voltage Scaling-->
+  <peripheral>
+   <name>FCR</name>
+   <description>Function Control.</description>
+   <baseAddress>0x40000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>FCR</name>
+     <description>Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>USB_CLK_SEL</name>
+       <description>USB External Core Clock Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>sys</name>
+         <description>Generated clock from system clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dig</name>
+         <description>Digital clock from a GPIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>QSPI0_FNC_SEL</name>
+       <description>SPI0 Function Select.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>hirc</name>
+         <description>High speed 96MHz oscillator.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ext_clk</name>
+         <description>External clock input.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0_SDA_FILTER_EN</name>
+       <description>I2C0 SDA Pad Deglitcher enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0_SCL_FILTER_EN</name>
+       <description>I2C0 SCL Pad Deglitcher enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1_SDA_FILTER_EN</name>
+       <description>I2C1 SDA Pad Deglitcher enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1_SCL_FILTER_EN</name>
+       <description>I2C1 SCL Pad Deglitcher enable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FCR Function Control.-->
+  <peripheral>
+   <name>FLC</name>
+   <description>Flash Memory Control.</description>
+   <prependToName>FLSH_</prependToName>
+   <baseAddress>0x40029000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Flash_Controller</name>
+    <description>Flash Controller interrupt.</description>
+    <value>23</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ADDR</name>
+     <description>Flash Write Address.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address for next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Flash Clock Divide. The clock (PLL0) is divided by this value to generate a 1 MHz clock for Flash controller.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000064</resetValue>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Flash Clock Divide. The clock is divided by this value to generate a 1MHz clock for flash controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CN</name>
+     <description>Flash Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WR</name>
+       <description>Write.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="WR">
+       <name>ME</name>
+       <description>Mass Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="WR">
+       <name>PGE</name>
+       <description>Page Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERASE_CODE</name>
+       <description>Erase Code.  The ERASE_CODE must be set up property before erase operation can be initiated. These bits are automatically cleared after the operation is complete.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>erasePage</name>
+         <description>Enable Page Erase.</description>
+         <value>0x55</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>eraseAll</name>
+         <description>Enable Mass Erase. The debug port must be enabled.</description>
+         <value>0xAA</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PEND</name>
+       <description>Flash Pending.  When Flash operation is in progress (busy), Flash reads and writes will fail. When PEND is set, write to all Flash registers, with exception of the Flash interrupt register, are ignored.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>UNLOCK</name>
+       <description>Flash Unlock.  The correct unlock code must be written to these four bits before any Flash write or erase operation is allowed.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Flash Unlocked.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Flash Locked.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Flash Interrupt Register.</description>
+     <addressOffset>0x024</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Flash Done Interrupt.  This bit is set to 1 upon Flash write or erase completion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AF</name>
+       <description>Flash Access Fail.  This bit is set when an attempt is made to write the flash while the flash is busy or the flash is locked. This bit can only be set to 1 by hardware.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONEIE</name>
+       <description>Flash Done Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DONEIE">
+       <name>AFIE</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECC_DATA</name>
+     <description>Flash Controller ECC Data Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ECC_EVEN</name>
+       <description>Error Correction Code Even Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>ECC_ODD</name>
+       <description>Error Correction Code Odd Data.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA[%s]</name>
+     <description>Flash Write Data.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACTNL</name>
+     <description>Access Control Register. Writing the ACNTL register with the following values in the order shown, allows read and write access to the system and user Information block: pflc-acntl = 0x3a7f5ca3; pflc-acntl = 0xa1e34f20; pflc-acntl = 0x9608b2c1. When unlocked, a write of any word will disable access to system and user information block. Readback of this register is always zero.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ACNTL</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FLC Flash Memory Control.-->
+  <peripheral derivedFrom="FLC">
+   <name>FLC1</name>
+   <description>Flash Memory Control. 1</description>
+   <baseAddress>0x40029400</baseAddress>
+   <interrupt>
+    <name>FLC1</name>
+    <description>FLC1 IRQ</description>
+    <value>87</value>
+   </interrupt>
+  </peripheral>
+<!--FLC1 Flash Memory Control. 1-->
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x40000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SCON</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>BSTAPEN</name>
+       <description>Boundary Scan TAP enable. When enabled, the JTAG port is connected to the Boundary Scan TAP. Otherwise, the port is connected to the ARM ICE function. This bit is reset by the POR. Reset value and access depend on the part number.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Boundary Scan TAP port disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Boundary Scan TAP port enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SBUSARB</name>
+       <description>System bus abritration scheme. These bits are used to select between Fixed-burst abritration and Round-Robin scheme. The Round-Robin scheme is selected by default. These bits are reset by the system reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>fix</name>
+         <description>Fixed Burst abritration.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>round</name>
+         <description>Round-robin scheme.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLASH_PAGE_FLIP</name>
+       <description>Flips the Flash bottom and top halves. (Depending on the total flash size, each half is either 256K or 512K). Initiating a flash page flip will cause a flush of both the data buffer on the DCODE bus and the internal instruction buffer.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Physical layout matches logical layout.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>swapped</name>
+         <description>Bottom half mapped to logical top half and vice versa.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CCACHE_FLUSH</name>
+       <description>Code Cache Flush. This bit is used to flush the code caches and the instruction buffer of the Cortex-M4. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DCACHE_FLUSH</name>
+       <description>Data Cache Flush. The system cache(s) will be flushed when this bit is set. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal System Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>System Cache is flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRCC_DIS</name>
+       <description>SPIXR Cache Controller Disable. Disables the SRCC used for SPIXR code and data cache. Setting this field disables the cache and bypasses the cache line buffer.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CCHK</name>
+       <description>Compute ROM Checksum. This bit is self-cleared when calculation is completed. Once set, software clearing this bit is ignored and the bit will remain set until the operation is completed.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CHKRES</name>
+       <description>ROM Checksum Result. This bit is only valid when CHKRD=1.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pass</name>
+         <description>ROM Checksum Correct.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fail</name>
+         <description>ROM Checksum Fail.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OVR</name>
+       <description>Operating Voltage Range. Setting these bits according to the VCore voltage allows the on-chip Random-Access memories to operate in their optimal timing range.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_9V</name>
+         <description>0.9V +/- 10%</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0V</name>
+         <description>1.0V +/- 10%</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1V</name>
+         <description>1.1V +/- 10%</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RSTR0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA">
+       <name>WDT0</name>
+       <description>Watchdog Timer Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO1</name>
+       <description>GPIO1 Reset. Setting this bit to 1 resets GPIO1 pins to their default states.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TIMER0</name>
+       <description>Timer0 Reset. Setting this bit to 1 resets Timer 0 blocks.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TIMER1</name>
+       <description>Timer1 Reset. Setting this bit to 1 resets Timer 1 blocks.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TIMER2</name>
+       <description>Timer2 Reset. Setting this bit to 1 resets Timer 2 blocks.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TIMER3</name>
+       <description>Timer3 Reset. Setting this bit to 1 resets Timer 3 blocks.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TIMER4</name>
+       <description>Timer3 Reset. Setting this bit to 1 resets Timer 4 blocks.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TIMER5</name>
+       <description>Timer3 Reset. Setting this bit to 1 resets Timer 5 blocks.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART0</name>
+       <description>UART0 Reset. Setting this bit to 1 resets all UART 0 blocks.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART1</name>
+       <description>UART1 Reset. Setting this bit to 1 resets all UART 1 blocks.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI1</name>
+       <description>SPI1 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI2</name>
+       <description>SPI2 Reset. Setting this bit to 1 resets all SPI 2 blocks.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>I2C0</name>
+       <description>I2C0 Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>RTC</name>
+       <description>Real Time Clock Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>CRYPTO</name>
+       <description>Cryptographic Reset. Setting this bit to 1 resets the AES block, the SHA block and the DES block.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SMPHR</name>
+       <description>SMPHR Reset. Setting this bit to 1 resets the SMPHR block.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>USB</name>
+       <description>USB Reset. Setting this bit resets both USB blocks.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>ADC</name>
+       <description>Analog to Digital Reset.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>DMA1</name>
+       <description>DMA 1 Reset.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART2</name>
+       <description>UART2 Reset. Setting this bit to 1 resets all UART 2 blocks.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SRST</name>
+       <description>Soft Reset. Setting this bit to 1 resets everything except the CPU and the watchdog timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>PRST</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SYSTEM</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCN</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>PSC</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the PLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKSEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>HIRC</name>
+         <description>HIRC Clock</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>XTAL32M</name>
+         <description>32MHz Crystal is used for the system clock.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>LIRC8</name>
+         <description>8kHz LIRC is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HIRC96</name>
+         <description>The internal 96 MHz oscillator is used for the system clock.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>HIRC8</name>
+         <description>The internal 8 MHz oscillator is used for the system clock.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>XTAL32k</name>
+         <description> 32kHz is used for the system clock.</description>
+         <value>6</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CKRDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CCD</name>
+       <description>Cryptographic clock divider</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>non_div</name>
+         <description>The cryptographic accelerator clock is running in non-divided mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div</name>
+         <description>The cryptographic accelerator clock is running in divided mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>X32M_EN</name>
+       <description>32MHz Crystal Oscillator Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>X32K_EN</name>
+       <description>32kHz Crystal Oscillator Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="X32K_EN">
+       <name>HIRC_EN</name>
+       <description>60MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="X32K_EN">
+       <name>HIRC96M_EN</name>
+       <description>96MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="X32K_EN">
+       <name>HIRC8M_EN</name>
+       <description>8MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HIRC8M_VS</name>
+       <description>8MHz High Frequency Internal Reference Clock Voltage Select. This register bit is used to select the power supply to the HIRC8M.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Vcor</name>
+         <description>VCore Supply</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1V</name>
+         <description>Dedicated 1v regulated supply.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>X32M_RDY</name>
+       <description>32MHz Crystal Oscillator Ready</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>X32K_RDY</name>
+       <description>32kHz Crystal Oscillator Ready</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="X32K_RDY">
+       <name>HIRC_RDY</name>
+       <description>60MHz HIRC Ready.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="X32K_RDY">
+       <name>HIRC96M_RDY</name>
+       <description>96MHz HIRC Ready.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="X32K_RDY">
+       <name>HIRC8M_RDY</name>
+       <description>8MHz HIRC Ready.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PM</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This two bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>DeepSleep Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>backup</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIOWKEN</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wake Up Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wake Up Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIOWKEN">
+       <name>RTCWKEN</name>
+       <description>RTC Alarm Wake Up Enable. This bit enables RTC alarm as wakeup source. If enabled, the desired RTC alarm must be configured via the RTC control registers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIOWKEN">
+       <name>USBWKEN</name>
+       <description>USB Wake Up Enable. This bit enables USB activity as wakeup source.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIOWKEN">
+       <name>WUTWKEN</name>
+       <description>WUT Wake Up Enable. This bit enables WUT IRQ as wakeup source.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIOWKEN">
+       <name>compwken</name>
+       <description>COMPARATOR Input Wake Up Enable. This bit enables COMP IRQ activity as wakeup source.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HIRCPD</name>
+       <description>HIRC Power Down. This bit selects HIRC power state in DEEPSLEEP mode. </description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="HIRCPD">
+       <name>HIRC96MPD</name>
+       <description>96MHz power down. This bit selects 96MHz HIRC power state in DEEPSLEEP mode. </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="HIRCPD">
+       <name>HIRC8MPD</name>
+       <description>8MHz power down. This bit selects 8MHz HIRC power state in DEEPSLEEP mode. </description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>XTALPB</name>
+       <description>32MHz Bluetooth Oscillator Bypass. </description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCKDIV</name>
+     <description>Peripheral Clock Divider.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>SDHCFRQ</name>
+       <description>SDHC Clock Frequency. This bits defines the clock frequency of SDHC.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>48MHz</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>24MHz</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADCFRQ</name>
+       <description>ADC clock Frequency. These bits define the ADC clock frequency. FADC = FPCLK/(ADCFRQ).</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>AONCD</name>
+       <description>Always-ON(AON) domain CLock Divider. These bits define the AON domain clock divider.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div_4</name>
+         <description>PCLK divide by 4.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div_8</name>
+         <description>PCLK divide by 8.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div_16</name>
+         <description>PCLK divide by 16.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div_32</name>
+         <description>PCLK divide by 32.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PERCKCN0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0D</name>
+       <description>GPIO0 Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>GPIO1D</name>
+       <description>GPIO1 Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>USBD</name>
+       <description>USB Disable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>DMAD</name>
+       <description>DMA Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>SPI1D</name>
+       <description>SPI 1 Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>SPI2D</name>
+       <description>SPI 2 Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>UART0D</name>
+       <description>UART 0 Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>UART1D</name>
+       <description>UART 1 Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>I2C0D</name>
+       <description>I2C 0 Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>CRYPTOD</name>
+       <description>Crypto Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>TIMER0D</name>
+       <description>Timer 0 Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>TIMER1D</name>
+       <description>Timer 1 Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>TIMER2D</name>
+       <description>Timer 2 Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>TIMER3D</name>
+       <description>Timer 3 Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>TIMER4D</name>
+       <description>Timer 4 Disable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>TIMER5D</name>
+       <description>Timer 5 Disable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>ADCD</name>
+       <description>ADC Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>I2C1D</name>
+       <description>I2C 1 Disable.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>PTD</name>
+       <description>PT Clock Disable.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>SPIXIPD</name>
+       <description>SPI XiP Disable.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0D">
+       <name>SPIMD</name>
+       <description>SPI XiP Master Controller Disable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCKCN</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 2.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM0LS</name>
+       <description>System RAM 0 Light Sleep Mode.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="SYSRAM0LS">
+       <name>SYSRAM1LS</name>
+       <description>System RAM 1 Light Sleep Mode.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SYSRAM0LS">
+       <name>SYSRAM2LS</name>
+       <description>System RAM 2 Light Sleep Mode.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SYSRAM0LS">
+       <name>SYSRAM3LS</name>
+       <description>System RAM 3 Light Sleep Mode.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SYSRAM0LS">
+       <name>SYSRAM4LS</name>
+       <description>System RAM 4 Light Sleep Mode.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SYSRAM0LS">
+       <name>SYSRAM5LS</name>
+       <description>System RAM 5 Light Sleep Mode.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SYSRAM0LS">
+       <name>SYSRAM6LS</name>
+       <description>System RAM 6 Light Sleep Mode.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SYSRAM0LS">
+       <name>ICACHELS</name>
+       <description>ICache RAM Light Sleep Mode.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SYSRAM0LS">
+       <name>ICACHEXIPLS</name>
+       <description>ICACHE-XIP RAM Light Sleep Mode.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SYSRAM0LS">
+       <name>SCACHELS</name>
+       <description>SysCache RAM Light Sleep Mode.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SYSRAM0LS">
+       <name>CRYPTOLS</name>
+       <description>CRYPTO RAM Light Sleep Mode.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SYSRAM0LS">
+       <name>USBLS</name>
+       <description>USB FIFO Light Sleep Mode.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SYSRAM0LS">
+       <name>ROM0LS</name>
+       <description>ROM Light Sleep Mode.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SYSRAM0LS">
+       <name>ROM1LS</name>
+       <description>ROM1 Light Sleep Mode.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SYSRAM0LS">
+       <name>ICACHE1LS</name>
+       <description>ICache RAM Light Sleep Mode.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMZCN</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>SRAM0Z</name>
+       <description>System RAM Block 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="SRAM0Z">
+       <name>SRAM1Z</name>
+       <description>System RAM Block 1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0Z">
+       <name>SRAM2</name>
+       <description>System RAM Block 2.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0Z">
+       <name>SRAM3Z</name>
+       <description>System RAM Block 3.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0Z">
+       <name>SRAM4Z</name>
+       <description>System RAM Block 4.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0Z">
+       <name>SRAM5Z</name>
+       <description>System RAM Block 5.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0Z">
+       <name>SRAM6Z</name>
+       <description>System RAM Block 6.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0Z">
+       <name>ICACHEZ</name>
+       <description>Instruction Cache.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0Z">
+       <name>ICACHEXIPZ</name>
+       <description>Instruction Cache XIP Data and Tag Ram zeroizatoin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0Z">
+       <name>SCACHEDATAZ</name>
+       <description>System Cache Data Ram Zeroization.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0Z">
+       <name>SCACHETAGZ</name>
+       <description>System Cache Tag Zeroization.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0Z">
+       <name>CRYPTOZ</name>
+       <description>Crypto (MAA) Memory.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0Z">
+       <name>USBFIFOZ</name>
+       <description>USB FIFO Zeroizatoin.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="SRAM0Z">
+       <name>ICACHE1Z</name>
+       <description>Instruction Cache.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSST</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICELOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CODEINTERR</name>
+       <description>Code Integrity Error Flag. This bit indicates a code integrity error has occured in XiP interface. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>norm</name>
+         <description>Normal Operating Condition.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>code</name>
+         <description>Code Integrity Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCMEMF</name>
+       <description>System Cache Memory Fault Flag. This bit indicates a memory fault has occured in the System Cache while receiving data from the Hyperbus Interface.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>norm</name>
+         <description>Normal Operating Condition.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>memory</name>
+         <description>Memory Fault.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RSTR1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>I2C1</name>
+       <description>I2C1 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>PT</name>
+       <description>PT Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPIXIP</name>
+       <description>SPI XiP Master Reset.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>XSPIM</name>
+       <description>GSPI XiP Master Controller Reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SDHC</name>
+       <description>SDHC/SDIO Reset.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>OWIRE</name>
+       <description>OWIRE Reset.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>WDT1</name>
+       <description>WDT1 Reset.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPI0</name>
+       <description>SPI0 Reset.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPIXMEM</name>
+       <description>SPIXMEM Reset.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SMPHR</name>
+       <description>SMPHR Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>WDT2</name>
+       <description>WDT2 Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>BTLE</name>
+       <description>BTLE Reset.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AUDIO</name>
+       <description>AUDIO Reset.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2C2</name>
+       <description>I2C2 Reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>RPU</name>
+       <description>RPU Reset.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>HTMR0</name>
+       <description>HTMR0 Reset.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>HTMR1</name>
+       <description>HTMR1 Reset.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>DVS</name>
+       <description>DVS Reset.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SIMO</name>
+       <description>SIMO Reset.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PERCKCN1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>BTLED</name>
+       <description>BTLE Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>UART2D</name>
+       <description>UART2 Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>TRNGD</name>
+       <description>TRNG Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>SCACHED</name>
+       <description>System Cache Clock Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>SDMAD</name>
+       <description>SDMA Clock Disable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>SMPHRD</name>
+       <description>Semaphore Clock Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>SDHCD</name>
+       <description>SDHC/SDIO Clock Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>ICACHEXIPD</name>
+       <description>ICache XIP Clock Disable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>OWIRED</name>
+       <description>One-Wire Clock Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>SPI0D</name>
+       <description>SPI0 Clock Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>SPIXIPDD</name>
+       <description>SPI-XIP Data Clock Disable</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>DMA1D</name>
+       <description>DMA1 Clock Disable</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>AUDIOD</name>
+       <description>AUDIO Clock Disable</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>I2C2D</name>
+       <description>I2C 2 Clock Disable</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>HTMR0D</name>
+       <description>HTMR 0 Clock Disable</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>HTMR1D</name>
+       <description>HTMR 1 Clock Disable</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>WDT0D</name>
+       <description>WDT0 Clock Disable</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>WDT1D</name>
+       <description>WDT1 Clock Disable</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>WDT2D</name>
+       <description>WDT2 Clock Disable</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2D">
+       <name>CPU1D</name>
+       <description>CPU1 Clock Disable</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVENT_EN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>CPU0DMAEVENT</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CPU0DMA1EVENT</name>
+       <description>Enable RXEV pin event. When this bit is set, a logic high of GPIO0[24] will cause an RXEV event to wake the CPU from WFE sleep mode. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CPU0TXEVENT</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO[25].</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CPU1DMAEVENT</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CPU1DMA1EVENT</name>
+       <description>Enable RXEV pin event. When this bit is set, a logic high of GPIO0[24] will cause an RXEV event to wake the CPU from WFE sleep mode. </description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CPU1TXEVENT</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO[25].</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REVISION</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSSIE</name>
+     <description>System Status Interrupt Enable Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEULIE</name>
+       <description>ARM ICE Unlock Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ICEULIE">
+       <name>CIEIE</name>
+       <description>Code Integrity Error Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ICEULIE">
+       <name>SCMFIE</name>
+       <description>System Cache Memory Fault Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECC_ER</name>
+     <description>ECC Error Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>SYSRAM0ECCERR</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM1ECCERR</name>
+       <description>ECC System RAM1 Error Flag. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM2ECCERR</name>
+       <description>ECC System RAM2 Error Flag. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM3ECCERR</name>
+       <description>ECC System RAM3 Error Flag. Write 1 to clear.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM4ECCERR</name>
+       <description>ECC System RAM4 Error Flag. Write 1 to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM5ECCERR</name>
+       <description>ECC System RAM5 Error Flag. Write 1 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM6ECCERR</name>
+       <description>ECC System RAM6 Error Flag. Write 1 to clear.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IC0ECCERR</name>
+       <description>ECC Icache0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IC1ECCERR</name>
+       <description>ECC Icache1 Error Flag. Write 1 to clear.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICXIPECCERR</name>
+       <description>ECC IcacheXIP Error Flag. Write 1 to clear.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FL0ECCERR</name>
+       <description>ECC Flash0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FL1ECCERR</name>
+       <description>ECC Flash1 Error Flag. Write 1 to clear.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECC_CED</name>
+     <description>ECC Correctable Error Detected Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>SYSRAM0ECCNDED</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM1ECCNDED</name>
+       <description>ECC System RAM1 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM2ECCNDED</name>
+       <description>ECC System RAM2 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM3ECCNDED</name>
+       <description>ECC System RAM3 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM4ECCNDED</name>
+       <description>ECC System RAM4 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM5ECCNDED</name>
+       <description>ECC System RAM5 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IC0ECCNDED</name>
+       <description>ECC Icache0 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IC1ECCNDED</name>
+       <description>ECC Icache1 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICXIPECCNDED</name>
+       <description>ECC IcacheXIP Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FL0ECCNDED</name>
+       <description>ECC Flash0 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FL1ECCNDED</name>
+       <description>ECC Flash1 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECC_IRQEN</name>
+     <description>ECC IRQ Enable Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>SYSRAM0ECCEN</name>
+       <description>System RAM0 ECC Error Interrupt Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM1ECCEN</name>
+       <description>System RAM1 ECC Error Interrupt Enable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM2ECCEN</name>
+       <description>System RAM2 ECC Error Interrupt Enable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM3ECCEN</name>
+       <description>System RAM3 ECC Error Interrupt Enable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM4ECCEN</name>
+       <description>System RAM4 ECC Error Interrupt Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM5ECCEN</name>
+       <description>System RAM5 ECC Error Interrupt Enable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IC0ECCEN</name>
+       <description>Icache0 ECC Error Interrupt Enable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IC1ECCEN</name>
+       <description>Icache1 ECC Error Interrupt Enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICXIPECCEN</name>
+       <description>IcacheXIP ECC Error Interrupt Enable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FL0ECCEN</name>
+       <description>Flash0 NError ECC Interrupt Enable</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FL1ECCEN</name>
+       <description>Flash1 ECC Error Interrupt Enable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECC_ERRAD</name>
+     <description>ECC Error Address Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>DATARAMADDR</name>
+       <description>ECC Error Address.Data Ram Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+      <field>
+       <name>DATARAMBANK</name>
+       <description>ECC Error Address.Data Error Bank.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATARAMERR</name>
+       <description>ECC Error Address.Data Ram Error.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMADDR</name>
+       <description>ECC Error Address.Tag Ram Address.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMBANK</name>
+       <description>ECC Error Address.Tag Ram Bank.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMERR</name>
+       <description>ECC Error Address.Tag Ram Error.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLE_LDOCR</name>
+     <description>BTLE LDO Control Register</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>LDORXEN</name>
+       <description>LDORX Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDORXOPULLD</name>
+       <description>LDORX PULL Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDORXVSEL</name>
+       <description>LDORX Voltage Setting</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_85</name>
+         <description>0.85V</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>0_9</name>
+         <description>0.9V</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0</name>
+         <description>1.0V</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1</name>
+         <description>1.1V</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDOTXEN</name>
+       <description>LDOTX Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDOTXPULLD</name>
+       <description>LDOTX Pulldown</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDOTXVSEL</name>
+       <description>LDOTX Output Voltage Setting</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_85</name>
+         <description>0.85V</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>0_9</name>
+         <description>0.9V</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0</name>
+         <description>1.0V</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1</name>
+         <description>1.1V</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDOTXBYP</name>
+       <description>LDOTX Bypass Enable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDOTXDISCH</name>
+       <description>LDOTX Discharge</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDORXBYP</name>
+       <description>LDORX Bypass Enable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDORXDISCH</name>
+       <description>LDORX Discharge</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDORXENDLY</name>
+       <description>LDORX Enable Delay</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDOTXENDLY</name>
+       <description>LDOTX Enable Delay</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDOTXBYPENENDLY</name>
+       <description>LDOTX Bypass Enable Delay</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORXBYPENENDLY</name>
+       <description>LDORX Bypass Enable Delay</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLE_LDODCR</name>
+     <description>BTLE LDO Delay Register</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>BYPDLYCNT</name>
+       <description>Bypass Delay Count. Count delay base on PCLK.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>LDOTXDLYCNT</name>
+       <description>LDOTX Delay Count. Count delay base on PCLK/128.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>LDORXDLYCNT</name>
+       <description>LDORX Delay Count. Count delay base on PCLK/128.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GP0</name>
+     <description>General Purpose Register 0</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>GPR0</name>
+       <description>User-defined register RAM.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>APB_ASYNC</name>
+     <description>APB Asynchronous Bridge Select Register</description>
+     <addressOffset>0x84</addressOffset>
+     <fields>
+      <field>
+       <name>APBASYNCI2C0</name>
+       <description>Feeds I2C0 with either PCLK or 7.37MHz Clk</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pclk</name>
+         <description>PCLK Source</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7mclk</name>
+         <description>7.37MHz Source</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="APBASYNCI2C0">
+       <name>APBASYNCI2C1</name>
+       <description>Feeds I2C1 with either PCLK or 7.37MHz Clk</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="APBASYNCI2C0">
+       <name>APBASYNCI2C2</name>
+       <description>Feeds I2C2 with either PCLK or 7.37MHz Clk</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="APBASYNCI2C0">
+       <name>APBASYNCPT</name>
+       <description>Feeds PT with either PCLK or 7.37MHz Clk</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCR Global Control Registers.-->
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x40008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN</name>
+     <description>GPIO Function Enable Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>alternate</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN_SET</name>
+     <description>GPIO Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_EN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_EN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_EN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_OUT bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_IN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_MOD</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_MOD</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_POL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_POL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN_EN</name>
+     <description>GPIO Port Input Enable.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_IN_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Input Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Input Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_EN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_EN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_STAT</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_INT_STAT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WAKE_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_DUAL_EDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INT_DUAL_EDGE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PAD_CFG1</name>
+     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PAD_CFG1</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PAD_CFG2</name>
+     <description>GPIO Input Mode Config 2. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PAD_CFG2</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_SET</name>
+     <description>GPIO Alternate Function Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN2</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_SET</name>
+     <description>GPIO Alternate Function 2 Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN2 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_CLR</name>
+     <description>GPIO Wake Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN2 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x7C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS0</name>
+     <description>GPIO Drive Strength  Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ld</name>
+         <description>GPIO port pin is in low-drive mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hd</name>
+         <description>GPIO port pin is in high-drive mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PS</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VSSEL</name>
+     <description>GPIO Voltage Select.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GPIO0 Individual I/O for each GPIO-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO1</name>
+   <description>Individual I/O for each GPIO 1</description>
+   <baseAddress>0x40009000</baseAddress>
+   <interrupt>
+    <name>GPIO1</name>
+    <description>GPIO1 IRQ</description>
+    <value>25</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO1 Individual I/O for each GPIO 1-->
+  <peripheral>
+   <name>HTMR</name>
+   <description>High Speed Timer Module.</description>
+   <baseAddress>0x4001B000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0xFFF</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>HTimer</name>
+    <description>HTimer interrupt.</description>
+    <value>93</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>HTimer Long-Interval Counter. This register contains the 32 most significant bits of the counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>RTS</name>
+       <description>HTimer Long Interval Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>HTimer Short Interval Counter. This counter ticks ever t_htclk (16.48uS). HTIMER_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>RTSS</name>
+       <description>HTimer Short Interval Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RAS</name>
+     <description>Long Interval Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>RAS</name>
+       <description>HTimer Long Interval Alarm. An Alarm is triggered when this value matches HTIMER_SEC[19:0]</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RSSA</name>
+     <description>HTimer Short Interval Alarm. This register contains the reload value for the short interval alarm, HTIMER_CTRL.alarm_ss_fl is raised on rollover.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>RSSA</name>
+       <description>This register contains the reload value for the short interval alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>HTimer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>HTEN</name>
+       <description>HTimer Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADE</name>
+       <description>Long Interval Alarm Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ASE</name>
+       <description>Short Interval Alarm Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>HTimer Busy. This bit is set to 1 by hardware when changes to HTimer registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>HTimer Ready. This bit is set to 1 by hardware when the HTimer count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the HTimer count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDYE</name>
+       <description>HTimer Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ALDF</name>
+       <description>Long Interval Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ALSF</name>
+       <description>Short Interval Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WE</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical HTimer bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--HTMR High Speed Timer Module.-->
+  <peripheral derivedFrom="HTMR">
+   <name>HTMR1</name>
+   <description>High Speed Timer Module. 1</description>
+   <baseAddress>0x4001C000</baseAddress>
+   <interrupt>
+    <name>HTMR1</name>
+    <description>HTMR1 IRQ</description>
+    <value>94</value>
+   </interrupt>
+  </peripheral>
+<!--HTMR1 High Speed Timer Module. 1-->
+  <peripheral>
+   <name>I2C0</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>I2C</groupName>
+   <baseAddress>0x4001D000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2C0</name>
+    <description>I2C0 IRQ</description>
+    <value>13</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>I2C_EN</name>
+       <description>I2C Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable I2C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable I2C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST</name>
+       <description>Master Mode Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave_mode</name>
+         <description>Slave Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master_mode</name>
+         <description>Master Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GEN_CALL_ADDR</name>
+       <description>General Call Address Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Ignore Gneral Call Address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Acknowledge general call address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_MODE</name>
+       <description>Interactive Receive Mode.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interactive Receive Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interactive Receive Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_MODE_ACK</name>
+       <description>Data Acknowledge. This bit defines the acknowledge bit returned by the I2C receiver while IRXM = 1 HW forces ACK to 0 when IRXM = 0.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ack</name>
+         <description>return ACK (pulling SDA LOW).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>return NACK (leaving SDA HIGH).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_OUT</name>
+       <description>SCL Output. This bits control SCL output when SWOE =1.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_scl_low</name>
+         <description>Drive SCL low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_scl</name>
+         <description>Release SCL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDA_OUT</name>
+       <description>SDA Output. This bits control SDA output when SWOE = 1. </description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_sda_low</name>
+         <description>Drive SDA low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_sda</name>
+         <description>Release SDA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL</name>
+       <description>SCL status. This bit reflects the logic gate of SCL signal. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDA</name>
+       <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SW_OUT_EN</name>
+       <description>Software Output Enable.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>outputs_disable</name>
+         <description>I2C Outputs SCLO and SDAO disabled. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputs_enable</name>
+         <description>I2C Outputs SCLO and SDAO enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read. This bit reflects the R/W bit of an address match (AMI = 1) or general call match(GCI = 1). This bit is valid 3 cycles after the relevant interrupt bit is set.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_CLK_STRETCH_DIS</name>
+       <description>This bit will disable slave clock stretching when set.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Slave clock stretching enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Slave clock stretching disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_PP_MODE</name>
+       <description>SCL Push-Pull Mode. This bit controls whether SCL is operated in a the I2C standard open-drain mode, or in a non-standard push-pull mode where the Hi-Z output isreplaced with Drive-1. The non-standard mode should only be used when operating as a master and communicating with slaves that are guaranteed to never drive SCL low. </description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Standard open-drain operation: drive low for 0, Hi-Z for 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Non-standard push-pull operation: drive low for 0, drive high for 1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HS_MODE</name>
+       <description>Hs-mode Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Hs-mode disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Hs-mode enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BUS</name>
+       <description>Bus Status.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>I2C Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>I2C Bus Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EMPTY</name>
+       <description>RX empty.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX Full.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX Empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>TX Full.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLK_MODE</name>
+       <description>Clock Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_actively_driving_scl_clock</name>
+         <description>Device not actively driving SCL clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>actively_driving_scl_clock</name>
+         <description>Device operating as master and actively driving SCL clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL0</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <name>INT_FL0_Done</name>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_MODE</name>
+       <description>Interactive Receive Interrupt.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GEN_CALL_ADDR</name>
+       <description>Slave General Call Address Match Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave Address Match Interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>Receive Threshold Interrupt. This bit is automaticcaly cleared when RX_FIFO is below the threshold level.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. RX_FIFO equal or more bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THRESH</name>
+       <description>Transmit Threshold Interrupt. This bit is automaticcaly cleared when TX_FIFO is above the threshold level.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP Interrupt.</description>
+       <bitRange>[6:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Address Acknowledge Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ER</name>
+       <description>Arbritation error Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ER</name>
+       <description>timeout Error Interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ER</name>
+       <description>Address NACK Error Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ER</name>
+       <description>Data NACK Error Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DO_NOT_RESP_ER</name>
+       <description>Do Not Respond Error Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ER</name>
+       <description>Start Error Interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ER</name>
+       <description>Stop Error Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCK_OUT</name>
+       <description>Transmit Lock Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt.</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt.</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN0</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when DONE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_MODE</name>
+       <description>Description not available.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when RX_MODE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GEN_CALL_ADDR</name>
+       <description>Slave mode general call address match received input enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when GEN_CTRL_ADDR = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave mode incoming address match interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when ADDR_MATCH = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>RX FIFO Above Treshold Level Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THRESH</name>
+       <description>TX FIFO Below Treshold Level Interrupt Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Stop Interrupt Enable</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when STOP = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Received Address ACK from Slave Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ER</name>
+       <description>Master Mode Arbitration Lost Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ER</name>
+       <description>Timeout Error Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ER</name>
+       <description>Master Mode Address NACK Received Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ER</name>
+       <description>Master Mode Data NACK Received Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DO_NOT_RESP_ER</name>
+       <description>Slave Mode Do Not Respond Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ER</name>
+       <description>Out of Sequence START condition detected interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ER</name>
+       <description>Out of Sequence STOP condition detected interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCK_OUT</name>
+       <description>TX FIFO Locked Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when TXLOIE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt.</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt.</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL1</name>
+     <description>Interrupt Status Register 1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OVERFLOW</name>
+       <description>Receiver Overflow Interrupt. When operating as a slave receiver, this bit is set when you reach the first data bit and the RX FIFO and shift register are both full.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UNDERFLOW</name>
+       <description>Transmit Underflow Interrupt. When operating as a slave transmitter, this bit is set when you reach the first data bit and the TX FIFO is empty and the master is still asking for more data (i.e the master hasn't sent a NACK yet).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN1</name>
+     <description>Interrupt Staus Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_OVERFLOW</name>
+       <description>Receiver Overflow Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UNDERFLOW</name>
+       <description>Transmit Underflow Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO_LEN</name>
+     <description>FIFO Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RX_LEN</name>
+       <description>Receive FIFO Length.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_LEN</name>
+       <description>Transmit FIFO Length.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RX_CTRL0</name>
+     <description>Receive Control Register 0.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>DNR</name>
+       <description>Do Not Respond.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Always respond to address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>not_respond_rx_fifo_empty</name>
+         <description>Do not respond to address match when RX_FIFO is not empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Receive FIFO Flush. This bit is automatically cleared to 0 after the operation. Setting this bit to 1 will affect RX_FIFO status.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush RX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>Receive FIFO Threshold. These bits define the RX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RX_CTRL1</name>
+     <description>Receive Control Register 1.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>RX_CNT</name>
+       <description>Receive Count Bits. These bits define the number of bytes to be received in a transaction, except for the case RXCNT = 0. RXCNT = 0 means 256 bytes to be received in a transaction.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>RX_FIFO</name>
+       <description>Receive FIFO Count. These bits reflect the number of byte in the RX_FIFO. These bits are flushed when I2CEN = 0.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TX_CTRL0</name>
+     <description>Transmit Control Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>TX_PRELOAD</name>
+       <description>Transmit FIFO Preaload Mode. Setting this bit will allow for high speed application to preload the transmit FIFO prior to Slave Address Match.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TX_READY_MODE</name>
+       <description>Transmit FIFO Ready Manual Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW control of I2CTXRDY enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW control of I2CTXRDY disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_AMGC_AFD</name>
+       <description>TX FIFO General Call Address Match Auto Flush.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>TX_AMW_AFD</name>
+       <description>TX FIFO Slave Address Match Write Auto Flush.</description>
+       <bitRange>[3:3]</bitRange>
+      </field>
+      <field>
+       <name>TX_AMR_AFD</name>
+       <description>TX FIFO Slave Address Match Read Auto Flush.</description>
+       <bitRange>[4:4]</bitRange>
+      </field>
+      <field>
+       <name>TX_NACK_AFD</name>
+       <description>TX FIFO received NACK Auto Flush.</description>
+       <bitRange>[5:5]</bitRange>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Transmit FIFO Flush. This bit is automatically cleared to 0 after the operation.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush TX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THRESH</name>
+       <description>Transmit FIFO Threshold. These bits define the TX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TX_CTRL1</name>
+     <description>Transmit Control Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>TX_READY</name>
+       <description>Transmit FIFO Preload Ready.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TXFIFO</name>
+       <description>Transmit FIFO Count. These bits reflect the number of bytes in the TX_FIFO.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MASTER_CTRL</name>
+     <description>Master Control Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Setting this bit to 1 will start a master transfer.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>RESTART</name>
+       <description>Setting this bit to 1 will generate a repeated START.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Setting this bit to 1 will generate a STOP condition.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>SL_EX_ADDR</name>
+       <description>Slave Extend Address Select.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MCODE</name>
+       <description>Master Code. These bits set the Master Code used in Hs-mode operation.</description>
+       <bitRange>[10:8]</bitRange>
+      </field>
+      <field>
+       <name>SCL_SPEED_UP</name>
+       <description>Serial Clock speed Up. Setting this bit disables the master's monitoring of SCL state for other external masters or slaves.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Master monitors SCL state.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SCL state monitoring disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_LO</name>
+     <description>Clock Low Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_LO</name>
+       <description>Clock low. In master mode, these bits define the SCL low period. In slave mode, these bits define the time SCL will be held low after data is outputted.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_HI</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_HI</name>
+       <description>Clock High. In master mode, these bits define the SCL high period.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HS_CLK</name>
+     <description>HS-Mode Clock Control Register</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>HS_CLK_LO</name>
+       <description>Slave Address.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>HS_CLK_HI</name>
+       <description>Slave Address.</description>
+       <bitRange>[15:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TIMEOUT</name>
+     <description>Timeout Register</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>TO</name>
+       <description>Timeout</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TXEN</name>
+       <description>TX channel enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXEN</name>
+       <description>RX channel enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLAVE_ADDR</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>SLAVE_ADDR</name>
+       <description>Slave Address.</description>
+       <bitRange>[9:0]</bitRange>
+      </field>
+      <field>
+       <name>EX_ADDR</name>
+       <description>Extended Address Select.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2C0 Inter-Integrated Circuit.-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C1</name>
+   <description>Inter-Integrated Circuit. 1</description>
+   <baseAddress>0x4001E000</baseAddress>
+   <interrupt>
+    <name>I2C1</name>
+    <description>I2C1 IRQ</description>
+    <value>36</value>
+   </interrupt>
+  </peripheral>
+<!--I2C1 Inter-Integrated Circuit. 1-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C2</name>
+   <description>Inter-Integrated Circuit. 2</description>
+   <baseAddress>0x4001F000</baseAddress>
+   <interrupt>
+    <name>I2C2</name>
+    <description>I2C2 IRQ</description>
+    <value>62</value>
+   </interrupt>
+  </peripheral>
+<!--I2C2 Inter-Integrated Circuit. 2-->
+  <peripheral>
+   <name>ICC0</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x4002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CACHE_ID</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CCHID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCFG</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCHSZ</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEMSZ</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CACHE_CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ICC0 Instruction Cache Controller Registers-->
+  <peripheral derivedFrom="ICC0">
+   <name>ICC1</name>
+   <description>Instruction Cache Controller Registers 1</description>
+   <baseAddress>0x4002AC000</baseAddress>
+  </peripheral>
+<!--ICC1 Instruction Cache Controller Registers 1-->
+  <peripheral>
+   <name>MCR</name>
+   <description>Misc Control.</description>
+   <baseAddress>0x40006C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>ECCEN</name>
+     <description>ECC Enable Register</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>SYSRAM0ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM1ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM2ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM3ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM4ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSRAM5ECCEN</name>
+       <description>ECC System RAM Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IC0ECCEN</name>
+       <description>Icache0 ECC Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IC1ECCEN</name>
+       <description>Icache1 ECC Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICXIPFECCEN</name>
+       <description>IcacheXIP ECC Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FL0ECCEN</name>
+       <description>Flash0 ECC Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FL1ECCEN</name>
+       <description>Flash1 ECC Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HIRC96M</name>
+     <description>96MHz High Frequency Clock Adjustment Register</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>HIRC96MTR</name>
+       <description>HIRC96M Trim: Allow user to change 96M Frequency</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>default</name>
+         <description>Default setting.</description>
+         <value>0x100</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>GPIOOUT_EN Function Enable Register</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>SQWOUT0EN</name>
+       <description>Allows SQWOUT on GPIO0_19</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQWOUT1EN</name>
+       <description>Allows SQWOUT on GPIO0_27</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PDOWNOUT0EN</name>
+       <description>Allows PDOWN on GPIO0_18</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PDOWNOUT1EN</name>
+       <description>Allows PDOWN on GPIO0_26</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AINCOMP</name>
+     <description>Comparator Power Control Register</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>AINCOMP0PD</name>
+       <description>Power Down AIN Comp0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>power on</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>power off</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AINCOMP1PD</name>
+       <description>Power Down AIN Comp1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>power on</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>power off</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AINCOMP2PD</name>
+       <description>Power Down AIN Comp2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>power on</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>power off</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AINCOMP3PD</name>
+       <description>Power Down AIN Comp3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>power on</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>power off</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AINCOMPHYST</name>
+       <description>Set Hysteresis on Analog Comparators</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Misc Power State Control Register</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>VDDCSWEN</name>
+       <description>Allows switching VDDC from VCOREA to VCOREB</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDCSW</name>
+       <description>Controls switching of VCORE</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>USBSWEN_N</name>
+       <description>USB Switch Control</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>off</name>
+         <description>USB SW off in LP modes</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>on</name>
+         <description>USB SW On</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUCKCLKSCALEN</name>
+       <description>Allows Dynamic scaling of SIMO clock, reduces power in LP Modes</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>P1M</name>
+       <description>Enable the Reset Pad Pull Up Resistors</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1m</name>
+         <description>1MOhm Pullup</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>25k</name>
+         <description>25kOhm Pullup.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RSTN_VOLTAGE_SEL</name>
+       <description>Error! Description not Found!</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--MCR Misc Control.-->
+  <peripheral>
+   <name>OWM</name>
+   <description>1-Wire Master Interface.</description>
+   <baseAddress>0x4003D000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>OneWire</name>
+    <value>67</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CFG</name>
+     <description>1-Wire Master Configuration.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>long_line_mode</name>
+       <description>Long Line Mode.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>force_pres_det</name>
+       <description>Force Line During Presence Detect.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_en</name>
+       <description>Bit Bang Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_mode</name>
+       <description>Provide an extra output control to control an external pullup.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_enable</name>
+       <description>Enable External Pullup.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>single_bit_mode</name>
+       <description>Enable Single Bit TX/RX Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>overdrive</name>
+       <description>Enables overdrive speed for 1-Wire operations.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>int_pullup_enable</name>
+       <description>Enable intenral pullup.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_DIV_1US</name>
+     <description>1-Wire Master Clock Divisor.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>divisor</name>
+       <description>Clock Divisor for 1Mhz.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL_STAT</name>
+     <description>1-Wire Master Control/Status.</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>start_ow_reset</name>
+       <description>Start OW Reset.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>sra_mode</name>
+       <description>SRA Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_oe</name>
+       <description>Bit Bang Output Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ow_input</name>
+       <description>OW Input State.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>od_spec_mode</name>
+       <description>Overdrive Spec Mode.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>presence_detect</name>
+       <description>Presence Pulse Detected.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>1-Wire Master Data Buffer.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>tx_rx</name>
+       <description>TX/RX Buffer.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>1-Wire Master Interrupt Flags.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>TX Data Empty Interrupt Flag.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>RX Data Ready Interrupt Flag</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Flag.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Flag.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>1-Wire Master Interrupt Enables.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>Tx Data Empty Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>Rx Data Ready Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Enable.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--OWM 1-Wire Master Interface.-->
+  <peripheral>
+   <name>PT</name>
+   <description>Pulse Train</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C020</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0010</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RATE_LENGTH</name>
+     <description>Pulse Train Configuration</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>rate_control</name>
+       <description>Pulse Train Enable and Rate Control. Set to 0 to disable the Pulse Train.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>27</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>mode</name>
+       <description>Pulse Train Output Mode/Train Length</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>32_BIT</name>
+         <description>Pulse train, 32 bit pattern.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SQUARE_WAVE</name>
+         <description>Square wave mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_BIT</name>
+         <description>Pulse train, 2 bit pattern.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_BIT</name>
+         <description>Pulse train, 3 bit pattern.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_BIT</name>
+         <description>Pulse train, 4 bit pattern.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5_BIT</name>
+         <description>Pulse train, 5 bit pattern.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_BIT</name>
+         <description>Pulse train, 6 bit pattern.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7_BIT</name>
+         <description>Pulse train, 7 bit pattern.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_BIT</name>
+         <description>Pulse train, 8 bit pattern.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9_BIT</name>
+         <description>Pulse train, 9 bit pattern.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_BIT</name>
+         <description>Pulse train, 10 bit pattern.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11_BIT</name>
+         <description>Pulse train, 11 bit pattern.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_BIT</name>
+         <description>Pulse train, 12 bit pattern.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13_BIT</name>
+         <description>Pulse train, 13 bit pattern.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14_BIT</name>
+         <description>Pulse train, 14 bit pattern.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15_BIT</name>
+         <description>Pulse train, 15 bit pattern.</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_BIT</name>
+         <description>Pulse train, 16 bit pattern.</description>
+         <value>16</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>17_BIT</name>
+         <description>Pulse train, 17 bit pattern.</description>
+         <value>17</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>18_BIT</name>
+         <description>Pulse train, 18 bit pattern.</description>
+         <value>18</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>19_BIT</name>
+         <description>Pulse train, 19 bit pattern.</description>
+         <value>19</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>20_BIT</name>
+         <description>Pulse train, 20 bit pattern.</description>
+         <value>20</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>21_BIT</name>
+         <description>Pulse train, 21 bit pattern.</description>
+         <value>21</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>22_BIT</name>
+         <description>Pulse train, 22 bit pattern.</description>
+         <value>22</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>23_BIT</name>
+         <description>Pulse train, 23 bit pattern.</description>
+         <value>23</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>24_BIT</name>
+         <description>Pulse train, 24 bit pattern.</description>
+         <value>24</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>25_BIT</name>
+         <description>Pulse train, 25 bit pattern.</description>
+         <value>25</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>26_BIT</name>
+         <description>Pulse train, 26 bit pattern.</description>
+         <value>26</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>27_BIT</name>
+         <description>Pulse train, 27 bit pattern.</description>
+         <value>27</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>28_BIT</name>
+         <description>Pulse train, 28 bit pattern.</description>
+         <value>28</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>29_BIT</name>
+         <description>Pulse train, 29 bit pattern.</description>
+         <value>29</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30_BIT</name>
+         <description>Pulse train, 30 bit pattern.</description>
+         <value>30</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>31_BIT</name>
+         <description>Pulse train, 31 bit pattern.</description>
+         <value>31</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRAIN</name>
+     <description>Write the repeating bit pattern that is shifted out, LSB first, when configured in Pulse Train mode. See PT_RATE_LENGTH.mode for setting the length.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>LOOP</name>
+     <description>Pulse Train Loop Count</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>count</name>
+       <description>Number of loops for this pulse train to repeat.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>delay</name>
+       <description>Delay between loops of the Pulse Train in PT Peripheral Clock cycles</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>12</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESTART</name>
+     <description> Pulse Train Auto-Restart Configuration.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt_x_select</name>
+       <description>Auto-Restart PT X Select</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_x_loop_exit</name>
+       <description>Enable Auto-Restart on PT X Loop Exit</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt_y_select</name>
+       <description>Auto-Restart PT Y Select</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_y_loop_exit</name>
+       <description>Enable Auto-Restart on PT Y Loop Exit</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PT Pulse Train-->
+  <peripheral derivedFrom="PT">
+   <name>PT1</name>
+   <description>Pulse Train 1</description>
+   <baseAddress>0x4003C030</baseAddress>
+  </peripheral>
+<!--PT1 Pulse Train 1-->
+  <peripheral derivedFrom="PT">
+   <name>PT2</name>
+   <description>Pulse Train 2</description>
+   <baseAddress>0x4003C040</baseAddress>
+  </peripheral>
+<!--PT2 Pulse Train 2-->
+  <peripheral derivedFrom="PT">
+   <name>PT3</name>
+   <description>Pulse Train 3</description>
+   <baseAddress>0x4003C050</baseAddress>
+  </peripheral>
+<!--PT3 Pulse Train 3-->
+  <peripheral derivedFrom="PT">
+   <name>PT4</name>
+   <description>Pulse Train 4</description>
+   <baseAddress>0x4003C060</baseAddress>
+  </peripheral>
+<!--PT4 Pulse Train 4-->
+  <peripheral derivedFrom="PT">
+   <name>PT5</name>
+   <description>Pulse Train 5</description>
+   <baseAddress>0x4003C070</baseAddress>
+  </peripheral>
+<!--PT5 Pulse Train 5-->
+  <peripheral derivedFrom="PT">
+   <name>PT6</name>
+   <description>Pulse Train 6</description>
+   <baseAddress>0x4003C080</baseAddress>
+  </peripheral>
+<!--PT6 Pulse Train 6-->
+  <peripheral derivedFrom="PT">
+   <name>PT7</name>
+   <description>Pulse Train 7</description>
+   <baseAddress>0x4003C090</baseAddress>
+  </peripheral>
+<!--PT7 Pulse Train 7-->
+  <peripheral derivedFrom="PT">
+   <name>PT8</name>
+   <description>Pulse Train 8</description>
+   <baseAddress>0x4003C0A0</baseAddress>
+  </peripheral>
+<!--PT8 Pulse Train 8-->
+  <peripheral derivedFrom="PT">
+   <name>PT9</name>
+   <description>Pulse Train 9</description>
+   <baseAddress>0x4003C0B0</baseAddress>
+  </peripheral>
+<!--PT9 Pulse Train 9-->
+  <peripheral derivedFrom="PT">
+   <name>PT10</name>
+   <description>Pulse Train 10</description>
+   <baseAddress>0x4003C0C0</baseAddress>
+  </peripheral>
+<!--PT10 Pulse Train 10-->
+  <peripheral derivedFrom="PT">
+   <name>PT11</name>
+   <description>Pulse Train 11</description>
+   <baseAddress>0x4003C0D0</baseAddress>
+  </peripheral>
+<!--PT11 Pulse Train 11-->
+  <peripheral derivedFrom="PT">
+   <name>PT12</name>
+   <description>Pulse Train 12</description>
+   <baseAddress>0x4003C0E0</baseAddress>
+  </peripheral>
+<!--PT12 Pulse Train 12-->
+  <peripheral derivedFrom="PT">
+   <name>PT13</name>
+   <description>Pulse Train 13</description>
+   <baseAddress>0x4003C0F0</baseAddress>
+  </peripheral>
+<!--PT13 Pulse Train 13-->
+  <peripheral derivedFrom="PT">
+   <name>PT14</name>
+   <description>Pulse Train 14</description>
+   <baseAddress>0x4003C100</baseAddress>
+  </peripheral>
+<!--PT14 Pulse Train 14-->
+  <peripheral derivedFrom="PT">
+   <name>PT15</name>
+   <description>Pulse Train 15</description>
+   <baseAddress>0x4003C110</baseAddress>
+  </peripheral>
+<!--PT15 Pulse Train 15-->
+  <peripheral>
+   <name>PTG</name>
+   <description>Pulse Train Generation</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0018</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>PT</name>
+    <description>Pulse Train IRQ</description>
+    <value>59</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ENABLE</name>
+     <description>Global Enable/Disable Controls for All Pulse Trains</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Enable/Disable control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Enable/Disable control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Enable/Disable control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Enable/Disable control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Enable/Disable control for PT4</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Enable/Disable control for PT5</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Enable/Disable control for PT6</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Enable/Disable control for PT7</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Enable/Disable control for PT8</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Enable/Disable control for PT9</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Enable/Disable control for PT10</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Enable/Disable control for PT11</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Enable/Disable control for PT12</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Enable/Disable control for PT13</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Enable/Disable control for PT14</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Enable/Disable control for PT15</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESYNC</name>
+     <description>Global Resync (All Pulse Trains) Control</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Resync control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Resync control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Resync control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Resync control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Resync control for PT4</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Resync control for PT5</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Resync control for PT6</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Resync control for PT7</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Resync control for PT8</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Resync control for PT9</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Resync control for PT10</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Resync control for PT11</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Resync control for PT12</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Resync control for PT13</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Resync control for PT14</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Resync control for PT15</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Pulse Train Interrupt Flags</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Flag</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Flag</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Flag</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Pulse Train 8 Stopped Interrupt Flag</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Pulse Train 9 Stopped Interrupt Flag</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Pulse Train 10 Stopped Interrupt Flag</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Pulse Train 11 Stopped Interrupt Flag</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Pulse Train 12 Stopped Interrupt Flag</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Pulse Train 13 Stopped Interrupt Flag</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Pulse Train 14 Stopped Interrupt Flag</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Pulse Train 15 Stopped Interrupt Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Pulse Train Interrupt Enable/Disable</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Pulse Train 8 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Pulse Train 9 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Pulse Train 10 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Pulse Train 11 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Pulse Train 12 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Pulse Train 13 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Pulse Train 14 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Pulse Train 15 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_EN</name>
+     <description>Pulse Train Global Safe Enable.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT8</name>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT9</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT10</name>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT11</name>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT12</name>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT13</name>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT14</name>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT15</name>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_DIS</name>
+     <description>Pulse Train Global Safe Disable.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT8</name>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT9</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT10</name>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT11</name>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT12</name>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT13</name>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT14</name>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT15</name>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PTG Pulse Train Generation-->
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x40006800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>LPCN</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAMRET</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en1</name>
+         <description>Enable System RAM 0 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en2</name>
+         <description>Enable System RAM 0 and 1 retention.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en3</name>
+         <description>Enable System RAM 0 and 1 retention, if RREGEN=0, Enable all System RAM retention.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BCKGRND</name>
+       <description>Background Mode ENable. This bit allows low-power background mode operations, while the CPU is in DeepSleep.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FWKM</name>
+       <description>Fast Wake-Up Mode. This bit enables fast wake-up from DeepSleep mode. (5uS typical). </description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BGOFF</name>
+       <description>Bandgap OFF. This controls the System Bandgap in DeepSleep mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>Bandgap is always ON.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>Bandgap is OFF in DeepSleep mode(default).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREMD</name>
+       <description>VDDC(Vcore) Monitor Disable. This bit controls the power monitor on the VCore supply in all operating modes.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON(default)</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VREGIMD</name>
+       <description>VRTC Monitor Disable. This bit controls the power monitor on the Always-On Supply in all operating modes.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON(default)</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDAMD</name>
+       <description>VDDA Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON(default)</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDIOMD</name>
+       <description>VDDIO Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON(default)</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDIOHMD</name>
+       <description>VFDDIOH Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON(default)</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PORVDDIOMD</name>
+       <description>VDDIO Power-On Reset Monitor Disable. This bit controls the Power-On Reset monitor on VDDIO supply in all operating mods.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PORVDDIOHMD</name>
+       <description>VDDIOH Power-On Reset Monitor Disable. This bit controls the Power-On Reset monitor on VDDIOH supply in all operating mods.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDBMD</name>
+       <description>VDDB Power-On Reset Monitor Disable. This bit controls the Power-On Reset monitor on VDDB supply in all operating mods.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VRXOUTMD</name>
+       <description>VRXOUT Bluetooth Receiver Supply Power Monitor Disable .</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VTXOUTMD</name>
+       <description>VTXOUT Bluetooth Transmitter Supply Power Monitor Disable .</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PDOWNDSLEN</name>
+       <description>PDOWN DEEPSLEEP Output Enable .</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST0</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO0.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin(s) transition(s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN0</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin(s) on transition(s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST1</name>
+     <description>Low Power I/O Wakeup Status Register 1. This register indicates the low power wakeup status for GPIO1.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin(s) transition(s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>18</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN1</name>
+     <description>Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup functionality for GPIO1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin(s) on transition(s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWST</name>
+     <description>Low Power Peripheral Wakeup Status Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>USBLSWKST</name>
+       <description>USB UTMI Linestate Detect Wakeup Flag(write one to clear). One or both of these bits will be set when the USB bus activity causes the linestate to change and the device to wake while USB wakeup is enabled using PMLUSBWKEN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>USBVBUSWKST</name>
+       <description>USB VBUS Detect Wakeup Flag (write one to clear). This bit will be set when the USB power supply is powered on or powered off.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SDMAWKST</name>
+       <description>SDMA Wakeup Status Flag.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP0WKST</name>
+       <description>Analog Input Comparator 0 Wakeup Status Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP1WKST</name>
+       <description>Analog Input Comparator 1 Wakeup Status Flag.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP2WKST</name>
+       <description>Analog Input Comparator 2 Wakeup Status Flag.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP3WKST</name>
+       <description>Analog Input Comparator 3 Wakeup Status Flag.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP0ST</name>
+       <description>Analog Input Comparator 0 Output Status Flag.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP1ST</name>
+       <description>Analog Input Comparator 1 Output Status Flag.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP2ST</name>
+       <description>Analog Input Comparator 2 Output Status Flag.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP3ST</name>
+       <description>Analog Input Comparator 3 Output Status Flag.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BBMODEST</name>
+       <description>Battery Back Wakeup Flag (write one to clear). This bit will be set when exiting Battery Backup Mode.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RSTWKST</name>
+       <description>Reset Detect Wakeup Status Flag.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWEN</name>
+     <description>Low Power Peripheral Wakeup Enable Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>USBLSWKEN</name>
+       <description>USB UTMI Linestate Detect Wakeup Enable. These bits allow wakeup from the corresponding USB linestate signal(s) on transition(s) from low to high or high to low when PM.USBWKEN is set.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>USBVBUSWKEN</name>
+       <description>USB VBUS Detect Wakeup Enable. This bit allows wakeup from the USB power supply on or off status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SDMAWKEN</name>
+       <description>SDMA Wakeup Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP0WKEN</name>
+       <description>Analog Input Comparator 0 Wakeup Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP1WKEN</name>
+       <description>Analog Input Comparator 1 Wakeup Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP2WKEN</name>
+       <description>Analog Input Comparator 2 Wakeup Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP3WKEN</name>
+       <description>Analog Input Comparator 3 Wakeup Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPMEMSD</name>
+     <description>Low Power Memory Shutdown Control.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>SRAM0SD</name>
+       <description>System RAM block 0 Shut Down.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM1SD</name>
+       <description>System RAM block 1 Shut Down.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM2SD</name>
+       <description>System RAM block 2 Shut Down.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM3SD</name>
+       <description>System RAM block 3 Shut Down.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM4SD</name>
+       <description>System RAM block 4 Shut Down.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRAM5SD</name>
+       <description>System RAM block 5 Shut Down.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHESD</name>
+       <description>Instruction Cache RAM Shut Down.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHEXIPSD</name>
+       <description>XiP Instruction Cache RAM Shut Down.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRCCSD</name>
+       <description>System Cache RAM Shut Down.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRYPTOSD</name>
+       <description>Crypto MAA RAM Shut Down.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USBFIFOSD</name>
+       <description>USB FIFO Shut Down.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROMSD</name>
+       <description>ROM Shut Down.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROM1SD</name>
+       <description>ROM1 Shut Down.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IC1SD</name>
+       <description>ICache 1 Shut Down.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPVDDPD</name>
+     <description>Low Power VDD Domain Power Down Control.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>VREGOBPD</name>
+       <description>Power down SIMO Vreg B (VCOREB+VDDC) in backup mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>up</name>
+         <description>Enabled in backup mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>down</name>
+         <description>Disabled in backup mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VREGODPD</name>
+       <description>Power down SIMO Vreg D (BTLE).</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>up</name>
+         <description>Enabled</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>down</name>
+         <description>Disabled</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDD2PD</name>
+       <description>Power down VDD2 (CPU0+peripherals).</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>up</name>
+         <description>Enabled</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>down</name>
+         <description>Disabled</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDD3PD</name>
+       <description>Power down VDD3 (CPU1+audio).</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>up</name>
+         <description>Enabled</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>down</name>
+         <description>Disabled</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDD4PD</name>
+       <description>Power down VDD4 (SDMA+peripherals).</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>up</name>
+         <description>Enabled</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>down</name>
+         <description>Disabled</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDD5PD</name>
+       <description>Power down VDD5 (BTLE digital).</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>up</name>
+         <description>Enabled</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>down</name>
+         <description>Disabled</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BURETVEC</name>
+     <description>BACKUP Return Vector Register</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>GPR0</name>
+       <description>General Purpose Register 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUAOD</name>
+     <description>BACKUP AoD Register</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>GPR1</name>
+       <description>General Purpose Register 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PWRSEQ Power Sequencer / Low Power Control Register.-->
+  <peripheral>
+   <name>RPU</name>
+   <description>Resource Protection Unit</description>
+   <baseAddress>0x40002000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>GCR</name>
+     <description>GCR RPU Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SIR</name>
+     <description>SIR RPU Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FCR</name>
+     <description>FCR RPU Register.</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TPU</name>
+     <description>TPU RPU Register.</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RPU</name>
+     <description>RPU Register.</description>
+     <addressOffset>0x0020</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WDT0</name>
+     <description>WDT0 RPU Register.</description>
+     <addressOffset>0x0030</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WDT1</name>
+     <description>WDT1 RPU Register.</description>
+     <addressOffset>0x0034</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WDT2</name>
+     <description>WDT2 RPU Register.</description>
+     <addressOffset>0x0038</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SMON</name>
+     <description>SMON RPU Register.</description>
+     <addressOffset>0x0040</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SIMO</name>
+     <description>SIMO RPU Register.</description>
+     <addressOffset>0x0044</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DVS</name>
+     <description>DVS RPU Register.</description>
+     <addressOffset>0x0048</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AES</name>
+     <description>AES RPU Register.</description>
+     <addressOffset>0x0050</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RTC</name>
+     <description>RTC RPU Register.</description>
+     <addressOffset>0x0060</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WUT</name>
+     <description>WUT RPU Register.</description>
+     <addressOffset>0x0064</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWRSEQ</name>
+     <description>PWRSEQ RPU Register.</description>
+     <addressOffset>0x0068</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MCR</name>
+     <description>MCR RPU Register.</description>
+     <addressOffset>0x006C</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO0</name>
+     <description>GPIO0 RPU Register.</description>
+     <addressOffset>0x0080</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO1</name>
+     <description>GPIO1 RPU Register.</description>
+     <addressOffset>0x0090</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TMR0</name>
+     <description>TMR0 RPU Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TMR1</name>
+     <description>TMR1 RPU Register.</description>
+     <addressOffset>0x0110</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TMR2</name>
+     <description>TMR2 RPU Register.</description>
+     <addressOffset>0x0120</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TMR3</name>
+     <description>TMR3 RPU Register.</description>
+     <addressOffset>0x0130</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TMR4</name>
+     <description>TMR4 RPU Register.</description>
+     <addressOffset>0x0140</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TMR5</name>
+     <description>TMR5 RPU Register.</description>
+     <addressOffset>0x0150</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HTIMER0</name>
+     <description>HTIMER0 RPU Register.</description>
+     <addressOffset>0x01B0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HTIMER1</name>
+     <description>HTIMER1 RPU Register.</description>
+     <addressOffset>0x01C0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>I2C0_BUS0</name>
+     <description>I2C0_BUS0 RPU Register.</description>
+     <addressOffset>0x01D0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>I2C1_BUS0</name>
+     <description>I2C1_BUS0 RPU Register.</description>
+     <addressOffset>0x01E0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>I2C2_BUS0</name>
+     <description>I2C2_BUS0 RPU Register.</description>
+     <addressOffset>0x01F0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SPIXFM</name>
+     <description>SPIXFM RPU Register.</description>
+     <addressOffset>0x0260</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SPIXFC</name>
+     <description>SPIXFC RPU Register.</description>
+     <addressOffset>0x0270</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA0</name>
+     <description>DMA0 RPU Register.</description>
+     <addressOffset>0x0280</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FLC0</name>
+     <description>FLC0 RPU Register.</description>
+     <addressOffset>0x0290</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FLC1</name>
+     <description>FLC1 RPU Register.</description>
+     <addressOffset>0x0294</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ICC0</name>
+     <description>ICC0 RPU Register.</description>
+     <addressOffset>0x02A0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ICC1</name>
+     <description>ICC1 RPU Register.</description>
+     <addressOffset>0x02A4</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFCC</name>
+     <description>SFCC RPU Register.</description>
+     <addressOffset>0x02F0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SRCC</name>
+     <description>SRCC RPU Register.</description>
+     <addressOffset>0x0330</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADC</name>
+     <description>ADC RPU Register.</description>
+     <addressOffset>0x0340</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA1</name>
+     <description>DMA1 RPU Register.</description>
+     <addressOffset>0x0350</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SDMA</name>
+     <description>SDMA RPU Register.</description>
+     <addressOffset>0x0360</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SDHCCTRL</name>
+     <description>SD Host Controller (APB).</description>
+     <addressOffset>0x0370</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SPIXR</name>
+     <description>SPIXR RPU Register.</description>
+     <addressOffset>0x03A0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PTG_BUS0</name>
+     <description>PTG_BUS0 RPU Register.</description>
+     <addressOffset>0x03C0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OWM</name>
+     <description>OWM RPU Register.</description>
+     <addressOffset>0x03D0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SEMA</name>
+     <description>SEMA RPU Register.</description>
+     <addressOffset>0x03E0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>UART0</name>
+     <description>UART0 RPU Register.</description>
+     <addressOffset>0x0420</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>UART1</name>
+     <description>UART1 RPU Register.</description>
+     <addressOffset>0x0430</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>UART2</name>
+     <description>UART2 RPU Register.</description>
+     <addressOffset>0x0440</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SPI1</name>
+     <description>SPI1 RPU Register.</description>
+     <addressOffset>0x0460</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SPI2</name>
+     <description>SPI2 RPU Register.</description>
+     <addressOffset>0x0470</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUDIO</name>
+     <description>AUDIO RPU Register.</description>
+     <addressOffset>0x04C0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRNG</name>
+     <description>TRNG RPU Register.</description>
+     <addressOffset>0x04D0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLE</name>
+     <description>BTLE RPU Register.</description>
+     <addressOffset>0x0500</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>I2C0_BUS1</name>
+     <description>I2C0_BUS1 RPU Register.</description>
+     <addressOffset>0x11D0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>I2C1_BUS1</name>
+     <description>I2C1_BUS1 RPU Register.</description>
+     <addressOffset>0x11E0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>I2C2_BUS1</name>
+     <description>I2C2_BU1 RPU Register.</description>
+     <addressOffset>0x11F0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PTG_BUS1</name>
+     <description>PTG_BUS1  RPU Register.</description>
+     <addressOffset>0x13C0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>USBHS</name>
+     <description>USBHS RPU Register.</description>
+     <addressOffset>0x0B10</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SDIO</name>
+     <description>SDIO/SDHC Target RPU Register.</description>
+     <addressOffset>0x0B60</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SPIXFM_FIFO</name>
+     <description>SPIXFM_FIFO RPU Register.</description>
+     <addressOffset>0x0BC0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SPI0</name>
+     <description>SPI0 RPU Register.</description>
+     <addressOffset>0x0BE0</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSRAM0</name>
+     <description>SYSRAM0 RPU Register.</description>
+     <addressOffset>0x0F00</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSRAM1</name>
+     <description>SYSRAM1 RPU Register.</description>
+     <addressOffset>0x0F10</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSRAM2</name>
+     <description>SYSRAM2 RPU Register.</description>
+     <addressOffset>0x0F20</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSRAM3</name>
+     <description>SYSRAM3 RPU Register.</description>
+     <addressOffset>0x0F30</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSRAM4</name>
+     <description>SYSRAM4 RPU Register.</description>
+     <addressOffset>0x0F40</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSRAM5</name>
+     <description>SYSRAM5 RPU Register.</description>
+     <addressOffset>0x0F50</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSRAM6_11</name>
+     <description>SYSRAM6-11 RPU Register.</description>
+     <addressOffset>0x0F60</addressOffset>
+     <fields>
+      <field>
+       <name>ACCESS</name>
+       <description>APB Slave Peripheral Access Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--RPU Resource Protection Unit-->
+  <peripheral>
+   <name>RTC</name>
+   <description>Real Time Clock and Alarm.</description>
+   <baseAddress>0x40006000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>RTC</name>
+    <description>RTC interrupt.</description>
+    <value>3</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>RTC Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC</name>
+       <description>RTC Sub-second Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TODA</name>
+     <description>Time-of-day Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-day Alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSECA</name>
+     <description>RTC sub-second alarm.  This register contains the reload value for the sub-second alarm.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>This register contains the reload value for the sub-second alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>RTC Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>RTCE</name>
+       <description>Real Time Clock Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADE</name>
+       <description>Alarm Time-of-Day Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ASE</name>
+       <description>Alarm Sub-second Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>RTC Busy. This bit is set to 1 by hardware when changes to RTC registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>RTC Ready. This bit is set to 1 by hardware when the RTC count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the RTC count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDYE</name>
+       <description>RTC Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ALDF</name>
+       <description>Time-of-Day Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ALSF</name>
+       <description>Sub-second Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQE</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FT</name>
+       <description>Frequency Output Selection. When SQE=1, these bits specify the output frequency on the SQW pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq1Hz</name>
+         <description>1 Hz (Compensated).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq512Hz</name>
+         <description>512 Hz (Compensated).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq4KHz</name>
+         <description>4 KHz.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clkDiv8</name>
+         <description>RTC Input Clock / 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACRE</name>
+       <description>Asynchronous Counter Read Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>sync</name>
+         <description>SEC and SSEC registers synchronized and should only be accessed while CTRL.rdy = 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>async</name>
+         <description>SEC and SSEC registers are asynchronous and will require software interaction to ensure data accuracy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WE</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical RTC bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIM</name>
+     <description>RTC Trim Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>RTC Trim. This register contains the 2's complement value that specifies the trim resolution. Each increment or decrement of the bit adds or subtracts 1ppm at each 4KHz clock value, with a maximum correction of +/- 127ppm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VRTC_TMR</name>
+       <description>VBAT Timer Value. When RTC is running off of VBAT, this field is incremented every 32 seconds.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>RTC Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>FILTER_EN</name>
+       <description>Enables analog deglitch filter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_SEL</name>
+       <description>If IBIAS_EN is 1, selects 4x,2x mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HYST_EN</name>
+       <description>Enables high current hysteresis buffer.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_EN</name>
+       <description>Enables higher 4x,2x current modes.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYPASS</name>
+       <description>RTC Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>32KOUT</name>
+       <description>RTC 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--RTC Real Time Clock and Alarm.-->
+  <peripheral>
+   <name>SDHC</name>
+   <description>SDHC/SDIO Controller</description>
+   <baseAddress>0x400B6000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SDHC</name>
+    <value>66</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SDMA</name>
+     <description>SDMA System Address / Argument 2.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>SDMA System Address / Argument 2  of Auto CMD23.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_SIZE</name>
+     <description>Block Size.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>TRANS</name>
+       <description>Transfer Block Size.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>HOST_BUFF</name>
+       <description>Host SDMA Buffer Boundary.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_CNT</name>
+     <description>Block Count.</description>
+     <addressOffset>0x06</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Blocks Count For Current Transfer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ARG_1</name>
+     <description>Argument 1.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>CMD</name>
+       <description>Command Argument 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRANS</name>
+     <description>Transfer Mode.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>DMA_EN</name>
+       <description>DMA Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>enable</name>
+        <enumeratedValue>
+         <name>dma_transfer</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>non_dma_transfer</name>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BLK_CNT_EN</name>
+       <description>Block Count Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>count</name>
+        <enumeratedValue>
+         <name>enable</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTO_CMD_EN</name>
+       <description>Auto CMD Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <name>CMD</name>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cmd12</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cmd23</name>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ_WRITE</name>
+       <description>Data Transfer Direction Select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>read</name>
+        <enumeratedValue>
+         <name>read</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>write</name>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MULTI</name>
+       <description>Multi / Single Block Select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>multi</name>
+        <enumeratedValue>
+         <name>enable</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMD</name>
+     <description>Command.</description>
+     <addressOffset>0x0E</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>RESP_TYPE</name>
+       <description>Response Type Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CRC_CHK_EN</name>
+       <description>Command CRC Check Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IDX_CHK_EN</name>
+       <description>Command Index Check Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_PRES_SEL</name>
+       <description>Data Present Select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TYPE</name>
+       <description>Command Type.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>IDX</name>
+       <description>Command Index.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>RESP[%s]</name>
+     <description>Response 0 Register 0-15.</description>
+     <addressOffset>0x010</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>CMD_RESP</name>
+       <description>Command Response.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUFFER</name>
+     <description>Buffer Data Port.</description>
+     <addressOffset>0x20</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Buffer Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESENT</name>
+     <description>Present State.</description>
+     <addressOffset>0x024</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CMD</name>
+       <description>Command Inhibit (CMD).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DAT</name>
+       <description>Command Inhibit (DAT).</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DAT_LINE_ACTIVE</name>
+       <description>DAT Line Active.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Request.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WRITE_TRANSFER</name>
+       <description>Write Transfer Active.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>READ_TRANSFER</name>
+       <description>Read Transfer Active.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BUFFER_WRITE</name>
+       <description>Buffer Write Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BUFFER_READ</name>
+       <description>Buffer Read Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CARD_INSERTED</name>
+       <description>Card Inserted.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CARD_STATE</name>
+       <description>Card State Stable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CARD_DETECT</name>
+       <description>Card Detect Pin Level.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WP</name>
+       <description>Write Protect Switch Pin Level.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DAT_SIGNAL_LEVEL</name>
+       <description>DAT[3:0] Line Signal Level.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CMD_SIGNAL_LEVEL</name>
+       <description>CMD Line Signal Level.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HOST_CN_1</name>
+     <description>Host Control 1.</description>
+     <addressOffset>0x028</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>LED_CN</name>
+       <description>LED Control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TRANSFER_WIDTH</name>
+       <description>Data Transfer Width.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HS_EN</name>
+       <description>High Speed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA_SELECT</name>
+       <description>DMA Select.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>EXT_DATA_TRANSFER_WIDTH</name>
+       <description>Extended Data Transfer Width.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_DETECT_TEST</name>
+       <description>Card Detect Test Level.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_DETECT_SIGNAL</name>
+       <description>Card Detect Signal Selection.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWR</name>
+     <description>Power Control.</description>
+     <addressOffset>0x029</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>BUS_POWER</name>
+       <description>SD Bus Power.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUS_VOLT_SEL</name>
+       <description>SD Bus Voltage Select.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_GAP</name>
+     <description>Block Gap Control.</description>
+     <addressOffset>0x02A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>STOP</name>
+       <description>Stop At Block Gap Request.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CONT</name>
+       <description>Continue Request.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>READ_WAIT</name>
+       <description>Read Wait Control.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTR</name>
+       <description>Interrupt At Block Gap.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKEUP</name>
+     <description>Wakeup Control.</description>
+     <addressOffset>0x02B</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>CARD_INT</name>
+       <description>Wakeup Event Enable On Card Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INS</name>
+       <description>Wakeup Event Enable On SD Card Insertion.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REM</name>
+       <description>Wakeup Event Enable On SD Card Removal.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_CN</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x02C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>INTERNAL_CLK_EN</name>
+       <description>Internal Clock Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTERNAL_CLK_STABLE</name>
+       <description>Internal Clock Stable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SD_CLK_EN</name>
+       <description>SD Clock Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLK_GEN_SEL</name>
+       <description>Clock Generator Select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>UPPER_SDCLK_FREQ_SEL</name>
+       <description>Upper Bits of SDCLK Frequency Select.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SDCLK_FREQ_SEL</name>
+       <description>SDCLK Frequency Select.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TO</name>
+     <description>Timeout Control.</description>
+     <addressOffset>0x02E</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>DATA_COUNT_VALUE</name>
+       <description>Data Timeout Counter Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SW_RESET</name>
+     <description>Software Reset.</description>
+     <addressOffset>0x02F</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RESET_ALL</name>
+       <description>Software Reset For All.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESET_CMD</name>
+       <description>Software Reset For CMD Line.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESET_DAT</name>
+       <description>Software Reset For DAT Line.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_STAT</name>
+     <description>Normal Interrupt Status.</description>
+     <addressOffset>0x030</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_COMP</name>
+       <description>Command Complete.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRANS_COMP</name>
+       <description>Transfer Complete.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BLK_GAP_EVENT</name>
+       <description>Block Gap Event.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFF_WR_READY</name>
+       <description>Buffer Write Ready.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFF_RD_READY</name>
+       <description>Buffer Read Ready.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INSERTION</name>
+       <description>Card Insertion.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REMOVAL</name>
+       <description>Card Removal.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INTR</name>
+       <description>Card Interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Event.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERR_INTR</name>
+       <description>Error Interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ER_INT_STAT</name>
+     <description>Error Interrupt Status.</description>
+     <addressOffset>0x032</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Command Timeout Error.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Command CRC Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Command End Bit Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_IDX</name>
+       <description>Command Index Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Data Timeout Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Data CRC Error.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Data End Bit Error.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CURRENT_LIMIT</name>
+       <description>Current Limit Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AUTO_CMD_12</name>
+       <description>Auto CMD Error.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>ADMA Error.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Error.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Normal Interrupt Status Enable.</description>
+     <addressOffset>0x034</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_COMP</name>
+       <description>Command Complete Status Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRANS_COMP</name>
+       <description>Transfer Complete Status Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BLK_GAP</name>
+       <description>Block Gap Event Status Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Interrupt Status Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_WR</name>
+       <description>Buffer Write Ready Status Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_RD</name>
+       <description>Buffer Read Ready Status Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INSERT</name>
+       <description>Card Insertion Status Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REMOVAL</name>
+       <description>Card Removal Status Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INT</name>
+       <description>Card Interrupt Status Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Event Status Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ER_INT_EN</name>
+     <description>Error Interrupt Status Enable.</description>
+     <addressOffset>0x36</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Command Timeout Error Status Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Command CRC Error Status Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Command End Bit Error Status Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_IDX</name>
+       <description>Command Index Error Status Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Data Timeout Error Status Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Data CRC Error Status Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Data End Bit Error Status Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AUTO_CMD</name>
+       <description>Auto CMD Error Status Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>ADMA Error Status Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TUNING</name>
+       <description>Tuning Error Status Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VENDOR</name>
+       <description>Vendor Specific Error Status Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_SIGNAL</name>
+     <description>Normal Interrupt Signal Enable.</description>
+     <addressOffset>0x038</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_COMP</name>
+       <description>Command Complete Signal Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRANS_COMP</name>
+       <description>Transfer Complete Signal Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BLK_GAP</name>
+       <description>Block Gap Event Signal Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Interrupt Signal Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_WR</name>
+       <description>Buffer Write Ready Signal Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_RD</name>
+       <description>Buffer Read Ready Signal Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INSERT</name>
+       <description>Card Insertion Signal Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REMOVAL</name>
+       <description>Card Removal Signal Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INT</name>
+       <description>Card Interrupt Signal Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Event Signal Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ER_INT_SIGNAL</name>
+     <description>Error Interrupt Signal Enable.</description>
+     <addressOffset>0x03A</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Command Timeout Error Signal Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Command CRC Error Signal Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Command End Bit Error Signal Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_IDX</name>
+       <description>Command Index Error Signal Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Data Timeout Error Signal Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Data CRC Error Signal Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Data End Bit Error Signal Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CURR_LIM</name>
+       <description>Current Limit Error Signal Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AUTO_CMD</name>
+       <description>Auto CMD Error Signal Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>ADMA Error Signal Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TUNING</name>
+       <description>Tuning Error Signal Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAR_RESP</name>
+       <description>Target Response Error Signal Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTO_CMD_ER</name>
+     <description>Auto CMD Error Status.</description>
+     <addressOffset>0x03C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>NOT_EXCUTED</name>
+       <description>Auto CMD12 Not Executed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TO</name>
+       <description>Auto CMD Timeout Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRC</name>
+       <description>Auto CMD CRC Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>END_BIT</name>
+       <description>Auto CMD End Bit Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INDEX</name>
+       <description>Auto CMD Index Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOT_ISSUED</name>
+       <description>Command Not Issued By Auto CMD12 Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HOST_CN_2</name>
+     <description>Host Control 2.</description>
+     <addressOffset>0x03E</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>UHS</name>
+       <description>UHS Mode Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SIGNAL_V1_8</name>
+       <description>1.8V Signaling Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>EXCUTE</name>
+       <description>Execute Tuning.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SAMPLING_CLK</name>
+       <description>Sampling Clock Select.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ASYNCH_INT</name>
+       <description>Asynchronous Interrupt Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PRESET_VAL_EN</name>
+       <description>Preset Value Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_0</name>
+     <description>Capabilities 0-31.</description>
+     <addressOffset>0x040</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CLK_FREQ</name>
+       <description>Timeout Clock Frequency.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TO_CLK_UNIT</name>
+       <description>Timeout Clock Unit.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TO_CLK_FREQ</name>
+       <description>Base Clock Frequency For SD Clock.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>MAX_BLK_LEN</name>
+       <description>Max Block Length.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BIT_8</name>
+       <description>8-bit Support for Embedded Device.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ADMA2</name>
+       <description>ADMA2 Support.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS</name>
+       <description>High Speed Support.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDMA</name>
+       <description>SDMA Support.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SUSPEND</name>
+       <description>Suspend/Resume Support.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>V3_3</name>
+       <description>Voltage Support 3.3V.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>V3_0</name>
+       <description>Voltage Support 3.0V.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>V1_8</name>
+       <description>Voltage Support 1.8V.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BIT_64_SYS_BUS</name>
+       <description>64-bit System Bus Support.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ASYNC_INT</name>
+       <description>Asynchronous Interrupt Support.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SLOT_TYPE</name>
+       <description>Slot Type.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_1</name>
+     <description>Capabilities 32-63.</description>
+     <addressOffset>0x044</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDR50</name>
+       <description>SDR50 Support.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDR104</name>
+       <description>SDR104 Support.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>0</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DDR50</name>
+       <description>DDR50 Support.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_A</name>
+       <description>Driver Type A Support.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_C</name>
+       <description>Driver Type C Support.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_D</name>
+       <description>Driver Type D Support.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TIMER_CNT_TUNING</name>
+       <description>Timer Count for Re-Tuning.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TUNING_SDR50</name>
+       <description>Use Tuning for SDR50.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Modes.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_MULTI</name>
+       <description>Clock Multiplier.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAX_CURR_CFG</name>
+     <description>Maximum Current Capabilities.</description>
+     <addressOffset>0x048</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>V3_3</name>
+       <description>Maximum Current for 3.3V.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>V3_0</name>
+       <description>Maximum Current for 3.0V.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>V1_8</name>
+       <description>Maximum Current for 1.8V.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FORCE_CMD</name>
+     <description>Force Event for Auto CMD Error Status.</description>
+     <addressOffset>0x050</addressOffset>
+     <size>16</size>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>NOT_EXCU</name>
+       <description>Force Event for Auto CMD12 Not Executed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TO</name>
+       <description>Force Event for Auto CMD Timeout Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>CRC</name>
+       <description>Force Event for Auto CMD CRC Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>END_BIT</name>
+       <description>Force Event for Auto CMD End Bit Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>INDEX</name>
+       <description>Force Event for Auto CMD Index Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>NOT_ISSUED</name>
+       <description>Force Event for Command Not Issued By Auto CMD12 Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FORCE_EVENT_INT_STAT</name>
+     <description>Force Event for Error Interrupt Status.</description>
+     <addressOffset>0x052</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Force Event for Command Timeout Error.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Force Event for Command CRC Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Force Event for Command End Bit Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CMD_INDEX</name>
+       <description>Force Event for Command Index Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Force Event for Data Timeout Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Force Event for Data CRC Error.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Force Event for Data End Bit Error.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CURR_LIMIT</name>
+       <description>Force Event for Current Limit Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>AUTO_CMD</name>
+       <description>Force Event for Auto CMD Error.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>Force Event for ADMA Error.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VENDOR</name>
+       <description>Force Event for Vendor Specific Error Status.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADMA_ER</name>
+     <description>ADMA Error Status.</description>
+     <addressOffset>0x054</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>STATE</name>
+       <description>ADMA Error State.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>LEN_MISMATCH</name>
+       <description>ADMA Length Mismatch Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADMA_ADDR_0</name>
+     <description>ADMA System Address 0-31.</description>
+     <addressOffset>0x058</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>ADMA System Address  Part 1 (part 2 is ADMA_ADDR_1).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADMA_ADDR_1</name>
+     <description>ADMA System Address 32-63.</description>
+     <addressOffset>0x05C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>ADMA System Address  Part 1 (part 2 is ADMA_ADDR_1).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_0</name>
+     <description>Preset Value for Initialization.</description>
+     <addressOffset>0x060</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_1</name>
+     <description>Preset Value for Default Speed.</description>
+     <addressOffset>0x062</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_2</name>
+     <description>Preset Value for High Speed.</description>
+     <addressOffset>0x064</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_3</name>
+     <description>Preset Value for SDR12.</description>
+     <addressOffset>0x066</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_4</name>
+     <description>Preset Value for SDR25.</description>
+     <addressOffset>0x068</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_5</name>
+     <description>Preset Value for SDR50.</description>
+     <addressOffset>0x06A</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_6</name>
+     <description>Preset Value for SDR104.</description>
+     <addressOffset>0x06C</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_7</name>
+     <description>Preset Value for DDR50.</description>
+     <addressOffset>0x06E</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLOT_INT</name>
+     <description>Slot Interrupt Status.</description>
+     <addressOffset>0x0FC</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>INT_SIGNALS</name>
+       <description>Interrupt Signal For Each Slot.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HOST_CN_VER</name>
+     <description>Host Controller Version.</description>
+     <addressOffset>0x0FE</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>SPEC_VER</name>
+       <description>Specification Version Number.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VEND_VER</name>
+       <description>Vendor Version Number.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SDHC SDHC/SDIO Controller-->
+  <peripheral>
+   <name>SEMA</name>
+   <description>The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.</description>
+   <baseAddress>0x4003E000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>0x04</dimIncrement>
+     <name>SEMAPHORES[%s]</name>
+     <description>Read to test and set, returns prior value. Write 0 to clear semaphore.</description>
+     <addressOffset>0x000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>sema</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>status</name>
+     <description>Semaphore status bits. 0 indicates the semaphore is free, 1 indicates taken.</description>
+     <addressOffset>0x100</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>STATUS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SEMA The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.-->
+  <peripheral>
+   <name>SIMO</name>
+   <description>Single Inductor Multiple Output Switching Converter</description>
+   <baseAddress>0x40004400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>VREGO_A</name>
+     <description>Buck Voltage Regulator A Control Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETA</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGEA</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGO_B</name>
+     <description>Buck Voltage Regulator B Control Register</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETB</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGEB</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGO_C</name>
+     <description>Buck Voltage Regulator C Control Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETC</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGEC</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGO_D</name>
+     <description>Buck Voltage Regulator D Control Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETD</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGED</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPKA</name>
+     <description>High Side FET Peak Current VREGO_A/VREGO_B Register</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IPKSETA</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IPKSETB</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPKB</name>
+     <description>High Side FET Peak Current VREGO_C/VREGO_D Register</description>
+     <addressOffset>0x0018</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IPKSETC</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IPKSETD</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAXTON</name>
+     <description>Maximum High Side FET Time On Register</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TONSET</name>
+       <description>Sets the maximum on time for the high side FET, each increment represents 500ns</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_A</name>
+     <description>Buck Cycle Count VREGO_A Register</description>
+     <addressOffset>0x0020</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADA</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_B</name>
+     <description>Buck Cycle Count VREGO_B Register</description>
+     <addressOffset>0x0024</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADB</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_C</name>
+     <description>Buck Cycle Count VREGO_C Register</description>
+     <addressOffset>0x0028</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADC</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_D</name>
+     <description>Buck Cycle Count VREGO_D Register</description>
+     <addressOffset>0x002C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADD</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_A</name>
+     <description>Buck Cycle Count Alert VERGO_A Register</description>
+     <addressOffset>0x0030</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRA</name>
+       <description>Threshold for ILOADA to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_B</name>
+     <description>Buck Cycle Count Alert VERGO_B Register</description>
+     <addressOffset>0x0034</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRB</name>
+       <description>Threshold for ILOADB to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_C</name>
+     <description>Buck Cycle Count Alert VERGO_C Register</description>
+     <addressOffset>0x0038</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRC</name>
+       <description>Threshold for ILOADC to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_D</name>
+     <description>Buck Cycle Count Alert VERGO_D Register</description>
+     <addressOffset>0x003C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRD</name>
+       <description>Threshold for ILOADD to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_OUT_READY</name>
+     <description>Buck Regulator Output Ready Register</description>
+     <addressOffset>0x0040</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUCKOUTRDYA</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notrdy</name>
+         <description>Output voltage not in range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rdy</name>
+         <description>Output voltage in range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="BUCKOUTRDYA">
+       <name>BUCKOUTRDYB</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BUCKOUTRDYA">
+       <name>BUCKOUTRDYC</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BUCKOUTRDYA">
+       <name>BUCKOUTRDYD</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_A</name>
+     <description>Zero Cross Calibration VERGO_A Register</description>
+     <addressOffset>0x0044</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALA</name>
+       <description>Zero Cross Calibrartion Value VREGO_A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_B</name>
+     <description>Zero Cross Calibration VERGO_B Register</description>
+     <addressOffset>0x0048</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALB</name>
+       <description>Zero Cross Calibrartion Value VREGO_B</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_C</name>
+     <description>Zero Cross Calibration VERGO_C Register</description>
+     <addressOffset>0x004C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALC</name>
+       <description>Zero Cross Calibrartion Value VREGO_C</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_D</name>
+     <description>Zero Cross Calibration VERGO_D Register</description>
+     <addressOffset>0x0050</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALD</name>
+       <description>Zero Cross Calibrartion Value VREGO_D</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIMO Single Inductor Multiple Output Switching Converter-->
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x40000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SISTAT</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>MAGIC</name>
+       <description>Magic Word Validation. This bit is set by the system initialization block
+              following power-up.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>magicNotSet</name>
+         <description>Magic word was not set (OTP has not been initialized properly).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>magicSet</name>
+         <description>Magic word was set (OTP contains valid settings).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRCERR</name>
+       <description>CRC Error Status. This bit is set by the system initialization block
+              following power-up.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No CRC errors occurred during the read of the OTP memory block.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>A CRC error occurred while reading the OTP. The address of the failure
+                  location in the OTP memory is stored in the ERRADDR register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ERRADDR</name>
+     <description>Read-only field set by the SIB block if a CRC error occurs during the read of
+          the OTP memory. Contains the failing address in OTP memory (when CRCERR equals 1).</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ERRADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLE_LDO_TRIM_TX</name>
+     <description>BTLE LDO TX Trim register.</description>
+     <addressOffset>0x54</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX</name>
+       <description>TX LDO trim value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLE_LDO_TRIM_RX</name>
+     <description>BTLE LDO RX Trim register.</description>
+     <addressOffset>0x5C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX</name>
+       <description>RX LDO trim value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FSTAT</name>
+     <description>funcstat register.</description>
+     <addressOffset>0x100</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>FPU</name>
+       <description>FPU Function.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USB</name>
+       <description>USB Device.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADC</name>
+       <description>10-bit Sigma Delta ADC.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>XIP</name>
+       <description>XiP function.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PBM</name>
+       <description>PBM function.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HBC</name>
+       <description>HBC function.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDHC</name>
+       <description>SDHC function.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SMPHR</name>
+       <description>SMPHR function.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCACHE</name>
+       <description>System Cache function.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFSTAT</name>
+     <description>secfuncstat register.</description>
+     <addressOffset>0x104</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TRNG</name>
+       <description>TRNG function.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AES</name>
+       <description>AES function.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHA</name>
+       <description>SHA function.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MAA</name>
+       <description>MAA function.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIR System Initialization Registers.-->
+  <peripheral>
+   <name>SMON</name>
+   <description>The Security Monitor block used to monitor system threat conditions.</description>
+   <baseAddress>0x40004000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>EXTSCN</name>
+     <description>External Sensor Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x3800FFC0</resetMask>
+     <fields>
+      <field>
+       <name>EXTS_EN0</name>
+       <description>External Sensor Enable for input/output pair 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN1</name>
+       <description>External Sensor Enable for input/output pair 1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN2</name>
+       <description>External Sensor Enable for input/output pair 2.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN3</name>
+       <description>External Sensor Enable for input/output pair 3.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN4</name>
+       <description>External Sensor Enable for input/output pair 4.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN5</name>
+       <description>External Sensor Enable for input/output pair 5.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTCNT</name>
+       <description>External Sensor Error Counter. These bits set the number of external sensor accepted mismatches that have to occur within a single bit period before an external sensor alarm is triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>EXTFRQ</name>
+       <description>External Sensor Frequency. These bits define the frequency at which the external sensors are clocked to/from the EXTS_IN and EXTS_OUT pair.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq2000Hz</name>
+         <description>Div 4 (2000Hz).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq1000Hz</name>
+         <description>Div 8 (1000Hz).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq500Hz</name>
+         <description>Div 16 (500Hz).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq250Hz</name>
+         <description>Div 32 (250Hz).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq125Hz</name>
+         <description>Div 64 (125Hz).</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq63Hz</name>
+         <description>Div 128 (63Hz).</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq31Hz</name>
+         <description>Div 256 (31Hz).</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RFU</name>
+         <description>Reserved. Do not use.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DIVCLK</name>
+       <description>Clock Divide.  These bits are used to divide the 8KHz input clock. The resulting divided clock is used for all logic within the Security Monitor Block. Note:
+                                                             If the input clock is divided with these bits, the error count threshold table and output frequency will be affected accordingly with the same divide factor.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1 (8000 Hz).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2 (4000 Hz).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4 (2000 Hz).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8 (1000 Hz).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16 (500 Hz).</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32 (250 Hz).</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64 (125 Hz).</description>
+         <value>6</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>Busy. This bit is set to 1 by hardware after EXTSCN register is written to. This bit is automatically cleared to 0 after this register information has been transferred to the security monitor domain.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Update in Progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock Register. Once locked, the EXTSCN register can no longer be modified.  Only a battery disconnect will clear this bit. VBAT powers this register.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTSCN</name>
+     <description>Internal Sensor Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x7F00FFF7</resetMask>
+     <fields>
+      <field>
+       <name>SHIELD_EN</name>
+       <description>Die Shield Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TEMP_EN</name>
+       <description>Temperature Sensor Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VBAT_EN</name>
+       <description>Battery Monitor Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DFD_EN</name>
+       <description>Digital Fault Dector Enable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DFD_NMI</name>
+       <description>Digital Fault NMI Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DFD_STDBY</name>
+       <description>Digital Fault Dector Stand by Enable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PUF_TRIM_ERASE</name>
+       <description>Erase puf trim Enable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LOTEMP_SEL</name>
+       <description>Low Temperature Detection Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>neg50C</name>
+         <description>-50 degrees C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>neg30C</name>
+         <description>-30 degrees C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORELOEN</name>
+       <description>VCORE Undervoltage Detect Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREHIEN</name>
+       <description>VCORE Overvoltage Detect Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDLOEN</name>
+       <description>VDD Undervoltage Detect Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDHIEN</name>
+       <description>VDD Overvoltage Detect Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VGLEN</name>
+       <description>Voltage Glitch Detection Enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock Register. Once locked, the INTSCN register can no longer be modified.  Only a battery disconnect will clear this bit. VBAT powers this register.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECALM</name>
+     <description>Security Alarm Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000000</resetValue>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>DRS</name>
+       <description>Destructive Reset Trigger. Setting this bit will generate a DRS. This bit is self-cleared by hardware.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>Key Wipe Trigger. Set to 1 to initiate a wipe of the AES key register. It does not reset the part, or log a timestamp. AES and DES registers are not affected by this bit. This bit is automatically cleared to 0 after the keys have been wiped.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHIELDF</name>
+       <description>Die Shield Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOTEMP</name>
+       <description>Low Temperature Detect.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HITEMP</name>
+       <description>High Temperature Detect.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATLO</name>
+       <description>Battery Undervoltage Detect.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATHI</name>
+       <description>Battery Overvoltage Detect.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTF</name>
+       <description>External Sensor Flag.   This bit is set to 1 when any of the EXTSTAT bits are set.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDLO</name>
+       <description>VDD Undervoltage Detect Flag.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORELO</name>
+       <description>VCORE Undervoltage Detect Flag.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREHI</name>
+       <description>VCORE Overvoltage Detect Flag.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDHI</name>
+       <description>VDD Overvoltage Flag.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VGL</name>
+       <description>Voltage Glitch Detection Flag.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT0</name>
+       <description>External Sensor 0 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT1</name>
+       <description>External Sensor 1 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT2</name>
+       <description>External Sensor 2 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT3</name>
+       <description>External Sensor 3 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT4</name>
+       <description>External Sensor 4 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT5</name>
+       <description>External Sensor 5 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN0</name>
+       <description>External Sensor 0 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN1</name>
+       <description>External Sensor 1 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN2</name>
+       <description>External Sensor 2 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN3</name>
+       <description>External Sensor 3 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN4</name>
+       <description>External Sensor 4 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN5</name>
+       <description>External Sensor 5 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECDIAG</name>
+     <description>Security Diagnostic Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00000001</resetValue>
+     <resetMask>0xFFC0FE02</resetMask>
+     <fields>
+      <field>
+       <name>BORF</name>
+       <description>Battery-On-Reset Flag. This bit is set once the back up battery is conneted.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHIELDF</name>
+       <description>Die Shield Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOTEMP</name>
+       <description>Low Temperature Detect.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HITEMP</name>
+       <description>High Temperature Detect.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATLO</name>
+       <description>Battery Undervoltage Detect.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATHI</name>
+       <description>Battery Overvoltage Detect.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DYNF</name>
+       <description>Dynamic Sensor Flag.  This bit is set to 1 when any of the EXTSTAT bits are set.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESKT</name>
+       <description>AES Key Transfer.  This bit is set to 1 when AES Key has been transferred from the TRNG to the battery backed AES key register. This bit can only be reset by a BOR.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>incomplete</name>
+         <description>Key has not been transferred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>Key has been transferred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT0</name>
+       <description>External Sensor 0 Detect.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT1</name>
+       <description>External Sensor 1 Detect.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT2</name>
+       <description>External Sensor 2 Detect.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT3</name>
+       <description>External Sensor 3 Detect.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT4</name>
+       <description>External Sensor 4 Detect.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT5</name>
+       <description>External Sensor 5 Detect.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DLRTC</name>
+     <description>DRS Log RTC Value. This register contains the 32 bit value in the RTC second register when the last DRS event occurred.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-only</access>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>DLRTC</name>
+       <description>DRS Log RTC Value. This register contains the 32 bit value in the RTC second register when the last DRS event occured.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEUCFG</name>
+     <description>MEU Configuration</description>
+     <addressOffset>0x24</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>MEUCFG</name>
+       <description>Configuration plain/encrypted area of the backed NVSRAM.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECST</name>
+     <description>Security Monitor Status Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>EXTSRS</name>
+       <description>External Sensor Control Register Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INTSRS</name>
+       <description>Internal Sensor Control Register Status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SECALRS</name>
+       <description>Security Alarm Register Status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SDBE</name>
+     <description>Security Monitor Self Destruct Byte.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>DBYTE</name>
+       <description>Self Destruct Byte</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>SBDEN</name>
+       <description>Self-Destruct Byte ENable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SMON The Security Monitor block used to monitor system threat conditions.-->
+  <peripheral>
+   <name>SPI</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x400BE000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>56</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>DATA32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>QSPIFIFO</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>DATA16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>DATA32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>QSPIFIFO</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>DATA8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>DATA32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>QSPIFIFO</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MASTER</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Start Select Control. Used in Master mode to control the behavior of the Slave Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DEASSERT</name>
+         <description>SPI De-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ASSERT</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Rising_Edge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Falling_Edge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin(s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_POL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SS_TIME</name>
+     <description>Register for controlling SPI peripheral/Slave Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PRE</name>
+       <description>Slave Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POST</name>
+       <description>Slave Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_CFG</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCALE</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_FIFO_LEVEL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CLEAR</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write
+            pointers. This should be done when FIFO is not being accessed on the SPI side.
+          .</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CNT</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DMA_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_LEVEL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CLEAR</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CNT</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_DMA_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_FL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE_EN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPI SPI peripheral.-->
+  <peripheral derivedFrom="SPI">
+   <name>SPI1</name>
+   <description>SPI peripheral. 1</description>
+   <baseAddress>0x40046000</baseAddress>
+   <interrupt>
+    <name>SPI1</name>
+    <description>SPI1 IRQ</description>
+    <value>16</value>
+   </interrupt>
+  </peripheral>
+<!--SPI1 SPI peripheral. 1-->
+  <peripheral derivedFrom="SPI">
+   <name>SPI2</name>
+   <description>SPI peripheral. 2</description>
+   <baseAddress>0x40047000</baseAddress>
+   <interrupt>
+    <name>SPI2</name>
+    <description>SPI2 IRQ</description>
+    <value>17</value>
+   </interrupt>
+  </peripheral>
+<!--SPI2 SPI peripheral. 2-->
+  <peripheral>
+   <name>SPIXFC</name>
+   <description>SPI XiP Flash Configuration Controller</description>
+   <baseAddress>0x40027000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPIXFC</name>
+    <description>SPIXFC IRQ</description>
+    <value>38</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CONFIG</name>
+     <description>Configuration Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>SSEL</name>
+       <description>Slaves Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Slave_0</name>
+         <description>Slave 0 is selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Slave_1</name>
+         <description>Slave 1 is selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description>Defines SPI Mode, Only valid values are 0 and 3.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SPIX_Mode_0</name>
+         <description>SPIX Mode 0. CLK Polarity = 0, CLK Phase = 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SPIX_Mode_3</name>
+         <description>SPIX Mode 3. CLK Polarity = 1, CLK Phase = 1.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PAGE_SIZE</name>
+       <description>Page Size.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>4_bytes</name>
+         <description>4 bytes.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_bytes</name>
+         <description>8 bytes.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_bytes</name>
+         <description>16 bytes.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>32_bytes</name>
+         <description>32 bytes.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI_CLK</name>
+       <description>SCLK High Clocks. Number of system clocks that SCLK will be high when SCLK pulses are generated. 0 Correspond to 16 system clocks and, all other values defines the number of system clock taht SCLK will be held high.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16_SCLK</name>
+         <description>16 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LO_CLK</name>
+       <description>SCLK low Clocks. Number of system clocks that SCLK will be low when SCLK pulses are generated. 0 correspond to 16 system clocks and, all other values defines the number of system clock taht SCLK will be held low.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16_SCLK</name>
+         <description>16 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_ACT</name>
+       <description>Slaves Select Activate Timing.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_CLKS</name>
+         <description>0 sytem clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_CLKS</name>
+         <description>2 sytem clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_CLKS</name>
+         <description>4 sytem clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_CLKS</name>
+         <description>8 sytem clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_INACT</name>
+       <description>Slaves Select Inactive Timing.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>4_CLKS</name>
+         <description>4 sytem clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_CLKS</name>
+         <description>6 sytem clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_CLKS</name>
+         <description>8 sytem clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_CLKS</name>
+         <description>12 sytem clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IOSMPL</name>
+       <description>Sample Delay.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SS_POL</name>
+     <description>SPIX Controller Slave Select Polarity Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>SSPOL_0</name>
+       <description>Slave Select Polarity.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lo</name>
+         <description>Active Low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hi</name>
+         <description>Active High.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GEN_CTRL</name>
+     <description>SPIX Controller General Controller Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ENABLE</name>
+       <description>SPI Master enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable SPI Master, putting a reset state.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable SPI Master for processing transactions.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transaction FIFO Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis_txfifo</name>
+         <description>Disable Transaction FIFO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en_txfifo</name>
+         <description>Enable Transaction FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Result FIFO Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS_RXFIFO</name>
+         <description>Disable Result FIFO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EN_RXFIFO</name>
+         <description>Enable Result FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BBMODE</name>
+       <description>Bit-Bang Mode.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Bit-Bang Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Bit-Bang Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSDR</name>
+       <description>This bits reflects the state of the currently selected slave select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output0</name>
+         <description>Selected Slave select output = 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>output1</name>
+         <description>Selected Slave select output = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLK_DR</name>
+       <description>SSCLK Drive and State.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SCLK_0</name>
+         <description>SCLK is 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SCLK_1</name>
+         <description>SCLK is 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDIO_DATA_IN</name>
+       <description>SDIO Input Data Value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BB_DATA</name>
+       <description>No description available.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BB_DATA_OUT_EN</name>
+       <description>Bit Bang SDIO Output Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SIMPLE</name>
+       <description>Simple Mode Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>En</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SIMPLERX</name>
+       <description>Simple Receive Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>En</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SMPLSS</name>
+       <description>Simple Mode Slave Select.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>En</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLK_FB</name>
+       <description>Enable SCLK Feedback Mode.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>En</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCKFBINV</name>
+       <description>SCK Inversion.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>En</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO_CTRL</name>
+     <description>SPIX Controller FIFO Control and Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>TX_FIFO_AE_LVL</name>
+       <description>Transaction FIFO Almost Empty Level.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_CNT</name>
+       <description>Transaction FIFO Used.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_AF_LVL</name>
+       <description>Results FIFO Almost Full Level.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_CNT</name>
+       <description>Result FIFO Used.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SPCTRL</name>
+     <description>SPIX Controller Special Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>SAMPL</name>
+       <description>SDIO Sample Mode Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>En</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDIOOUT</name>
+       <description>SDIO Output Value Sample Mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDIOOE</name>
+       <description>SDIO Output Enable Sample Mode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLKINH3</name>
+       <description>SCLK Inhibit Mode3. In SPI Mode 3, some SPI flash read timing diagrams show the last SCLK going low prior to de-assertion. The default is to support this additional falling edge of clock. When this bit is set and the device is in SPI Mode 3, the SPI clock is held high while Slave Select is de-asserted. This is to support some SPI flash write timing diagrams.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Allow trailing SCLK low pulse prior to Slave Select de-assertion.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Inhibit trailing SCLK low pulse prior to Slave Select de-assertion.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>SPIX Controller Interrupt Status Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>TX_STALLED</name>
+       <description>Transaction Stalled Interrupt Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Normal FIFO Transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Stalled FIFO Transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_STALLED</name>
+       <description>Results Stalled Interrupt Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Normal FIFO Operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Stalled FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_READY</name>
+       <description>Transaction Ready Interrupt Status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>FIFO Transaction not ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>FIFO Transaction ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_DONE</name>
+       <description>Results Done Interrupt Status.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Results FIFO ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Results FIFO Not ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_AE</name>
+       <description>Transaction FIFO Almost Empty Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Transaction FIFO not Almost Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Transaction FIFO Almost Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_AF</name>
+       <description>Results FIFO Almost Full Flag.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Results FIFO level below the Almost Full level.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Results FIFO level at Almost Full level.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>SPIX Controller Interrupt Enable Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>TX_STALLED</name>
+       <description>Transaction Stalled Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable Transaction Stalled Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable Transaction Stalled Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_STALLED</name>
+       <description>Results Stalled Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable Results Stalled Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable Results Stalled Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_READY</name>
+       <description>Transaction Ready Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable FIFO Transaction Ready Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable FIFO Transaction Ready Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_DONE</name>
+       <description>Results Done Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable Results Done Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable Results Done Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_AE</name>
+       <description>Transaction FIFO Almost Empty Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable Transaction FIFO Almost Empty Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable Transaction FIFO Almost Empty Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_AF</name>
+       <description>Results FIFO Almost Full Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable Results FIFO Almost Full Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable Results FIFO Almost Full Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXFC SPI XiP Flash Configuration Controller-->
+  <peripheral>
+   <name>SPIXFC_FIFO</name>
+   <description>SPI XiP Master Controller FIFO.</description>
+   <baseAddress>0x400BC000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>TX_8</name>
+     <description>SPI TX FIFO 8-Bit Write</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <dataType>uint8_t</dataType>
+    </register>
+    <register>
+     <name>TX_16</name>
+     <description>SPI TX FIFO 16-Bit Write</description>
+     <alternateRegister>TX_8</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <dataType>uint16_t</dataType>
+    </register>
+    <register>
+     <name>TX_32</name>
+     <description>SPI TX FIFO 32-Bit Write</description>
+     <alternateRegister>TX_8</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <dataType>uint32_t</dataType>
+    </register>
+    <register>
+     <name>RX_8</name>
+     <description>SPI RX FIFO 8-Bit Access</description>
+     <addressOffset>0x04</addressOffset>
+     <size>8</size>
+     <dataType>uint8_t</dataType>
+    </register>
+    <register>
+     <name>RX_16</name>
+     <description>SPI RX FIFO 16-Bit Access</description>
+     <alternateRegister>RX_8</alternateRegister>
+     <addressOffset>0x04</addressOffset>
+     <size>16</size>
+     <dataType>uint16_t</dataType>
+    </register>
+    <register>
+     <name>RX_32</name>
+     <description>SPI RX FIFO 32-Bit Access</description>
+     <alternateRegister>RX_8</alternateRegister>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+     <dataType>uint32_t</dataType>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXFC_FIFO SPI XiP Master Controller FIFO.-->
+  <peripheral>
+   <name>SPIXFM</name>
+   <description>SPIXF Master</description>
+   <baseAddress>0x40026000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CFG</name>
+     <description>SPIX Configuration Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Defines SPI Mode, Only valid values are 0 and 3.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SCLK_HI_SAMPLE_RISING</name>
+         <description>Description not available.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SCLK_LO_SAMPLE_FAILLING</name>
+         <description>Description not available.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSPOL</name>
+       <description>Slave Select Polarity.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ACTIVE_HIGH</name>
+         <description>Slave Select is Active High.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ACTIVE_LOW</name>
+         <description>Slave Select is Active Low.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEL</name>
+       <description>Slave Select. Only valid value is zero.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>LO_CLK</name>
+       <description>Number of system clocks that SCLK will be low when SCLK pulses are generated.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>HI_CLK</name>
+       <description>Number of system clocks that SCLK will be high when SCLK pulses are generated.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>SSACT</name>
+       <description>Slave Select Active Timing.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>off</name>
+         <description>0 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_2_mod_clk</name>
+         <description>2 System clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_4_mod_clk</name>
+         <description>4 System clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_8_mod_clk</name>
+         <description>8 System clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSIACT</name>
+       <description>Slave Select Inactive Timing.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>for_1_mod_clk</name>
+         <description>1 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_3_mod_clk</name>
+         <description>3 System clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_5_mod_clk</name>
+         <description>5 System clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_9_mod_clk</name>
+         <description>9 System clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FETCH_CTRL</name>
+     <description>SPIX Fetch Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>CMDVAL</name>
+       <description>Command Value sent to target to initiate fetching from SPI flash.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>CMD_WIDTH</name>
+       <description>Command Width. Number of data I/O used to send commands.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Single</name>
+         <description>Single SDIO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual_IO</name>
+         <description>Dual SDIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad_IO</name>
+         <description>Quad SDIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Invalid</name>
+         <description>Invalid.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_WIDTH</name>
+       <description>Address Width. Number of data I/O used to send address, and mode/dummy clocks.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Single</name>
+         <description>Single SDIO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual_IO</name>
+         <description>Dual SDIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad_IO</name>
+         <description>Quad SDIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Invalid</name>
+         <description>Invalid.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>Data Width. Number of data I/O used to receive data.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Single</name>
+         <description>Single SDIO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual_IO</name>
+         <description>Dual SDIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad_IO</name>
+         <description>Quad SDIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Invalid</name>
+         <description>Invalid.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FOUR_BYTE_ADDR</name>
+       <description>Four Byte Address Mode. Enables 4-byte Flash Address Mode.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>3</name>
+         <description>3 Byte Address Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4</name>
+         <description>4 Byte Address Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MODE_CTRL</name>
+     <description>SPIX Mode Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>MDCLK</name>
+       <description>Mode Clocks. Number of SPI clocks needed during mode/dummy phase of fetch.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>NO_CMD_MODE</name>
+       <description>No Command Mode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>always</name>
+         <description>Send read command every time SPI transaction is initiated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>once</name>
+         <description>Send read command only once. NO read command in subsequent SPI transactions.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXIT_NO_CMD_MODE</name>
+       <description>Exit no command mode.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MODE_DATA</name>
+     <description>SPIX Mode Data Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Mode Data. Specifies the data to send with the Dummy/Mode clocks.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>OUT_EN</name>
+       <description>Mode Output Enable. Output enable state for each corresponding data bit in MD_DATA. 0: output enable off, I/O is tristate and 1: Output enable on, I/O is driving MD_DATA.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCLK_FB_CTRL</name>
+     <description>SPIX Feedback Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>FB_EN</name>
+       <description>Enable SCLK feedback mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable SCLK feedback mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable SCLK feedback mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INVERT_EN</name>
+       <description>Invert SCLK in feedback mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Invert SCLK feedback mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Invert SCLK feedback mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IO_CTRL</name>
+     <description>SPIX IO Control Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>SCLK_DS</name>
+       <description>SCLK drive Strength. This bit controls the drive strength on the SCLK pin.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Low</name>
+         <description>Low drive strength.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>High</name>
+         <description>High drive strength.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_DS</name>
+       <description>Slave Select Drive Strength. This bit controls the drive strength on the dedicated slave select pin.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Low</name>
+         <description>Low drive strength.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>High</name>
+         <description>High drive strength.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDIO_DS</name>
+       <description>SDIO Drive Strength. This bit controls the drive strength of all SDIO pins.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Low</name>
+         <description>Low drive strength.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>High</name>
+         <description>High drive strength.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PU_PD_CTRL</name>
+       <description>IO Pullup/Pulldown Control. These bits control the pullups and pulldowns associated with all SPI XiP SDIO pins.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>tri_state</name>
+         <description>Tristate.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pull_Up</name>
+         <description>Pull-Up.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pull_down</name>
+         <description>Pull-Down.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMSECCN</name>
+     <description>SPIX Memory Security Control Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>DECEN</name>
+       <description>Decryption Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable decryption of SPIX data.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable decryption of SPIX data.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTH_DISABLE</name>
+       <description>Integrity Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Integrity checking disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Integrity checking enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CNTOPTIEN</name>
+       <description>Enable counters optimization (when authentication is enabled)</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INTERLDIS</name>
+       <description>Disable authenticity interleaving (when authentication is enabled)</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTHERR</name>
+       <description>Authentication Error Flah Bit.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUS_IDLE</name>
+     <description>SPIXF Bus Idle Detection.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>BUSIDLE</name>
+       <description>Bus Idle Timer Limit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXFM SPIXF Master-->
+  <peripheral>
+   <name>SPIXR</name>
+   <description>SPIXR peripheral.</description>
+   <baseAddress>0x4003A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>DATA32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>DATA16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>DATA32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>DATA8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>DATA32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SPIEN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MMEN</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TIMER</name>
+       <description>Timer Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Timer is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Timer is enabled, only valid if SPIEN=0.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FL_EN</name>
+       <description>Flow Control Mode Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Flow Control mode is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Flow Control Mode is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSIO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,
+						Slave Select 0 can be input in Master mode. This bit has no
+						effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is
+								self clearing when transactions are done. If
+								a transaction completes, and the TX FIFO
+								is empty, the Master halts, if a transaction
+								completes, and the TX FIFO is not empty,
+								the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Slave Select Control.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>deassert</name>
+         <description>SPI de-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>assert</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are
+						selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3</name>
+         <description>SS3 is selected.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS4</name>
+         <description>SS4 is selected.</description>
+         <value>0x10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS5</name>
+         <description>SS5 is selected.</description>
+         <value>0x20</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS6</name>
+         <description>SS6 is selected.</description>
+         <value>0x40</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS7</name>
+         <description>SS7 is selected.</description>
+         <value>0x80</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL3</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCLK_FB_INV</name>
+       <description>Invert SCLK Feedback in Master Mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>NON_INV</name>
+         <description>SCLK is not inverted to Line Receiver.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INV</name>
+         <description>SCLK is inverted to Line Receiver.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin(s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSPOL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3_high</name>
+         <description>SS3 active high.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS4_high</name>
+         <description>SS4 active high.</description>
+         <value>0x10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS5_high</name>
+         <description>SS5 active high.</description>
+         <value>0x20</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS6_high</name>
+         <description>SS6 active high.</description>
+         <value>0x40</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS7_high</name>
+         <description>SS7 active high.</description>
+         <value>0x80</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL4</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SSACT1</name>
+       <description>Slave Select Action delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSACT2</name>
+       <description>Slave Select Action delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSINACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BRG_CTRL</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LOW</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCALE</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_FIFO_LEVEL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for
+						threshold status. When TX FIFO has fewer than this many bytes, the
+						associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CLEAR</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write
+						pointers. This should be done when FIFO is not being accessed on the SPI side.
+					</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CNT</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_DMA_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_LEVEL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for
+						threshold status. When RX FIFO has more than this many bytes, the
+						associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CLEAR</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write
+						pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFIO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CNT</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RX_DMA_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IRQ</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data
+						to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data
+						from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IRQE</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKE</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKEE</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts,
+						cleared when last bit of last character is acted upon and Slave Select
+						de-assertion would occur. In Slave mode, set when Slave Select is
+						asserted, cleared when Slave Select is de-asserted. Not used in Timer mode.
+					</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>XMEM_CTRL</name>
+     <description>Register to control external memory.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RD_CMD</name>
+       <description>Read command.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>WR_CMD</name>
+       <description>Write command.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>DUMMY_CLK</name>
+       <description>Dummy clocks.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>XMEM_EN</name>
+       <description>XMEM enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXR SPIXR peripheral.-->
+  <peripheral>
+   <name>SRCC</name>
+   <description>External Memory Cache Controller Registers.</description>
+   <baseAddress>0x40033000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CACHE_ID</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CCHID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCFG</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCHSZ</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEMSZ</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CACHE_CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>CACHE_EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRITE_ALLOC</name>
+       <description>Write Allocate Enable. This bit only writable while the cache is disabled.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Write-no-allocate.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Write-allocate enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CWFST_DIS</name>
+       <description>Critical word first and streaming disable. This bit only writeable while the cache is disabled.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Critical word first and streaming disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Critical word first and streaming enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CACHE_RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Cache Contents. Any time this register location is written (regardless of the data value), the cache controller immediately begins invalidating the entire contents of the cache memory. The cache will be in bypass mode until the invalidate operation is complete. System software can examine the Cache Ready bit (CACHE_CTRL.CACHE_RDY) to determine when the invalidate operation is complete. Note that it is not necessary to disable the cache controller prior to beginning this operation. Reads from this register always return 0.</description>
+     <addressOffset>0x0700</addressOffset>
+     <fields>
+      <field>
+       <name>IA</name>
+       <description>Invalidate all cache contents.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SRCC External Memory Cache Controller Registers.-->
+  <peripheral>
+   <name>TMR0</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting.</description>
+   <groupName>Timers</groupName>
+   <baseAddress>0x40010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR0</name>
+    <description>TMR0 IRQ</description>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Count.  This register stores the current timer count.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000001</resetValue>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Compare.  This register stores the compare value, which is used to set the maximum count value to initiate a reload of the timer to 0x0001.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x0000FFFF</resetValue>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>PWM.  This register stores the value that is compared to the current timer count.</description>
+     <addressOffset>0x08</addressOffset>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Clear Interrupt. Writing a value (0 or 1) to a bit in this register clears the associated interrupt.</description>
+     <addressOffset>0x0C</addressOffset>
+     <modifiedWriteValues>oneToClear</modifiedWriteValues>
+     <fields>
+      <field>
+       <name>IRQ</name>
+       <description>Clear Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CN</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>TMODE</name>
+       <description>Timer Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>oneShot</name>
+         <description>One Shot Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Continuous Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>counter</name>
+         <description>Counter Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pwm</name>
+         <description>PWM Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>capture</name>
+         <description>Capture Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>compare</name>
+         <description>Compare Mode.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>gated</name>
+         <description>Gated Mode.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>captureCompare</name>
+         <description>Capture/Compare Mode.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES</name>
+       <description>Prescaler.  Set the Timer's prescaler value. The prescaler divides the PCLK input to the timer and sets the Timer's Count Clock, F_CNT_CLK = PCLK (HZ) /prescaler. The Timer's prescaler setting is a 4-bit value with pres3:pres[2:0].</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TPOL</name>
+       <description>Timer input/output polarity bit.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TEN</name>
+       <description>Timer Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES3</name>
+       <description>MSB of prescaler value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC</name>
+       <description>Timer PWM Synchronization Mode Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NOLHPOL</name>
+       <description>Timer PWM output 0A polarity bit.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NOLLPOL</name>
+       <description>Timer PWM output 0A' polarity bit.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PWMCKBD</name>
+       <description>Timer PWM output 0A Mode Disable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>NOLLCMP</name>
+       <description>Non-overlapping Low Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A and next rising edge of PWM output 0A'.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>NOLHCMP</name>
+       <description>Non-overlapping High Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A' and next rising edge of PWM output 0A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TMR0 32-bit reloadable timer that can be used for timing and event counting.-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR1</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 1</description>
+   <baseAddress>0x40011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+<!--TMR1 32-bit reloadable timer that can be used for timing and event counting. 1-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR2</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 2</description>
+   <baseAddress>0x40012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+<!--TMR2 32-bit reloadable timer that can be used for timing and event counting. 2-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR3</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 3</description>
+   <baseAddress>0x40013000</baseAddress>
+   <interrupt>
+    <name>TMR3</name>
+    <description>TMR3 IRQ</description>
+    <value>8</value>
+   </interrupt>
+  </peripheral>
+<!--TMR3 32-bit reloadable timer that can be used for timing and event counting. 3-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR4</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 4</description>
+   <baseAddress>0x40014000</baseAddress>
+   <interrupt>
+    <name>TMR4</name>
+    <description>TMR4 IRQ</description>
+    <value>9</value>
+   </interrupt>
+  </peripheral>
+<!--TMR4 32-bit reloadable timer that can be used for timing and event counting. 4-->
+  <peripheral derivedFrom="TMR0">
+   <name>TMR5</name>
+   <description>32-bit reloadable timer that can be used for timing and event counting. 5</description>
+   <baseAddress>0x40015000</baseAddress>
+   <interrupt>
+    <name>TMR5</name>
+    <description>TMR5 IRQ</description>
+    <value>10</value>
+   </interrupt>
+  </peripheral>
+<!--TMR5 32-bit reloadable timer that can be used for timing and event counting. 5-->
+  <peripheral>
+   <name>TPU</name>
+   <description>The Trust Protection Unit used to assist the computationally intensive operations of several common cryptographic algorithms.</description>
+   <baseAddress>0x40001000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Crypto_Engine</name>
+    <description>Crypto Engine interrupt.</description>
+    <value>27</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Crypto Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0xC0000000</resetValue>
+     <fields>
+      <field>
+       <name>RST</name>
+       <description>Reset. This bit is used to reset the crypto accelerator.  All crypto internal states and related registers are reset to their default reset values. Control register such as CRYPTO_CTRL, CIPHER_CTRL, HASH_CTRL, CRC_CTRL, MAA_CTRL (with the exception of the STC bit), HASH_MSG_SZ_[3:0] and MAA_MAWS will retain their values. This bit will automatically clear itself after one cycle.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_write</name>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>Starts reset operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT</name>
+       <description>Interrupt Enable. Generates an interrupt when done or error set.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRC</name>
+       <description>Source Select.  This bit selects the hash function and CRC generator input source.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inputFIFO</name>
+         <description>Input FIFO</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputFIFO</name>
+         <description>Output FIFO</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="INT">
+       <name>BSO</name>
+       <description>Byte Swap Output. Note. No byte swap will occur if there is not a full word.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="INT">
+       <name>BSI</name>
+       <description>Byte Swap Input. Note. No byte swap will occur if there is not a full word.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="INT">
+       <name>WAIT_EN</name>
+       <description>Wait Pin Enable. This can be used to hold off the crypto DMA until an external memory is ready. This is useful for transferring pages from NAND flash which may take several microseconds to become ready.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WAIT_POL</name>
+       <description>Wait Pin Polarity. When the wait pin is enabled, this bit selects its active state.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRSRC</name>
+       <description>Write FIFO Source Select. This field determines where data written to the write FIFO comes from. When data is written to the write FIFO, it is always written out the DMA. To decrypt or encrypt data, the write FIFO source should be set to the cipher output. To implement memcpy() or memset() functions, or to fill memory with random data, the write FIFO source should be set to the read FIFO. When calculating a HASH or CMAC, the write FIFO should be disabled.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>none</name>
+         <description>None.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cipherOutput</name>
+         <description>Cipher Output.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>readFIFO</name>
+         <description>Read FIFO.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDSRC</name>
+       <description>Read FIFO Source Select. This field selects the source of the read FIFO. Typically, it is set to use the DMA. To implement a memset() function, the read FIFO DMA should be disabled. To fill memory with random data or to hash random numbers, the read FIFO source should be set to the random number generator.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dmaDisabled</name>
+         <description>DMA Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dmaOrApb</name>
+         <description>DMA Or APB.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rng</name>
+         <description>RNG.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLAG_MODE</name>
+       <description>Done Flag Mode. This bit configures the access behavior of the individual CRYPTO_CTRL Done flags (CRYPTO_CTRL[27:24]). This bit is cleared only on reset to limit upkeep, i.e. once set, it will remain set until a reset occurs.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unres_wr</name>
+         <description>Unrestricted write (0 or 1) of CRYPTO_CTRL[27:24] flags.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>res_wr</name>
+         <description>Access to CRYPTO_CTRL[27:24] are write 1 to clear/write 0 no effect.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMADNE_MSK</name>
+       <description>DMA Done Flag Mask. This bit masks the DMA_DONE flag from being used to generate the CRYPTO_CTRL.DONE flag, and this disables a DMA_DONE condition from generating and interrupt. The DMA_DONE flag itself is unaffected and still may be monitored. This allows more optimal interrupt-driven crypto operations using DMA.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_used</name>
+         <description>DMA_DONE not used in setting CRYPTO_CTRL.DONE bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>used</name>
+         <description>DMA_DONE used in setting CRYPTO_CTRL.DONE bit.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMA_DONE</name>
+       <description>DMA Done. DMA write/read operation is complete. This bit must be cleared before starting a DMA operation.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notDone</name>
+         <description>Not Done.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>done</name>
+         <description>Done.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>GLS_DONE</name>
+       <description>Galois Done. FIFO is full and CRC or Hamming Code Generator is enabled. This bit must be cleared before starting a CRC operation Note that DMA_DONE must be polled instead of this bit to determine the end of DMA operation during the utilization of Hamming Code Generator.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>HSH_DONE</name>
+       <description>Hash Done. SHA operation is complete. This bit must be cleared before starting a HASH operation.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>CPH_DONE</name>
+       <description>Cipher Done. Either AES or DES encryption/decryption operation is complete. This bit must be cleared before starting a cipher operation.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>MAA_DONE</name>
+       <description>MAA Done. MAA operation is complete. This bit must be cleared before starting a new MAA operation. This bit is read only while the MAA is in progress. This bit is negate of MAA_CTRL.STC.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERR</name>
+       <description>AHB Bus Error. This bit is set when the DMA encounters a bus error during a read or write operation. Once this bit is set, the DMA will stop. This bit can only be cleared by resetting the crypto block.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Ready. Crypto block ready for more data.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>DONE</name>
+       <description>Done. One or more cryptographic calculations complete (logical OR of done flags).</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CIPHER_CTRL</name>
+     <description>Cipher Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ENC</name>
+       <description>Encrypt. Select encryption or decryption of input data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>encrypt</name>
+         <description>Encrypt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>decrypt</name>
+         <description>Decrypt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEY</name>
+       <description>Load Key from crypto DMA. This bit is automatically cleared by hardware after the DMA has completed loading the key. When the DMA operation is done, it sets the appropriate crypto DMA Done flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRC</name>
+       <description>Source of Random key.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>cipherKey</name>
+         <description>User cipher key (0x4000_1060).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>regFile</name>
+         <description>Key from battery-backed register file (0x4000_5000 to 0x4000_501F).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>qspiKey_regFile</name>
+         <description>Key from battery-backed register file (0x4000_5020 to 0x4000_502F).</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CIPHER</name>
+       <description>Cipher Operation Select.  Symmetric Block Cipher algorithm selection or memory operation.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes128</name>
+         <description>AES 128.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes192</name>
+         <description>AES 192.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes256</name>
+         <description>AES 256.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>des</name>
+         <description>DES.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>tdes</name>
+         <description>Triple DES.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description>Mode Select. Mode of operation for block cipher or memory operation. DES/TDES cannot be used in CFB, OFB or CTR modes.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ECB</name>
+         <description>ECB Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CBC</name>
+         <description>CBC Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CFB</name>
+         <description>CFB (AES only).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>OFB</name>
+         <description>OFB (AES only).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CTR</name>
+         <description>CTR (AES only).</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HASH_CTRL</name>
+     <description>HASH Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>INIT</name>
+       <description>Initialize. Initializes hash registers with standard constants.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>XOR</name>
+       <description>XOR data with IV from cipher block. Useful when calculating HMAC to XOR the input pad and output pad.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HASH</name>
+       <description>Hash function selection.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha1</name>
+         <description>SHA-1.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha224</name>
+         <description>SHA 224.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha256</name>
+         <description>SHA 256.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha384</name>
+         <description>SHA 384.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha512</name>
+         <description>SHA 512.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LAST</name>
+       <description>Last Message Bit. This bit shall be set along with the HASH_MSG_SZ register prior to hashing the last 512 or 1024-bit block of the message data. It will allow automatic preprocessing of the last message padding, which includes the trailing bit 1, followed by the respective number of zero bits for the last block size and finally the message length represented in bytes. The bit will be automatically cleared at the same time the HASH DONE is set, designating the completion of the last message hash.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEffect</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>lastMsgData</name>
+         <description>Last Message Data.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_CTRL</name>
+     <description>CRC Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>CRC_EN</name>
+       <description>Cyclic Redundancy Check Enable. The CRC cannot be enabled if the PRNG is enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MSB</name>
+       <description>MSB select. This bit selects the order of calculating CRC on data.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lsbFirst</name>
+         <description>LSB First.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>msbFirst</name>
+         <description>MSB First.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CRC_EN">
+       <name>PRNG</name>
+       <description>Pseudo Random Number Generator Enable. If entropy is disabled, this outputs one byte of pseudo random data per clock cycle. If entropy is enabled, data is output at a rate of one bit per clock cycle.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CRC_EN">
+       <name>ENT</name>
+       <description>Entropy Enable. If the PRNG is enabled, this mixes the high frequency ring oscillator with the LFSR. If the PRNG is disabled, the raw entropy data is output at a rate of 1 bit per clock. This makes it possible to characterize the quality of the entropy source.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CRC_EN">
+       <name>HAM</name>
+       <description>Hamming Code Enable. Enable hamming code calculation.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HRST</name>
+       <description>Hamming Reset. Reset Hamming code ECC generator for next block.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+       <enumeratedValues>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>Starts reset operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_SRC</name>
+     <description>Crypto DMA Source Address.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>SRC_ADDR</name>
+       <description>DMA Source Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_DST</name>
+     <description>Crypto DMA Destination Address.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>DST_ADDR</name>
+       <description>DMA Destination Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_CNT</name>
+     <description>Crypto DMA Byte Count.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>DMA Byte Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAA_CTRL</name>
+     <description>MAA Control Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>STC</name>
+       <description>Start Calculation. This bit functions as both the control and the status of the MAA. If the size value in the MAWS register is invalid, the STC bit will be cleared by hardware immediately.  Otherwise, the STC bit is automatically cleared following the completion of each calculation or detecting an error. Clearing the STC bit resets the controller to its default state.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLC</name>
+       <description>Calculation Configuration. These bits select desired calculation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>exp</name>
+         <description>Exponentiation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sq</name>
+         <description>Square operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>mul</name>
+         <description>Multiplication.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sqMul</name>
+         <description>Square followed by a multiplication.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>add</name>
+         <description>Addition.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sub</name>
+         <description>Subtraction.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OCALC</name>
+       <description>Optimized Calculation Control.  For optimized calculation, unnecessary multiply operations after normalizing the exponent are skipped.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MAAER</name>
+       <description>MAA Error. The MAAER bit defaults to 0 and can only be set by hardware. Once set, it must be cleared by software otherwise no new operation can be initiated.  Software writes 1 to this bit has no effect and MAAER will maintain its original state.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AMS</name>
+       <description>Multiplier A Memory Select.  These bits select the starting position of the parameter 'a' within the logical segment specified by AMA.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>BMS</name>
+       <description>Multiplicand B Memory Select.  These bits select the starting position of the parameter 'b' within the logical segment specified by BMA.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>EMS</name>
+       <description>Exponent Memory Select.  These bits select the starting position of the parameter 'e' within the logical segment specified by EMA.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>MMS</name>
+       <description>Modulus Memory Select.  These bits select the starting position of the parameter 'm' within the logical segment 5.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>AMA</name>
+       <description>Multiplier / Operand A Memory Assignment. These bits select the logical cryptographic RAM segment for the parameter 'a'.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>BMA</name>
+       <description>Multiplicand / Operand B Memory Assignment. These bits select the logical cryptographic RAM segment for the parameter 'b'.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RMA</name>
+       <description>Result Memory Assignment. These bits select the logical cryptographic RAM segment for the parameter 'r'.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TMA</name>
+       <description>Temporary Memory Assignment. These bits select the logical cryptographic RAM segment for the parameter 't'.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA_IN[%s]</name>
+     <description>Crypto Data Input. Data input can be written to this register instead of using the DMA. This register writes to the FIFO. This register occupies four successive words to allow the use of multi-store instructions. Words can be written to any location, they will be placed in the FIFO in the order they are written. The endian swap input control bit affects this register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Crypto Data Input. Input can be written to this register instead of using DMA.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA_OUT[%s]</name>
+     <description>Crypto Data Output. Resulting data from cipher calculation. Data is placed in the lower words of these four registers depending on the algorithm. For block cipher modes, this register holds the result of most recent encryption or decryption operation. These registers are affected by the endian swap bits.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Crypto Data Output. Resulting data from cipher calculation. Data is placed in the lower words of these four registers depending on algorithm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_POLY</name>
+     <description>CRC Polynomial. The polynomial to be used for Galois Field calculations (CRC or LFSR) should be written to this register. This register is affected by the MSB control bit.</description>
+     <addressOffset>0x40</addressOffset>
+     <resetValue>0xEDB88320</resetValue>
+     <fields>
+      <field>
+       <name>SRC_ADDR</name>
+       <description>CRC Polynomial. The polynomial to be used for Galois Field calculations (CRC or LFSR) should be written to this register. This register is affected by the MSB control bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_VAL</name>
+     <description>CRC Value. This is the state for the Galois Field. This register holds the result of a CRC calculation or the current state of the LFSR. This register is affected by the MSB control bit.</description>
+     <addressOffset>0x44</addressOffset>
+     <resetValue>0xFFFFFFFF</resetValue>
+     <fields>
+      <field>
+       <name>VAL</name>
+       <description>CRC Value. This is the state for the Galois Field. This register holds the result of a CRC calculation or the current state of LFSR. This register is affected by the MSB control bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_PRNG</name>
+     <description>Pseudo Random Value. Output of the Galois Field shift register. This holds the resulting pseudo-random number if entropy is disabled or true random number if entropy is enabled.</description>
+     <addressOffset>0x48</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>PRNG</name>
+       <description>Pseudo Random Value. Output of the Galois Field Shift Register. This holds the resulting pseudo-random number if entropy is disabled or true random number if entropy is enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HAM_ECC</name>
+     <description>Hamming ECC Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>ECC</name>
+       <description>Hamming ECC Value. These bits are the even parity of their corresponding bit groups.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PAR</name>
+       <description>Parity. This is the parity of the entire array.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>even</name>
+         <description>Even.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>odd</name>
+         <description>Odd.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CIPHER_INIT[%s]</name>
+     <description>Initial Vector. For block cipher operations that use CBC, CFB, OFB, or CNTR modes, this register holds the initial value. This register is updated with each encryption or decryption operation. This register is affected by the endian swap bits.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>IVEC</name>
+       <description>Initial Vector. For block cipher operations that use CBC, CFB, OFB, or CNTR modes, this register holds the initial value. This register is updated with each encryption or decryption operation. This register is affected by the endian swap bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CIPHER_KEY[%s]</name>
+     <description>Cipher Key.  This register holds the key used for block cipher operations. The lower words are used for block ciphers that use shorter key lengths. This register is affected by the endian swap input control bits.</description>
+     <addressOffset>0x60</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>KEY</name>
+       <description>Cipher Key. This register holds the key used for block cipher operations. The lower words are used for block ciphers that use shorter kye lengths. This register is affected by the endian swap input control bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>16</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>HASH_DIGEST[%s]</name>
+     <description>This register holds the calculated hash value. This register is affected by the endian swap bits.</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>HASH</name>
+       <description>This register holds the calculated hash value. This register is affected by the endian swap bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>HASH_MSG_SZ[%s]</name>
+     <description>Message Size. This register holds the lowest 32-bit of message size in bytes.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>MSGSZ</name>
+       <description>Message Size. This register holds the lowest 32-bit of message size in bytes.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAA_MAWS</name>
+     <description>MAA Word Size. This register defines the number of bits for a modular operation. This register must be set to a valid value prior to the MAA operation start. Valid values are from 1 to 2048.  Invalid values are ignored and will not initiate a MAA operation.</description>
+     <addressOffset>0xD0</addressOffset>
+     <fields>
+      <field>
+       <name>MSGSZ</name>
+       <description>MAA Word Size.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TPU The Trust Protection Unit used to assist the computationally intensive operations of several common cryptographic algorithms.-->
+  <peripheral>
+   <name>TRNG</name>
+   <description>Random Number Generator.</description>
+   <baseAddress>0x4004D000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TRNG</name>
+    <description>TRNG interrupt.</description>
+    <value>4</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CN</name>
+     <description>TRNG Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000003</resetValue>
+     <fields>
+      <field>
+       <name>ODHT</name>
+       <description>Start On-Demand health test</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RND_IRQ_EN</name>
+       <description>To enable IRQ generation when a new 32-bit Random number is ready.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HEALTH_EN</name>
+       <description>To enable IRQ generation when a health test fails</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESKG_MEU</name>
+       <description>AES Key Generate. When enabled, the key for securing NVSRAM is generated and transferred to the secure key register automatically without user visibility or intervention. This bit is cleared by hardware once the key has been transferred to the secure key register.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="AESKG_MEU">
+       <name>AESKG_MEMPROTE</name>
+       <description>AES Key Generate. When enabled, the key for securing NVSRAM is generated and transferred to the secure key register automatically without user visibility or intervention. This bit is cleared by hardware once the key has been transferred to the secure key register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="AESKG_MEU">
+       <name>AESKG_MEMPROTA</name>
+       <description>AES Key Generate. When enabled, the key for securing NVSRAM is generated and transferred to the secure key register automatically without user visibility or intervention. This bit is cleared by hardware once the key has been transferred to the secure key register.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ST</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RND_RDY</name>
+       <description>32-bit random data is ready to read from TRNG_DATA register. Reading TRNG_DATA when RND_RDY=0 will return all 0's. IRQ is generated when RND_RDY=1 if TRNG_CN.RND_IRQ_EN=1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Busy</name>
+         <description>TRNG Busy</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Ready</name>
+         <description>32 bit random data is ready</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ODHTS</name>
+       <description>On-Demand health test status</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Done</name>
+         <description>On demand health test done</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Busy</name>
+         <description>On demand health test on going</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HTS</name>
+       <description>Health test status. This bit shall be read when On-demand health test is completed (ODHTS=0) to check the result. This bit is also set when a continuous health test reports an error, IRQ is generated if HEALTH_EN=1. Write 1 to clear this bit.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Pass</name>
+         <description>Pass</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Fail</name>
+         <description>Fail</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRCFAIL</name>
+       <description>Entropy source has failed. IRQ is generated if HEALTH_EN=1. Write 1 to clear this bit.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Works</name>
+         <description>Entopy source works correctly</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Fail</name>
+         <description>Entropy Source has failed</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESKGD_MEU_S</name>
+       <description>Automatically AES transfer on going</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data. The content of this register is valid only when RNG_IS =1. When TNRG is disabled, read returns 0x0000 0000.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRNG Random Number Generator.-->
+  <peripheral>
+   <name>TRIMSIR</name>
+   <description>Trim System Initilazation Registers</description>
+   <baseAddress>0x40005400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RTC</name>
+     <description>System Init. Configuration Register 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>RTCX1</name>
+       <description>RTC X1 Trim.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RTCX2</name>
+       <description>RTC X2 Trim.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SIR13</name>
+     <description>System Init. Configuration Register 13.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>SIMOCLKDIV</name>
+       <description>SIMO Clock Divide while in LP mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SIR17</name>
+     <description>System Init. Configuration Register 17.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>BUCKCLKSELLP</name>
+       <description>BUCK Clock Select Low Power Mode.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRIMSIR Trim System Initilazation Registers-->
+  <peripheral>
+   <name>UART0</name>
+   <description>UART</description>
+   <baseAddress>0x40042000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>UART0</name>
+    <description>UART0 IRQ</description>
+    <value>14</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ENABLE</name>
+       <description>UART enabled, to enable UART block, it is used to drive a gated clock in order to save power consumption when UART is not used. FIFOs are flushed when UART is disabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>UART disabled. FIFOs are flushed. Clock is gated off for power savings. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>UART enabled. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PARITY_EN</name>
+       <description>Enable/disable Parity bit (9th character).</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Parity </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Parity enabled as 9th bit</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PARITY</name>
+       <description>When PARITY_EN=1, selects odd, even, Mark or Space parity.
+                Mark parity = always 1;
+
+                Space parity = always 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Even</name>
+         <description>Even parity selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ODD</name>
+         <description>Odd parity selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>MARK</name>
+         <description>Mark parity selected.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SPACE</name>
+         <description>Space parity selected.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PARMD</name>
+       <description>Selects parity based on 1s or 0s count (when PARITY_EN=1).</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1</name>
+         <description>Parity calculation is based on number of 1s in frame.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>0</name>
+         <description>Parity calculation is based on number of 0s in frame.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Flushes the TX FIFO buffer.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Flushes the RX FIFO buffer.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BITACC</name>
+       <description>If set, bit accuracy is selected, in this case the bit duration is the same for all the bits with the optimal accuracy. But the frame duration can have a significant deviation from the expected baudrate.If clear, frame accuracy is selected, therefore bits can have different duration in order to guarantee the minimum frame deviation.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>FRAME</name>
+         <description>Frame accuracy.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BIT</name>
+         <description>Bit accuracy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CHAR_SIZE</name>
+       <description>Selects UART character size.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5</name>
+         <description>5 bits.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6</name>
+         <description>6 bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7</name>
+         <description>7 bits.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8</name>
+         <description>8 bits.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPBITS</name>
+       <description>Selects the number of stop bits that will be generated.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1</name>
+         <description>1 stop bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_5</name>
+         <description>1.5 stop bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLOW_CTRL</name>
+       <description>Enables/disables hardware flow control.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW Flow Control with RTS/CTS enabled</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW Flow Control disabled</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLOW_POL</name>
+       <description>RTS/CTS polarity.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0</name>
+         <description>RTS/CTS asserted is logic 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1</name>
+         <description>RTS/CTS asserted is logic 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NULL_MODEM</name>
+       <description>NULL Modem Support (RTS/CTS and TXD/RXD swap).</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Direct convention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Null Modem Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>Break control bit. It causes a break condition to be transmitted to receiving UART.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Break characters are not generated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Break characters are sent (all the bits are at '0' including start/parity/stop).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKSEL</name>
+       <description>Baud Rate Clock Source Select.  Selects the baud rate clock.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SYSTEM</name>
+         <description>System clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate 7.3727MHz internal clock.  Useful in low power modes when the system clock is slow.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_TO</name>
+       <description>RX Time Out. RX time out interrupt will occur after RXTO Uart
+                       characters if RX-FIFO is not empty and RX FIFO has not been read.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>THRESH_CTRL</name>
+     <description>Threshold Control register.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>RX_FIFO_THRESH</name>
+       <description>RX FIFO Threshold Level.When the RX FIFO reaches this many bytes or higher, UARTn_INFTL.rx_fifo_level is set.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_THRESH</name>
+       <description>TX FIFO Threshold Level. When the TX FIFO reaches this many bytes or higher, UARTn_INTFL.tx_fifo_level is set.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RTS_FIFO_THRESH</name>
+       <description>RTS threshold control. When the RX FIFO reaches this many bytes or higher, the RTS output signal is deasserted, informing the transmitting UART to stop sending data to this UART.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TX_BUSY</name>
+       <description>Read-only flag indicating the UART transmit status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_BUSY</name>
+       <description>Read-only flag indicating the UARTreceiver status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>PARITY</name>
+       <description>9th Received bit state. This bit identifies the state of the 9th bit of received data. Only available for UART_CTRL.SIZE[1:0]=3.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>Received BREAK status. BREAKS is cleared when UART_STAT register is read. Received data input is held in spacing (logic 0) state for longer than a full word transmission time (that is, the total time of Start bit + data bits + Parity + Stop bits).</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_EMPTY</name>
+       <description>Read-only flag indicating the RX FIFO state.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Read-only flag indicating the RX FIFO state.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>Read-only flag indicating the TX FIFO state.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>Read-only flag indicating the TX FIFO state.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_NUM</name>
+       <description>Indicates the number of bytes currently in the RX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_FIFO_CNT</name>
+       <description>Indicates the number of bytes currently in the TX FIFO.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RX_TO</name>
+       <description>Receiver Timeout Status. Indicates if timeout has occurred.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>RX_FRAME_ERROR</name>
+       <description>Enable for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PARITY_ERROR</name>
+       <description>Enable for RX Parity Error interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_CHANGE</name>
+       <description>Enable for CTS signal change interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OVERRUN</name>
+       <description>Enable for RX FIFO OVerrun interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_THRESH</name>
+       <description>Enable for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_ALMOST_EMPTY</name>
+       <description>Enable for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_THRESH</name>
+       <description>Enable for interrupt when TX FIFO reaches the number of bytes configured by the TXTHD field.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>Enable for received BREAK character interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_TIMEOUT</name>
+       <description>Enable for RX Timeout Interrupt. Trigger if there is no RX communication during n UART characters (n=UART_CN.RXTO).</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LAST_BREAK</name>
+       <description>Enable for Last break character interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Interrupt Status Flags.</description>
+     <addressOffset>0x10</addressOffset>
+     <size>32</size>
+     <modifiedWriteValues>oneToClear</modifiedWriteValues>
+     <fields>
+      <field>
+       <name>RX_FRAME_ERROR</name>
+       <description>FLAG for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PARITY_ERROR</name>
+       <description>FLAG for RX Parity Error interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_CHANGE</name>
+       <description>FLAG for CTS signal change interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OVERRUN</name>
+       <description>FLAG for RX FIFO Overrun interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_THRESH</name>
+       <description>FLAG for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_ALMOST_EMPTY</name>
+       <description>FLAG for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_THRESH</name>
+       <description>FLAG for interrupt when TX FIFO reaches the number of bytes configured by the TXTHD field.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BREAK</name>
+       <description>FLAG for received BREAK character interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_TIMEOUT</name>
+       <description>FLAG for RX Timeout Interrupt. Trigger if there is no RX communication during n UART characters (n=UART_CN.RXTO).</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LAST_BREAK</name>
+       <description>FLAG for Last break character interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BAUD0</name>
+     <description>Baud rate register. Integer portion.</description>
+     <addressOffset>0x14</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>IBAUD</name>
+       <description>Integer portion of baud rate divisor value. IBAUD = InputClock / (factor * Baud Rate Frequency).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>FACTOR</name>
+       <description>FACTOR must be chosen to have IDIV&gt;
+                0. factor used in calculation = 128 &gt;
+                &gt;
+                FACTOR.
+      </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>128</name>
+         <description>Baud Factor 128</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>64</name>
+         <description>Baud Factor 64</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>32</name>
+         <description>Baud Factor 32</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16</name>
+         <description>Baud Factor 16</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BAUD1</name>
+     <description>Baud rate register. Decimal Setting.</description>
+     <addressOffset>0x18</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DBAUD</name>
+       <description>Decimal portion of baud rate divisor value. DIV = InputClock/ (factor*Baud Rate Frequency). DDIV= (DIV-IDIV) *128.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Data buffer.</description>
+     <addressOffset>0x1C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>FIFO</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration.</description>
+     <addressOffset>0x20</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>TXDMA_EN</name>
+       <description>TX DMA channel enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>DMA is disabled </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>DMA is enabled </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXDMA_EN</name>
+       <description>RX DMA channel enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>DMA is disabled </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>DMA is enabled </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RXDMA_START</name>
+       <description>Receive DMA Start.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXDMA_AUTO_TO</name>
+       <description>Receive DMA Timeout Start.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXDMA_LEVEL</name>
+       <description>TX threshold for DMA transmission.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RXDMA_LEVEL</name>
+       <description>RX threshold for DMA transmission.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TX_FIFO</name>
+     <description>Transmit FIFO Status register.</description>
+     <addressOffset>0x24</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Reading from this field returns the next character available at the output of the TX FIFO (if one is available, otherwise 00h is returned).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--UART0 UART-->
+  <peripheral derivedFrom="UART0">
+   <name>UART1</name>
+   <description>UART 1</description>
+   <baseAddress>0x40043000</baseAddress>
+   <interrupt>
+    <name>UART1</name>
+    <description>UART1 IRQ</description>
+    <value>15</value>
+   </interrupt>
+  </peripheral>
+<!--UART1 UART 1-->
+  <peripheral derivedFrom="UART0">
+   <name>UART2</name>
+   <description>UART 2</description>
+   <baseAddress>0x40044000</baseAddress>
+   <interrupt>
+    <name>UART2</name>
+    <description>UART2 IRQ</description>
+    <value>34</value>
+   </interrupt>
+  </peripheral>
+<!--UART2 UART 2-->
+  <peripheral>
+   <name>USBHS</name>
+   <description>USB 2.0 High-speed Controller.</description>
+   <baseAddress>0x400B1000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>USB</name>
+    <value>2</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FADDR</name>
+     <description>Function address register.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <resetMask>0x00</resetMask>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Function address for this controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>UPDATE</name>
+       <description>Set when ADDR is written, cleared when new address takes effect.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>POWER</name>
+     <description>Power management register.</description>
+     <addressOffset>0x01</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>EN_SUSPENDM</name>
+       <description>Enable SUSPENDM signal.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SUSPEND</name>
+       <description>Suspend mode detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESUME</name>
+       <description>Generate resume signaling.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESET</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS_MODE</name>
+       <description>High-speed mode detected.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS_ENABLE</name>
+       <description>High-speed mode enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SOFTCONN</name>
+       <description>Softconn.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ISO_UPDATE</name>
+       <description>Wait for SOF during Isochronous xfers.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRIN</name>
+     <description>Interrupt register for EP0 and IN EP1-15.</description>
+     <addressOffset>0x02</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_IN_INT</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP14_IN_INT</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP13_IN_INT</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP12_IN_INT</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP11_IN_INT</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP10_IN_INT</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP9_IN_INT</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP8_IN_INT</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP7_IN_INT</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP6_IN_INT</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP5_IN_INT</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP4_IN_INT</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP3_IN_INT</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP2_IN_INT</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP1_IN_INT</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP0_IN_INT</name>
+       <description>Endpoint 0 interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTROUT</name>
+     <description>Interrupt register for OUT EP 1-15.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_OUT_INT</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP14_OUT_INT</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP13_OUT_INT</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP12_OUT_INT</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP11_OUT_INT</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP10_OUT_INT</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP9_OUT_INT</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP8_OUT_INT</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP7_OUT_INT</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP6_OUT_INT</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP5_OUT_INT</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP4_OUT_INT</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP3_OUT_INT</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP2_OUT_INT</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP1_OUT_INT</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRINEN</name>
+     <description>Interrupt enable for EP 0 and IN EP 1-15.</description>
+     <addressOffset>0x06</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_IN_INT_EN</name>
+       <description>Endpoint 15 interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP14_IN_INT_EN</name>
+       <description>Endpoint 14 interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP13_IN_INT_EN</name>
+       <description>Endpoint 13 interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP12_IN_INT_EN</name>
+       <description>Endpoint 12 interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP11_IN_INT_EN</name>
+       <description>Endpoint 11 interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP10_IN_INT_EN</name>
+       <description>Endpoint 10 interrupt enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP9_IN_INT_EN</name>
+       <description>Endpoint 9 interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP8_IN_INT_EN</name>
+       <description>Endpoint 8 interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP7_IN_INT_EN</name>
+       <description>Endpoint 7 interrupt enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP6_IN_INT_EN</name>
+       <description>Endpoint 6 interrupt enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP5_IN_INT_EN</name>
+       <description>Endpoint 5 interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP4_IN_INT_EN</name>
+       <description>Endpoint 4 interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP3_IN_INT_EN</name>
+       <description>Endpoint 3 interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP2_IN_INT_EN</name>
+       <description>Endpoint 2 interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP1_IN_INT_EN</name>
+       <description>Endpoint 1 interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP0_INT_EN</name>
+       <description>Endpoint 0 interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTROUTEN</name>
+     <description>Interrupt enable for OUT EP 1-15.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_OUT_INT_EN</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP14_OUT_INT_EN</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP13_OUT_INT_EN</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP12_OUT_INT_EN</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP11_OUT_INT_EN</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP10_OUT_INT_EN</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP9_OUT_INT_EN</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP8_OUT_INT_EN</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP7_OUT_INT_EN</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP6_OUT_INT_EN</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP5_OUT_INT_EN</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP4_OUT_INT_EN</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP3_OUT_INT_EN</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP2_OUT_INT_EN</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP1_OUT_INT_EN</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRUSB</name>
+     <description>Interrupt register for common USB interrupts.</description>
+     <addressOffset>0x0A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SOF_INT</name>
+       <description>Start of Frame.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESET_INT</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESUME_INT</name>
+       <description>Resume detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SUSPEND_INT</name>
+       <description>Suspend detected.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRUSBEN</name>
+     <description>Interrupt enable for common USB interrupts.</description>
+     <addressOffset>0x0B</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SOF_INT_EN</name>
+       <description>Start of Frame.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESET_INT_EN</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESUME_INT_EN</name>
+       <description>Resume detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SUSPEND_INT_EN</name>
+       <description>Suspend detected.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FRAME</name>
+     <description>Frame number.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>FRAMENUM</name>
+       <description>Read the last received frame number, that is the 11-bit frame number received in the SOF packet.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INDEX</name>
+     <description>Index for banked registers.</description>
+     <addressOffset>0x0E</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>INDEX</name>
+       <description>Index Register Access Selector. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TESTMODE</name>
+     <description>USB 2.0 test mode enable register.</description>
+     <addressOffset>0x0F</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>FORCE_FS</name>
+       <description>Force USB to Full-speed after reset.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FORCE_HS</name>
+       <description>Force USB to High-speed after reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_PKT</name>
+       <description>Transmit fixed test packet.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_K</name>
+       <description>Force USB to continuous K state.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_J</name>
+       <description>Force USB to continuous J state.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_SE0_NAK</name>
+       <description>Respond to any valid IN token with NAK.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INMAXP</name>
+     <description>Maximum packet size for INx endpoint (x == INDEX).</description>
+     <addressOffset>0x10</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>MAXPACKETSIZE</name>
+       <description>Maximum Packet Size in a Single Transaction. That is the maximum packet size in bytes, that is transmitted for each microframe. The maximum value is 1024, subject to the limitations of the endpoint type set in USB 2.0 Specification, Chapter 9</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+      <field>
+       <name>NUMPACKMINUS1</name>
+       <description>Number of Split Packets - 1. Defines the maximum number of packets minus 1 that a USB payload can be split into. THis must be an exact multiple of maxpacketsize. Only applicable for HS High-Bandwidth isochronous endpoints and Bulk endpoints. Ignored in all other cases. </description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CSR0</name>
+     <description>Control status register for EP 0 (when INDEX == 0).</description>
+     <addressOffset>0x12</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SERV_SETUP_END</name>
+       <description>Clear EP0 Setup End Bit. Write a 1 to clear the setupend bit. Automatically cleared after being set </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SERV_OUTPKTRDY</name>
+       <description>Clear EP0 Out Packet Ready Bit. Write a 1 to clear the outpktrdy bit. Automatically cleared after being set.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SEND_STALL</name>
+       <description>Send EP0 STALL Handshake. Write a 1 to this bit to terminate the current control transaction by sneding a STALL handshake. Automatically cleared after being set. </description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SETUP_END</name>
+       <description>Read Setup End Status. Automatically set when a contorl transaction ends before the dataend bit has been set by fimrware. An interrupt is generated when this bit is set. Write 1 to servicedsetupend to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_END</name>
+       <description>Control Transaction Data End. Write a 1 to this bit after firmware completes any of the following three transactions: 1. set inpktrdy = 1 for the last data packet. 2. Set inpktrdy =1 for a zero-length data packet. 3. Clear outpktrdy = 0 after unloading the last data packet. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENT_STALL</name>
+       <description> Read EP0 STALL Handshake Sent Status Automatically set when a STALL handshake is transmitted. Write a 0 to clear. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPKTRDY</name>
+       <description>EP0 IN Packet Ready 1: Write a 1 after writing a data packet to the IN FIFO. Automatically cleared when the data packet is transmitted. An interrupt is generated when this bit is cleared. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPKTRDY</name>
+       <description>EP0 OUT Packet Ready Status Automatically set when a data packet is received in the OUT FIFO. An interrupt is generated when this bit is set. Write a 1 to the servicedoutpktrdy bit (above) to clear after the packet is unloaded from the OUT FIFO. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INCSRL</name>
+     <description>Control status lower register for INx endpoint (x == INDEX).</description>
+     <alternateRegister>CSR0</alternateRegister>
+     <addressOffset>0x12</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>INCOMPTX</name>
+       <description>Read Incomplete Split Transfer Error Status High-bandwidth isochronous transfers: Automatically set when a payload is split into multiple packets but insufficient IN tokens were received to send all packets. The current packets is flushed from the IN FIFO. Write 0 to clear.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLRDATATOG</name>
+       <description>Write 1 to clear IN endpoint data-toggle to 0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENTSTALL</name>
+       <description>Read STALL Handshake Sent Status Automatically set when a STALL handshake is transmitted, at which time the IN FIFO is flushed, and inpktrdy is cleared. Write 0 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENDSTALL</name>
+       <description>Send STALL Handshake.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>terminate</name>
+         <description>Terminate STALL handhsake</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Respond to an IN token with a STALL handshake</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSHFIFO</name>
+       <description>Flush Next Packet from IN FIFO. Write 1 to clear</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>UNDERRUN</name>
+       <description>Read IN FIFO Underrun Error Status Isochronous Mode: Automatically set if the IN FIFO is empty. Write 0 to clear</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFONOTEMPTY</name>
+       <description>Read FIFO Not Empty Status. Automatically set when there is at least one packet in the IN FIFO. Write a 0 to clear. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPKTRDY</name>
+       <description>IN Packet Ready. Write a 1 to clear </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INCSRU</name>
+     <description>Control status upper register for INx endpoint (x == INDEX).</description>
+     <addressOffset>0x13</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>AUTOSET</name>
+       <description>Auto Set inpktrdy. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>set</name>
+         <description>USBHS_INCSRL_inpktrdy must be set by firmware.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>auto</name>
+         <description>USBHS_INCSRL_inpktrdy is automatically set. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ISO</name>
+       <description>Isochronous Transfer Enable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>interrupt</name>
+         <description>Enable IN Bulk and IN interrupt transfers.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>isochronous</name>
+         <description>Enable IN Isochronous transfers. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description> Endpoint Direction Mode.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>out</name>
+         <description>Endpoint direction is OUT.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>in</name>
+         <description>Endpoint direction is IN. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FRCDATATOG</name>
+       <description> Force In Data - Toggle</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>received</name>
+         <description>Toggle data-toglge only when an ACK is received.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dontcare</name>
+         <description>Toggle data-toggle regardless of ACK. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPKTBUFDIS</name>
+       <description> Double Packet Buffering Disable </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Double packet buffering.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Double Packet Buffering.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTMAXP</name>
+     <description>Maximum packet size for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x14</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>NUMPACKMINUS1</name>
+       <description>Number of Split Packets -1. Defines the maximum number of packets - 1 that a usb payload is combined into. The value must be exact multiple of maxpacketsize. </description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>MAXPACKETSIZE</name>
+       <description>Maximum Packet in a Single Transaction. This is the maximum packet size, in bytes, that is transmitted for each microframe. The maximum value is 1024, subject to the limitations for the endpoint type set in USB2.0 spesification, chapter 9.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCSRL</name>
+     <description>Control status lower register for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x16</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>CLRDATATOG</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENTSTALL</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENDSTALL</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FLUSHFIFO</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DATAERROR</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>OVERRUN</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFOFULL</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>OUTPKTRDY</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCSRU</name>
+     <description>Control status upper register for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x17</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>AUTOCLEAR</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ISO</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DISNYET</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DPKTBUFDIS</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INCOMPRX</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>COUNT0</name>
+     <description>Number of received bytes in EP 0 FIFO (INDEX == 0).</description>
+     <addressOffset>0x18</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>COUNT0</name>
+       <description>Read Number of Data Bytes in the Endpoint 0 FIFO. Returns the number of data bytes in the endpoint 0 FIFO. This value changes as contents of the FIFO change. The value is only valued when USBHS_OUTSCRL_outpktrdy = 1 </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCOUNT</name>
+     <description>Number of received bytes in OUT EPx FIFO (x == INDEX).</description>
+     <alternateRegister>COUNT0</alternateRegister>
+     <addressOffset>0x18</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>OUTCOUNT</name>
+       <description>Read Number of Data Bytes in OUT FIFO. Returns the number of data bytes in the packet that are read next in the OUT FIFO. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>13</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO0</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO0</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO1</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO1</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO2</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO2</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO3</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x2c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO3</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO4</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO4</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO5</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO5</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO6</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO6</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO7</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x3c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO7</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO8</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO8</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO9</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO9</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO10</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO10</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO11</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x4c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO11</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO12</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO12</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO13</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO13</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO14</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO14</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO15</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x5c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO15</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HWVERS</name>
+     <description>HWVERS</description>
+     <addressOffset>0x6c</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>USBHS_HWVERS</name>
+       <description>USBHS Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EPINFO</name>
+     <description>Endpoint hardware information.</description>
+     <addressOffset>0x78</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>OUTENDPOINTS</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>INTENDPOINTS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RAMINFO</name>
+     <description>RAM width information.</description>
+     <addressOffset>0x79</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RAMBITS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SOFTRESET</name>
+     <description>Software reset register.</description>
+     <addressOffset>0x7A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RSTXS</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RSTS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTUCH</name>
+     <description>Chirp timeout timer setting.</description>
+     <addressOffset>0x80</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>C_T_UCH</name>
+       <description>HS Chirp Timeout Clock Cycles. This configures the chirp timeout used by this device to negotiate a HS connection with a FS Host. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTHSRTN</name>
+     <description>Sets delay between HS resume to UTM normal operating mode.</description>
+     <addressOffset>0x82</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>C_T_HSTRN</name>
+       <description>High Speed Resume Delay Clock Cycles. This configures the delay from when the RESUME state on the bus ends, the when the USBHS resumes normal operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_USB_REG_00</name>
+     <description>MXM_USB_REG_00</description>
+     <addressOffset>0x400</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_UTMI_RESET</name>
+     <description>M31_PHY_UTMI_RESET</description>
+     <addressOffset>0x404</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_UTMI_VCONTROL</name>
+     <description>M31_PHY_UTMI_VCONTROL</description>
+     <addressOffset>0x408</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CLK_EN</name>
+     <description>M31_PHY_CLK_EN</description>
+     <addressOffset>0x40C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_PONRST</name>
+     <description>M31_PHY_PONRST</description>
+     <addressOffset>0x410</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_NONCRY_RSTB</name>
+     <description>M31_PHY_NONCRY_RSTB</description>
+     <addressOffset>0x414</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_NONCRY_EN</name>
+     <description>M31_PHY_NONCRY_EN</description>
+     <addressOffset>0x418</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_EN</name>
+     <description>M31_PHY_U2_COMPLIANCE_EN</description>
+     <addressOffset>0x420</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_DAC_ADJ</name>
+     <description>M31_PHY_U2_COMPLIANCE_DAC_ADJ</description>
+     <addressOffset>0x424</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_DAC_ADJ_EN</name>
+     <description>M31_PHY_U2_COMPLIANCE_DAC_ADJ_EN</description>
+     <addressOffset>0x428</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CLK_RDY</name>
+     <description>M31_PHY_CLK_RDY</description>
+     <addressOffset>0x42C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_PLL_EN</name>
+     <description>M31_PHY_PLL_EN</description>
+     <addressOffset>0x430</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_BIST_OK</name>
+     <description>M31_PHY_BIST_OK</description>
+     <addressOffset>0x434</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DATA_OE</name>
+     <description>M31_PHY_DATA_OE</description>
+     <addressOffset>0x438</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_OSCOUTEN</name>
+     <description>M31_PHY_OSCOUTEN</description>
+     <addressOffset>0x43C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_LPM_ALIVE</name>
+     <description>M31_PHY_LPM_ALIVE</description>
+     <addressOffset>0x440</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_HS_BIST_MODE</name>
+     <description>M31_PHY_HS_BIST_MODE</description>
+     <addressOffset>0x444</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CORECLKIN</name>
+     <description>M31_PHY_CORECLKIN</description>
+     <addressOffset>0x448</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XTLSEL</name>
+     <description>M31_PHY_XTLSEL</description>
+     <addressOffset>0x44C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_LS_EN</name>
+     <description>M31_PHY_LS_EN</description>
+     <addressOffset>0x450</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DEBUG_SEL</name>
+     <description>M31_PHY_DEBUG_SEL</description>
+     <addressOffset>0x454</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DEBUG_OUT</name>
+     <description>M31_PHY_DEBUG_OUT</description>
+     <addressOffset>0x458</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_OUTCLKSEL</name>
+     <description>M31_PHY_OUTCLKSEL</description>
+     <addressOffset>0x45C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_31_0</name>
+     <description>M31_PHY_XCFGI_31_0</description>
+     <addressOffset>0x460</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_63_32</name>
+     <description>M31_PHY_XCFGI_63_32</description>
+     <addressOffset>0x464</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_95_64</name>
+     <description>M31_PHY_XCFGI_95_64</description>
+     <addressOffset>0x468</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_127_96</name>
+     <description>M31_PHY_XCFGI_127_96</description>
+     <addressOffset>0x46C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_137_128</name>
+     <description>M31_PHY_XCFGI_137_128</description>
+     <addressOffset>0x470</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_HS_COARSE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_HS_COARSE_TUNE_NUM</description>
+     <addressOffset>0x474</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_HS_FINE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_HS_FINE_TUNE_NUM</description>
+     <addressOffset>0x478</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_FS_COARSE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_FS_COARSE_TUNE_NUM</description>
+     <addressOffset>0x47C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_FS_FINE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_FS_FINE_TUNE_NUM</description>
+     <addressOffset>0x480</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_LOCK_RANGE_MAX</name>
+     <description>M31_PHY_XCFG_LOCK_RANGE_MAX</description>
+     <addressOffset>0x484</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_LOCK_RANGE_MIN</name>
+     <description>M31_PHY_XCFGI_LOCK_RANGE_MIN</description>
+     <addressOffset>0x488</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_OB_RSEL</name>
+     <description>M31_PHY_XCFG_OB_RSEL</description>
+     <addressOffset>0x48C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_OC_RSEL</name>
+     <description>M31_PHY_XCFG_OC_RSEL</description>
+     <addressOffset>0x490</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGO</name>
+     <description>M31_PHY_XCFGO</description>
+     <addressOffset>0x494</addressOffset>
+    </register>
+    <register>
+     <name>MXM_INT</name>
+     <description>USB Added Maxim Interrupt Flag Register.</description>
+     <addressOffset>0x498</addressOffset>
+     <fields>
+      <field>
+       <name>VBUS</name>
+       <description>VBUS</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOVBUS</name>
+       <description>NOVBUS</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_INT_EN</name>
+     <description>USB Added Maxim Interrupt Enable Register.</description>
+     <addressOffset>0x49C</addressOffset>
+     <fields>
+      <field>
+       <name>VBUS</name>
+       <description>VBUS</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOVBUS</name>
+       <description>NOVBUS</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_SUSPEND</name>
+     <description>USB Added Maxim Suspend Register.</description>
+     <addressOffset>0x4A0</addressOffset>
+     <fields>
+      <field>
+       <name>SEL</name>
+       <description>Suspend register</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_REG_A4</name>
+     <description>USB Added Maxim Power Status Register</description>
+     <addressOffset>0x4A4</addressOffset>
+     <fields>
+      <field>
+       <name>VRST_VDDB_N_A</name>
+       <description>VRST_VDDB_N_A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--USBHS USB 2.0 High-speed Controller.-->
+  <peripheral>
+   <name>WDT0</name>
+   <description>Watchdog Timer 0</description>
+   <baseAddress>0x40003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WDT0</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x7FFFF000</resetMask>
+     <fields>
+      <field>
+       <name>INT_PERIOD</name>
+       <description>Watchdog Interrupt Period. The watchdog timer will assert an interrupt, if enabled, if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_PERIOD</name>
+       <description>Watchdog Reset Period. The watchdog timer will assert a reset, if enabled, if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_EN</name>
+       <description>Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_FLAG</name>
+       <description>Watchdog Timer Interrupt Flag.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EN</name>
+       <description>Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EN</name>
+       <description>Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_FLAG</name>
+       <description>Watchdog Timer Reset Flag.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>WDT_RST</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WDT0 Watchdog Timer 0-->
+  <peripheral derivedFrom="WDT0">
+   <name>WDT1</name>
+   <description>Watchdog Timer 0 1</description>
+   <baseAddress>0x40003400</baseAddress>
+   <interrupt>
+    <name>WDT1</name>
+    <description>WDT1 IRQ</description>
+    <value>57</value>
+   </interrupt>
+  </peripheral>
+<!--WDT1 Watchdog Timer 0 1-->
+  <peripheral derivedFrom="WDT0">
+   <name>WDT2</name>
+   <description>Watchdog Timer 0 2</description>
+   <baseAddress>0x40003800</baseAddress>
+   <interrupt>
+    <name>WDT2</name>
+    <description>WDT2 IRQ</description>
+    <value>81</value>
+   </interrupt>
+  </peripheral>
+<!--WDT2 Watchdog Timer 0 2-->
+  <peripheral>
+   <name>WUT</name>
+   <description>Wake Up Timer</description>
+   <baseAddress>0x40006400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WUT</name>
+    <value>53</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Wakeup Timer Count Register</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Timer Count Value. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Wakeup Timer Compare Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>Timer Compare Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Wakeup Timer Interrupt Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ_CLR</name>
+       <description>Timer Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Wakeup Timer Control Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TMODE</name>
+       <description>Timer Mode Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>oneShot</name>
+         <description>One Shot Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Continuous Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>counter</name>
+         <description>Counter Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pwm</name>
+         <description>PWM Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>capture</name>
+         <description>Capture Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>compare</name>
+         <description>Compare Mode.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>gated</name>
+         <description>Gated Mode.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>captureCompare</name>
+         <description>Capture/Compare Mode.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES</name>
+       <description>Timer Prescaler Select.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV8</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV16</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV32</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV64</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV128</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV256</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV512</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV1024</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV2048</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4096</name>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TPOL</name>
+       <description>Timer Polarity.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TEN</name>
+       <description>Timer Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>timer_dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>timer_en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES3</name>
+       <description>Timer Prescaler Select.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pres3_1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_2</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_4</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_8</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_16</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_32</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_64</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_128</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_256</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_512</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_1024</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_2048</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_4096</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Non Overlaping Compare Register</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>NOLLCMP</name>
+       <description>Non Overlaping Low Compare.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>NOLHCMP</name>
+       <description>Non Overlaping High Compare.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET</name>
+     <description>Preset register.</description>
+     <addressOffset>0x0018</addressOffset>
+     <fields>
+      <field>
+       <name>PRESET</name>
+       <description>Preset Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RELOAD</name>
+     <description>Reload register.</description>
+     <addressOffset>0x001C</addressOffset>
+     <fields>
+      <field>
+       <name>RELOAD</name>
+       <description>Reload Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SNAPSHOT</name>
+     <description>Snapshot register.</description>
+     <addressOffset>0x0020</addressOffset>
+     <fields>
+      <field>
+       <name>SNAPSHOT</name>
+       <description>Snapshot Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WUT Wake Up Timer-->
+ </peripherals>
+</device>

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32670/Include/max32670.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32670/Include/max32670.svd
@@ -1,0 +1,9971 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max32670</name>
+ <series>ARMCM4</series>
+ <version>1.0</version>
+ <description>MAX32670 32-bit ARM Cortex-M4 microcontroller, 1024KB of flash, 760KB of system RAM, 128KB of Boot ROM.</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>AESKEYS</name>
+   <description>AES Key Registers.</description>
+   <baseAddress>0x40007800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>KEY0</name>
+     <description>AES Key 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY1</name>
+     <description>AES Key 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY2</name>
+     <description>AES Key 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY3</name>
+     <description>AES Key 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY4</name>
+     <description>AES Key 4.</description>
+     <addressOffset>0x10</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY5</name>
+     <description>AES Key 5.</description>
+     <addressOffset>0x14</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY6</name>
+     <description>AES Key 6.</description>
+     <addressOffset>0x18</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY7</name>
+     <description>AES Key 7.</description>
+     <addressOffset>0x1C</addressOffset>
+     <size>32</size>
+    </register>
+   </registers>
+  </peripheral>
+<!--AESKEYS AES Key Registers.-->
+  <peripheral>
+   <name>AES</name>
+   <description>AES Keys.</description>
+   <baseAddress>0x40007400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>AES Control Register</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>AES Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>DMA Request To Read Data Output FIFO</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>DMA Request To Write Data Input FIFO</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start AES Calculation</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FLUSH</name>
+       <description>Flush the data input FIFO</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FLUSH</name>
+       <description>Flush the data output FIFO</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_SIZE</name>
+       <description>Encryption Key Size</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AES128</name>
+         <description>128 Bits.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES192</name>
+         <description>192 Bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES256</name>
+         <description>256 Bits.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TYPE</name>
+       <description>Encryption Type Selection</description>
+       <bitRange>[9:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>AES Status Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>AES Busy Status</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_EM</name>
+       <description>Data input FIFO empty status</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FULL</name>
+       <description>Data input FIFO full status</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_EM</name>
+       <description>Data output FIFO empty status</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FULL</name>
+       <description>Data output FIFO full status</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>AES Interrupt Flag Register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>AES Interrupt Enable Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>AES Data Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>AES FIFO</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--AES AES Keys.-->
+  <peripheral>
+   <name>CRC</name>
+   <description>CRC Registers.</description>
+   <baseAddress>0x4000F000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>CRC Control</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>CRC Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_EN</name>
+       <description>DMA Request Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB</name>
+       <description>MSB Select</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BYTE_SWAP_IN</name>
+       <description>Byte Swap CRC Data Input</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BYTE_SWAP_OUT</name>
+       <description>Byte Swap CRC Value Output</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>CRC Busy</description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN32</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN16</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN8</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>POLY</name>
+     <description>CRC Polynomial</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>POLY</name>
+       <description>CRC Polynomial</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VAL</name>
+     <description>Current CRC Value</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>VALUE</name>
+       <description>Current CRC Value</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CRC CRC Registers.-->
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0</name>
+    <value>28</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1</name>
+    <value>29</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA2</name>
+    <value>30</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA3</name>
+    <value>31</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA4</name>
+    <value>68</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA5</name>
+    <value>69</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA6</name>
+    <value>70</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA7</name>
+    <value>71</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA8</name>
+    <value>72</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA9</name>
+    <value>73</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA10</name>
+    <value>74</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA11</name>
+    <value>75</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA12</name>
+    <value>76</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA13</name>
+    <value>77</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA14</name>
+    <value>78</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA15</name>
+    <value>79</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>INTEN</name>
+     <description>DMA Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel 0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <description>Channel 1 Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <description>Channel 2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <description>Channel 3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH4</name>
+       <description>Channel 4 Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH5</name>
+       <description>Channel 5 Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH6</name>
+       <description>Channel 6 Interrupt Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH7</name>
+       <description>Channel 7 Interrupt Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>DMA Interrupt Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel Interrupt. To clear an interrupt, all active interrupt bits of the DMA_ST must be cleared. The interrupt bits are set only if their corresponding interrupt enable bits are set in DMA_CN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>8</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CTRL</name>
+      <description>DMA Channel Control Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>EN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQUEST</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0RX</name>
+          <description>SPI0 RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1RX</name>
+          <description>SPI1 RX</description>
+          <value>0x02</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI2RX</name>
+          <description>SPI2 RX</description>
+          <value>0x03</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0RX</name>
+          <description>UART0 RX</description>
+          <value>0x04</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1RX</name>
+          <description>UART1 RX</description>
+          <value>0x05</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0RX</name>
+          <description>I2C0 RX</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1RX</name>
+          <description>I2C1 RX</description>
+          <value>0x08</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2RX</name>
+          <description>I2C2 RX</description>
+          <value>0x0A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2RX</name>
+          <description>UART2 RX</description>
+          <value>0x0E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI3RX</name>
+          <description>SPI3 RX</description>
+          <value>0x0F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESRX</name>
+          <description>AES RX</description>
+          <value>0x10</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3RX</name>
+          <description>UART3 RX</description>
+          <value>0x1C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2SRX</name>
+          <description>I2S RX</description>
+          <value>0x1E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0TX</name>
+          <description>SPI0 TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1TX</name>
+          <description>SPI1 TX</description>
+          <value>0x22</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI2TX</name>
+          <description>SPI2 TX</description>
+          <value>0x23</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0TX</name>
+          <description>UART0 TX</description>
+          <value>0x24</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1TX</name>
+          <description>UART1 TX</description>
+          <value>0x25</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0TX</name>
+          <description>I2C0 TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1TX</name>
+          <description>I2C1 TX</description>
+          <value>0x28</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2TX</name>
+          <description>I2C2 TX</description>
+          <value>0x2A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>CRCTX</name>
+          <description>CRC TX</description>
+          <value>0x2C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2TX</name>
+          <description>UART2 TX</description>
+          <value>0x2E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI3TX</name>
+          <description>SPI3 TX</description>
+          <value>0x2F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESTX</name>
+          <description>AES TX</description>
+          <value>0x30</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3TX</name>
+          <description>UART3 TX</description>
+          <value>0x3C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2STX</name>
+          <description>I2S TX</description>
+          <value>0x3E</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_WAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_PER</name>
+        <description>Timeout Period Select.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_CLKDIV</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BURST_SIZE</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>DIS_IE</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IE</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>STATUS</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>STATUS</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IF</name>
+        <description>Count-to-Zero (CTZ) Interrupt Flag</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>RLD_IF</name>
+        <description>Reload Event Interrupt Flag.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>TO_IF</name>
+        <description>Time-Out Event Interrupt Flag.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRCRLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DSTRLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNTRLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>EN</name>
+        <description>Reload Enable. This bit should be set after the address reload registers have been programmed. This bit is automatically cleared to 0 when reload occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+<!--DMA DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral>
+   <name>FCR</name>
+   <description>Function Control Register.</description>
+   <baseAddress>0x40000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>FCTRL0</name>
+     <description>Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ERFO_RANGE_SEL</name>
+       <description>14MHz-32MHz ERFO Frequency Range Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>I2C0_SDA_FILTER_EN</name>
+       <description>I2C0 SDA Glitch Filter Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0_SCL_FILTER_EN</name>
+       <description>I2C0 SCL Glitch Filter Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1_SDA_FILTER_EN</name>
+       <description>I2C1 SDA Glitch Filter Enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1_SCL_FILTER_EN</name>
+       <description>I2C1 SCL Glitch Filter Enable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2_SDA_FILTER_EN</name>
+       <description>I2C2 SDA Glitch Filter Enable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2_SCL_FILTER_EN</name>
+       <description>I2C2 SCL Glitch Filter Enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL0</name>
+     <description>Register 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SEL</name>
+       <description>Auto-calibration Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Autocalibration Run.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOAD</name>
+       <description>Load Trim.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INVERT</name>
+       <description>Invert Gain.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ATOMIC</name>
+       <description>Atomic mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GAIN</name>
+       <description>MU value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>TRIM</name>
+       <description>150MHz HFIO Auto Calibration Trim</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL1</name>
+     <description>Register 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INITIAL</name>
+       <description>100MHz IPO Trim Automatic Calibration Initial Trim.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL2</name>
+     <description>Register 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RUNTIME</name>
+       <description>100MHz IPO Trim Automatic Calibration Run Time.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>DIV</name>
+       <description>100MHz IPO Trim Automatic Calibration Divide Factor.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FCR Function Control Register.-->
+  <peripheral>
+   <name>FLC</name>
+   <description>Flash Memory Control.</description>
+   <prependToName>FLSH_</prependToName>
+   <baseAddress>0x40029000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Flash_Controller</name>
+    <description>Flash Controller interrupt.</description>
+    <value>23</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ADDR</name>
+     <description>Flash Write Address.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address for next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Flash Clock Divide. The clock (PLL0) is divided by this value to generate a 1 MHz clock for Flash controller.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000064</resetValue>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Flash Clock Divide. The clock is divided by this value to generate a 1MHz clock for flash controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Flash Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WR</name>
+       <description>Write.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="WR">
+       <name>ME</name>
+       <description>Mass Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="WR">
+       <name>PGE</name>
+       <description>Page Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERASE_CODE</name>
+       <description>Erase Code.  The ERASE_CODE must be set up property before erase operation can be initiated. These bits are automatically cleared after the operation is complete.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>erasePage</name>
+         <description>Enable Page Erase.</description>
+         <value>0x55</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>eraseAll</name>
+         <description>Enable Mass Erase. The debug port must be enabled.</description>
+         <value>0xAA</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PEND</name>
+       <description>Flash Pending.  When Flash operation is in progress (busy), Flash reads and writes will fail. When PEND is set, write to all Flash registers, with exception of the Flash interrupt register, are ignored.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LVE</name>
+       <description>Low Voltage enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNLOCK</name>
+       <description>Flash Unlock.  The correct unlock code must be written to these four bits before any Flash write or erase operation is allowed.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Flash Unlocked.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Flash Locked.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Flash Interrupt Register.</description>
+     <addressOffset>0x024</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Flash Done Interrupt.  This bit is set to 1 upon Flash write or erase completion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AF</name>
+       <description>Flash Access Fail.  This bit is set when an attempt is made to write the flash while the flash is busy or the flash is locked. This bit can only be set to 1 by hardware.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONEIE</name>
+       <description>Flash Done Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DONEIE">
+       <name>AFIE</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCDATA</name>
+     <description>ECC Data Register.</description>
+     <addressOffset>0x028</addressOffset>
+     <fields>
+      <field>
+       <name>EVEN</name>
+       <description>Error Correction Code Odd Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>ODD</name>
+       <description>Error Correction Code Even Data.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA[%s]</name>
+     <description>Flash Write Data.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACTRL</name>
+     <description>Access Control Register. Writing the ACTRL register with the following values in the order shown, allows read and write access to the system and user Information block:
+    pflc-actrl = 0x3a7f5ca3;
+    pflc-actrl = 0xa1e34f20;
+    pflc-actrl = 0x9608b2c1. When unlocked, a write of any word will disable access to system and user information block. Readback of this register is always zero.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ACTRL</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR0</name>
+     <description>WELR0</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>WELR0</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR1</name>
+     <description>WELR1</description>
+     <addressOffset>0x88</addressOffset>
+     <fields>
+      <field>
+       <name>WELR1</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR0</name>
+     <description>RLR0</description>
+     <addressOffset>0x90</addressOffset>
+     <fields>
+      <field>
+       <name>RLR0</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR1</name>
+     <description>RLR1</description>
+     <addressOffset>0x98</addressOffset>
+     <fields>
+      <field>
+       <name>RLR1</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FLC Flash Memory Control.-->
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x40000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SYSCTRL</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>SBUSARB</name>
+       <description>System bus abritration scheme. These bits are used to select between Fixed-burst abritration and Round-Robin scheme. The Round-Robin scheme is selected by default. These bits are reset by the system reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>fix</name>
+         <description>Fixed Burst abritration.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>round</name>
+         <description>Round-robin scheme.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FPU_DIS</name>
+       <description>Cortex M4 Floating Point Disable This bit is used to disable the floating-point unit of the Cortex-M4</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0_FLUSH</name>
+       <description>Code Cache Flush. This bit is used to flush the code caches and the instruction buffer of the Cortex-M4. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROMDONE</name>
+       <description>ROM_DONE status. Used to disable SWD interface during system initialization procedure</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CCHK</name>
+       <description>Compute ROM Checksum. This bit is self-cleared when calculation is completed. Once set, software clearing this bit is ignored and the bit will remain set until the operation is completed.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SWD_DIS</name>
+       <description> Serial Wire Debug Disable. This bit is used to disable the serial wire debug interface This bit is only writeable if (FMV lock word is not programmed) or if (ICE lock word is not programmed and the ROM_DONE bit is not set)
+				</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHKRES</name>
+       <description>ROM Checksum Result. This bit is only valid when CHKRD=1.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pass</name>
+         <description>ROM Checksum Correct.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fail</name>
+         <description>ROM Checksum Fail.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA">
+       <name>WDT0</name>
+       <description>Watchdog Timer Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO1</name>
+       <description>GPIO1 Reset. Setting this bit to 1 resets GPIO1 pins to their default states.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR0</name>
+       <description>Timer0 Reset. Setting this bit to 1 resets Timer 0 blocks.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR1</name>
+       <description>Timer1 Reset. Setting this bit to 1 resets Timer 1 blocks.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR2</name>
+       <description>Timer2 Reset. Setting this bit to 1 resets Timer 2 blocks.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR3</name>
+       <description>Timer3 Reset. Setting this bit to 1 resets Timer 3 blocks.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART0</name>
+       <description>UART0 Reset. Setting this bit to 1 resets all UART 0 blocks.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART1</name>
+       <description>UART1 Reset. Setting this bit to 1 resets all UART 1 blocks.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI0</name>
+       <description>SPI0 Reset. Setting this bit to 1 resets all SPI 0 blocks.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI1</name>
+       <description>SPI1 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI2</name>
+       <description>SPI2 Reset. Setting this bit to 1 resets all SPI 2 blocks.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>I2C0</name>
+       <description>I2C0 Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>RTC</name>
+       <description>Real Time Clock Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TRNG</name>
+       <description>TRNG Reset.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART2</name>
+       <description>UART2 Reset. Setting this bit to 1 resets all UART 2 blocks.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SOFT</name>
+       <description>Soft Reset. Setting this bit to 1 resets everything except the CPU and the watchdog timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>PERIPH</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SYS</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>SYSCLK_DIV</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the PLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_SEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ERFO</name>
+         <description>32MHz Crystal is used for the system clock.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INRO</name>
+         <description>80kHz LIRC is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>The internal 96 MHz oscillator is used for the system clock.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBRO</name>
+         <description>The internal 8 MHz oscillator is used for the system clock.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERTCO</name>
+         <description> 32kHz is used for the system clock.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EXTCLK</name>
+         <description> External clock on gpio0 11.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_RDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IPO_DIV</name>
+       <description>Divides the HIRC96M clock before the system clock prescaler, will affect HIRC96M Autocalibration.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>divide clock by 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>divide clock by 2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>divide clock by 4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>divide clock by 8</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_EN</name>
+       <description>32MHz Crystal Oscillator Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>32kHz Crystal Oscillator Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>IPO_EN</name>
+       <description>96MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>IBRO_EN</name>
+       <description>8MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_VS</name>
+       <description>8MHz High Frequency Internal Reference Clock Voltage Select. This register bit is used to select the power supply to the HIRC8M.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Vcor</name>
+         <description>VCore Supply</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1V</name>
+         <description>Dedicated 1v regulated supply.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_RDY</name>
+       <description>32MHz Crystal Oscillator Ready</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERTCO_RDY</name>
+       <description>32kHz Crystal Oscillator Ready</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>IPO_RDY</name>
+       <description>96MHz HIRC Ready.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>IBRO_RDY</name>
+       <description>8MHz HIRC Ready.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>INRO_RDY</name>
+       <description>8kHz Low Frequency Reference Clock Ready.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>EXTCLK_RDY</name>
+       <description>External Clock (GPIO0[11] AF2) </description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PM</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This two bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>backup</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO_WE</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wake Up Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wake Up Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>RTC_WE</name>
+       <description>RTC Alarm Wake Up Enable. This bit enables RTC alarm as wakeup source. If enabled, the desired RTC alarm must be configured via the RTC control registers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>LPTMR0_WE</name>
+       <description>TIMER4 Wake Up Enable. This bit enables TIMER4 as wakeup source. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>LPTMR1_WE</name>
+       <description>TIMER5 Wake Up Enable. This bit enables TIMER5 as wakeup source. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>LPUART0_WE</name>
+       <description>LPUART3 Wake Up Enable. This bit enables LPUART3 as wakeup source. </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_PD</name>
+       <description>32MHz power down. This bit selects 32MHz Crystal power state in DEEPSLEEP mode.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERFO_PD">
+       <name>IPO_PD</name>
+       <description>96MHz power down. This bit selects 96MHz HIRC power state in DEEPSLEEP mode. </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_PD">
+       <name>IBRO_PD</name>
+       <description>8MHz power down. This bit selects 8MHz HIRC power state in DEEPSLEEP mode. </description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_BP</name>
+       <description>32MHz Oscillator Bypass</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIV</name>
+     <description>Peripheral Clock Divider.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>AON_CLKDIV</name>
+       <description>Always-ON (AON) domain Clock Divider. These bits define the AON domain clock divider</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div4</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DIV_CLK_OUT_CTRL</name>
+       <description>DIV_CLK_OUT Control</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>DIV_CLK_OUT_EN</name>
+       <description>DIV_CLK_OUT Enable</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0</name>
+       <description>GPIO0 Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>GPIO1</name>
+       <description>GPIO1 Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>DMA</name>
+       <description>DMA Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI0</name>
+       <description>SPI 0 Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI1</name>
+       <description>SPI 1 Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI2</name>
+       <description>SPI 2 Disable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART0</name>
+       <description>UART 0 Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART1</name>
+       <description>UART 1 Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C0</name>
+       <description>I2C 0 Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR0</name>
+       <description>Timer 0 Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR1</name>
+       <description>Timer 1 Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR2</name>
+       <description>Timer 2 Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR3</name>
+       <description>Timer 3 Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C1</name>
+       <description>I2C 1 Disable.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCTRL</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 2.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>RAMWS_EN</name>
+       <description>System RAM Wait State enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM0LS_EN</name>
+       <description>System RAM 0 Light Sleep Mode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM1LS_EN</name>
+       <description>System RAM 1 Light Sleep Mode.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM2LS_EN</name>
+       <description>System RAM 2 Light Sleep Mode.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM3LS_EN</name>
+       <description>System RAM 3 Light Sleep Mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>ICC0LS_EN</name>
+       <description>ICache RAM Light Sleep Mode.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>ROMLS_EN</name>
+       <description>ROM Light Sleep Mode.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMZ</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>System RAM Block.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM">
+       <name>RAMCB</name>
+       <description>System RAM check bit zeroization.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM">
+       <name>ICC0</name>
+       <description>Instruction Cache.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSST</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICELOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>I2C1</name>
+       <description>I2C1 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>WDT1</name>
+       <description>WDT1 Reset.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>CRC</name>
+       <description>CRC Reset.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AES</name>
+       <description>AES Reset.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AC</name>
+       <description>AC Reset.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2C2</name>
+       <description>I2C2 Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2S</name>
+       <description>I2S Reset.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>UART2</name>
+       <description>UART2 Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="UART2">
+       <name>TRNG</name>
+       <description>TRNG Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>WWDT0</name>
+       <description>WDT0  Disable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>WWDT1</name>
+       <description>WDT1  Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>ICC0</name>
+       <description>ICACHE Disable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>CRC</name>
+       <description>CRC Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>AES</name>
+       <description>AES Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>I2C2</name>
+       <description>I2C2 Disable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>I2S</name>
+       <description>I2S Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVENTEN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Enable RXEV pin event. When this bit is set, a logic high of GPIO0[20] will cause an RXEV event to wake the CPU from WFE sleep mode. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO[21].</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REVISION</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSIE</name>
+     <description>System Status Interrupt Enable Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEUNLOCK</name>
+       <description>ARM ICE Unlock Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCERR</name>
+     <description>ECC Error Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0</name>
+       <description>ECC Icache Error Flag. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH</name>
+       <description>ECC Flash Error Flag. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCCED</name>
+     <description>ECC Not Double Error Detect Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0</name>
+       <description>ECC Icache Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH</name>
+       <description>ECC Flash0 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCIE</name>
+     <description>ECC IRQ Enable Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Interrup Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0</name>
+       <description>ECC Icache0 Error Interrup Enable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH</name>
+       <description>ECC Flash0 NError Interrup Enable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCADDR</name>
+     <description>ECC Error Address Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>DATARAMADDR</name>
+       <description>ECC Error Address/TAG RAM Error Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>DATARAMBANK</name>
+       <description>ECC Error Address/DATA RAM Error Bank.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATARAMERR</name>
+       <description>ECC Error Address/DATA RAM Error Address.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMADDR</name>
+       <description>ECC Error Address/TAG RAM Error Address.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMBANK</name>
+       <description>ECC Error Address/TAG RAM Error Bank.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMERR</name>
+       <description>ECC Error Address/TAG RAM Error.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCR Global Control Registers.-->
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x40008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN0</name>
+     <description>GPIO Function Enable Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_SET</name>
+     <description>GPIO Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_OUT bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_IN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTMODE</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTMODE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTPOL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTPOL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INEN</name>
+     <description>GPIO Input Enable</description>
+     <addressOffset>0x30</addressOffset>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_INTFL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WKEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DUALEDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DUALEDGE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL0</name>
+     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL0</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL1</name>
+     <description>GPIO Input Mode Config 2. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL1</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_SET</name>
+     <description>GPIO Alternate Function Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN2</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_SET</name>
+     <description>GPIO Alternate Function 2 Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN2 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_CLR</name>
+     <description>GPIO Wake Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN2 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x7C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HYSEN</name>
+     <description>GPIO Input Hysteresis Enable.</description>
+     <addressOffset>0xA8</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_HYSEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SRSEL</name>
+     <description>GPIO Slew Rate Enable Register.</description>
+     <addressOffset>0xAC</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_SRSEL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>FAST</name>
+         <description>Fast Slew Rate selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SLOW</name>
+         <description>Slow Slew Rate selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS0</name>
+     <description>GPIO Drive Strength  Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS0</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ld</name>
+         <description>GPIO port pin is in low-drive mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hd</name>
+         <description>GPIO port pin is in high-drive mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PS</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GPIO0 Individual I/O for each GPIO-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO1</name>
+   <description>Individual I/O for each GPIO 1</description>
+   <baseAddress>0x40009000</baseAddress>
+   <interrupt>
+    <name>GPIO1</name>
+    <description>GPIO1 IRQ</description>
+    <value>25</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO1 Individual I/O for each GPIO 1-->
+  <peripheral>
+   <name>I2C0</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>I2C</groupName>
+   <baseAddress>0x4001D000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2C0</name>
+    <description>I2C0 IRQ</description>
+    <value>13</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>I2C Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable I2C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable I2C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave_mode</name>
+         <description>Slave Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master_mode</name>
+         <description>Master Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_EN</name>
+       <description>General Call Address Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Ignore Gneral Call Address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Acknowledge general call address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_EN</name>
+       <description>Interactive Receive Mode.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interactive Receive Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interactive Receive Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_ACK</name>
+       <description>Data Acknowledge. This bit defines the acknowledge bit returned by the I2C receiver while IRXM = 1 HW forces ACK to 0 when IRXM = 0.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ack</name>
+         <description>return ACK (pulling SDA LOW).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>return NACK (leaving SDA HIGH).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_OUT</name>
+       <description>SCL Output. This bits control SCL output when SWOE =1.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_scl_low</name>
+         <description>Drive SCL low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_scl</name>
+         <description>Release SCL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDA_OUT</name>
+       <description>SDA Output. This bits control SDA output when SWOE = 1. </description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_sda_low</name>
+         <description>Drive SDA low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_sda</name>
+         <description>Release SDA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL</name>
+       <description>SCL status. This bit reflects the logic gate of SCL signal. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDA</name>
+       <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BB_MODE</name>
+       <description>Software Output Enable.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>outputs_disable</name>
+         <description>I2C Outputs SCLO and SDAO disabled. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputs_enable</name>
+         <description>I2C Outputs SCLO and SDAO enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read. This bit reflects the R/W bit of an address match (AMI = 1) or general call match (GCI = 1). This bit is valid 3 cycles after the relevant interrupt bit is set.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKSTR_DIS</name>
+       <description>This bit will disable slave clock stretching when set.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Slave clock stretching enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Slave clock stretching disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ONE_MST_MODE</name>
+       <description>SCL Push-Pull Mode. This bit controls whether SCL is operated in a the I2C standard open-drain mode, or in a non-standard push-pull mode where the Hi-Z output isreplaced with Drive-1. The non-standard mode should only be used when operating as a master and communicating with slaves that are guaranteed to never drive SCL low. </description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Standard open-drain operation:
+					drive low for 0, Hi-Z for 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Non-standard push-pull operation:
+					drive low for 0, drive high for 1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HS_EN</name>
+       <description>High speed mode enable</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>IRXM
+    </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>Bus Status.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>I2C Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>I2C Bus Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>RX empty.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX Full.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX Empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>TX Full.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_BUSY</name>
+       <description>Clock Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_actively_driving_scl_clock</name>
+         <description>Device not actively driving SCL clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>actively_driving_scl_clock</name>
+         <description>Device operating as master and actively driving SCL clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL0</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <name>INT_FL0_Done</name>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Interactive Receive Interrupt.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave General Call Address Match Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave Address Match Interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Receive Threshold Interrupt. This bit is automaticcaly cleared when RX_FIFO is below the threshold level.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. RX_FIFO equal or more bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>Transmit Threshold Interrupt. This bit is automaticcaly cleared when TX_FIFO is above the threshold level.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP Interrupt.</description>
+       <bitRange>[6:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Address Acknowledge Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Arbritation error Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>timeout Error Interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Address NACK Error Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Data NACK Error Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Do Not Respond Error Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Start Error Interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Stop Error Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>Transmit Lock Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN0</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when DONE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Description not available.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when RX_MODE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave mode general call address match received input enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when GEN_CTRL_ADDR = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave mode incoming address match interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when ADDR_MATCH = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Above Treshold Level Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Below Treshold Level Interrupt Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Stop Interrupt Enable</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when STOP = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Received Address ACK from Slave Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Master Mode Arbitration Lost Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>Timeout Error Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Master Mode Address NACK Received Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Master Mode Data NACK Received Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Slave Mode Do Not Respond Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Out of Sequence START condition detected interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Out of Sequence STOP condition detected interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>TX FIFO Locked Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL1</name>
+     <description>Interrupt Status Register 1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt. When operating as a slave receiver, this bit is set when you reach the first data bit and the RX FIFO and shift register are both full.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt. When operating as a slave transmitter, this bit is set when you reach the first data bit and the TX FIFO is empty and the master is still asking for more data (i.e the master hasn't sent a NACK yet).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Status Flag.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN1</name>
+     <description>Interrupt Staus Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOLEN</name>
+     <description>FIFO Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RX_DEPTH</name>
+       <description>Receive FIFO Length.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DEPTH</name>
+       <description>Transmit FIFO Length.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL0</name>
+     <description>Receive Control Register 0.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>DNR</name>
+       <description>Do Not Respond.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Always respond to address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>not_respond_rx_fifo_empty</name>
+         <description>Do not respond to address match when RX_FIFO is not empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Receive FIFO Flush. This bit is automatically cleared to 0 after the operation. Setting this bit to 1 will affect RX_FIFO status.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush RX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_LVL</name>
+       <description>Receive FIFO Threshold. These bits define the RX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL1</name>
+     <description>Receive Control Register 1.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Receive Count Bits. These bits define the number of bytes to be received in a transaction, except for the case RXCNT = 0. RXCNT = 0 means 256 bytes to be received in a transaction.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Receive FIFO Count. These bits reflect the number of byte in the RX_FIFO. These bits are flushed when I2CEN = 0.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL0</name>
+     <description>Transmit Control Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_MODE</name>
+       <description>Transmit FIFO Preaload Mode. Setting this bit will allow for high speed application to preload the transmit FIFO prior to Slave Address Match.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TX_READY_MODE</name>
+       <description>Transmit FIFO Ready Manual Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW control of I2CTXRDY enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW control of I2CTXRDY disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO General Call Address Match Auto Flush Disable.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Write Auto Flush Disable.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Read Auto Flush Disable.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NACK_FLUSH_DIS</name>
+       <description>TX FIFO received NACK Auto Flush Disable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Transmit FIFO Flush. This bit is automatically cleared to 0 after the operation.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush TX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_VAL</name>
+       <description>Transmit FIFO Threshold. These bits define the TX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL1</name>
+     <description>Transmit Control Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_RDY</name>
+       <description>Transmit FIFO Preload Ready.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Transmit FIFO Count. These bits reflect the number of bytes in the TX_FIFO.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MSTCTRL</name>
+     <description>Master Control Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Setting this bit to 1 will start a master transfer.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>RESTART</name>
+       <description>Setting this bit to 1 will generate a repeated START.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Setting this bit to 1 will generate a STOP condition.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>EX_ADDR_EN</name>
+       <description>Slave Extend Address Select.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKLO</name>
+     <description>Clock Low Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock low. In master mode, these bits define the SCL low period. In slave mode, these bits define the time SCL will be held low after data is outputted.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKHI</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>HI</name>
+       <description>Clock High. In master mode, these bits define the SCL high period.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HSCLK</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock Low. This field sets the Hs-Mode clock low count. In Slave mode, this is the time SCL is held low after data is output on SDA.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Clock High. This field sets the Hs-Mode clock high count. In Slave mode, this is the time SCL is held high after data is output on SDA</description>
+       <bitRange>[15:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TIMEOUT</name>
+     <description>Timeout Register</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_TO_VAL</name>
+       <description>Timeout</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLAVE</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Slave Address.</description>
+       <bitRange>[9:0]</bitRange>
+      </field>
+      <field>
+       <name>DIS</name>
+       <description>Slave Address Disable.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>IDX</name>
+       <description>Slave Address Index.</description>
+       <bitRange>[14:11]</bitRange>
+      </field>
+      <field>
+       <name>EXT_ADDR_EN</name>
+       <description>Extended Address Select.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2C0 Inter-Integrated Circuit.-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C1</name>
+   <description>Inter-Integrated Circuit. 1</description>
+   <baseAddress>0x4001E000</baseAddress>
+   <interrupt>
+    <name>I2C1</name>
+    <description>I2C1 IRQ</description>
+    <value>36</value>
+   </interrupt>
+  </peripheral>
+<!--I2C1 Inter-Integrated Circuit. 1-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C2</name>
+   <description>Inter-Integrated Circuit. 2</description>
+   <baseAddress>0x4001F000</baseAddress>
+   <interrupt>
+    <name>I2C2</name>
+    <description>I2C2 IRQ</description>
+    <value>62</value>
+   </interrupt>
+  </peripheral>
+<!--I2C2 Inter-Integrated Circuit. 2-->
+  <peripheral>
+   <name>I2S</name>
+   <description>Inter-IC Sound Interface.</description>
+   <groupName>I2S</groupName>
+   <baseAddress>0x40060000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2S</name>
+    <description>I2S IRQ</description>
+    <value>99</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0CH0</name>
+     <description>Global mode channel.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>LSB_FIRST</name>
+       <description>LSB Transmit Receive First.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_MODE</name>
+       <description>SCK Select.</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>WS_POL</name>
+       <description>WS polarity select. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB_LOC</name>
+       <description>MSB location. </description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ALIGN</name>
+       <description>Align to MSB or LSB.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EXT_SEL</name>
+       <description>External SCK/WS selection.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>STEREO</name>
+       <description>Stereo mode of I2S.</description>
+       <bitRange>[13:12]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WSIZE</name>
+       <description>Data size when write to FIFO.</description>
+       <bitRange>[15:14]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable. </description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable. </description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Flushes the TX/RX FIFO buffer. </description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RST</name>
+       <description>Write 1 to reset channel. </description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_LSB</name>
+       <description>Bit Field Control. </description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>depth of receive FIFO for threshold interrupt generation. </description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1CH0</name>
+     <description>Local channel Setup.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>BITS_WORD</name>
+       <description>I2S word length.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>I2S clock enable.</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SMP_SIZE</name>
+       <description>I2S sample size length.</description>
+       <bitRange>[13:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ADJST</name>
+       <description>LSB/MSB Justify.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>I2S clock frequency divisor.</description>
+       <bitRange>[31:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMACH0</name>
+     <description>DMA Control.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DMA_TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger.</description>
+       <bitRange>[6:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA channel enable.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_THD_VAL</name>
+       <description>RX FIFO Level DMA Trigger.</description>
+       <bitRange>[14:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA channel enable.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Number of data word in the TX FIFO.</description>
+       <bitRange>[23:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Number of data word in the RX FIFO.</description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOCH0</name>
+     <description>I2S Fifo.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>ISR Status.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Status for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Status for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Status for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Status for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Enable for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Enable for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Enable for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Enable for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EXTSETUP</name>
+     <description>Ext Control.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>EXT_BITS_WORD</name>
+       <description>Word Length for ch_mode.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2S Inter-IC Sound Interface.-->
+  <peripheral>
+   <name>ICC0</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x4002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x800</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>INFO</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SZ</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCH</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEM</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ICC0 Instruction Cache Controller Registers-->
+  <peripheral>
+   <name>MCR</name>
+   <description>Miscellaneous Control Registers.</description>
+   <baseAddress>0x40106C00</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RST</name>
+     <description>Reset control register 0.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0</resetMask>
+     <fields>
+      <field>
+       <name>lptmr0</name>
+       <description>Setting this bit will reset LPTMR0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>rst</name>
+         <description>Reset LPTMR0.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>lptmr1</name>
+       <description>Setting this bit will reset LPTMR1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>rst</name>
+         <description>Reset LPTMR1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>lpuart0</name>
+       <description>Setting this bit will reset LPUART0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>rst</name>
+         <description>Reset LPUART0.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>rtc</name>
+       <description>Setting this bit will reset the Real-Time Clock.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>rst</name>
+         <description>Reset Real-Time Clock.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPIOCTRL</name>
+     <description>Low-power peripheral IO control.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetMask>0</resetMask>
+     <fields>
+      <field>
+       <name>LPTMR0_I</name>
+       <description>Setting this bit will enable the low-power timer 0 (timer 4) input pin while operating in low-power modes.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPTMR0 input pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPTMR0 input pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPTMR0_O</name>
+       <description>Setting this bit will enable the low-power timer 0 (timer 4) output pin while operating in low-power modes.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPTMR0 output pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPTMR0 output pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPTMR1_I</name>
+       <description>Setting this bit will enable the low-power timer 1 (timer 5) input pin while operating in low-power modes.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPTMR1 input pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPTMR1 input pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPTMR1_O</name>
+       <description>Setting this bit will enable the low-power timer 1 (timer 5) output pin while operating in low-power modes.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPTMR1 output pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPTMR1 output pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPUART0_RX</name>
+       <description>Setting this bit will enable the low-power UART 0 (UART3) RX pin while operating in low-power modes.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPUART0 RX pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPUART0 RX pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPUART0_TX</name>
+       <description>Setting this bit will enable the low-power UART 0 (UART3) TX pin while operating in low-power modes.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPUART0 TX pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPUART0 TX pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPUART0_CTS</name>
+       <description>Setting this bit will enable the low-power UART 0 (UART3) CTS pin while operating in low-power modes.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPUART0 CTS pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPUART0 CTS pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPUART0_RTS</name>
+       <description>Setting this bit will enable the low-power UART 0 (UART3) RTS pin while operating in low-power modes.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPUART0 RTS pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPUART0 RTS pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIS</name>
+     <description>Peripheral clock control register.</description>
+     <addressOffset>0x24</addressOffset>
+     <resetMask>0xFFFFFFFF</resetMask>
+     <fields>
+      <field>
+       <name>lptmr0</name>
+       <description>Clearing this bit will enable the low-power timer 0 (timer 4) peripheral clock.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPTMR0 clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPTMR0 clock.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>lptmr1</name>
+       <description>Clearing this bit will enable the low-power timer 1 (timer 5) peripheral clock.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPTMR1 clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPTMR1 clock.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>lpuart0</name>
+       <description>Clearing this bit will enable the low-power UART 0 (UART3) peripheral clock.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPUART0 clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPUART0 clock.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--MCR Miscellaneous Control Registers.-->
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x40106800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>LPCN</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0RET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 0 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM1RET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 1 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM2RET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 2 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM3RET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OVR</name>
+       <description>Operating Voltage Range</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_9V</name>
+         <description>0.9V 24MHz</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0V</name>
+         <description>1.0V 48MHz</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1V</name>
+         <description>1.1V 96MHz</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORE_DET_BYPASS</name>
+       <description>Block Auto-Detect</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>enabled</name>
+         <description>enable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Disable</name>
+         <description>disable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RETREG_EN</name>
+       <description>Retention Regulator Enable. This bit controls the retention regulator in BACKUP mode. </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STORAGE_EN</name>
+       <description>STORAGE Mode ENable. This bit allows low-power background mode operations, while the CPU is in DeepSleep.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FASTWK_EN</name>
+       <description>Fast Wake-Up Mode. This bit enables fast wake-up from DeepSleep mode. (5uS typical). </description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BG_DIS</name>
+       <description>Bandgap OFF. This controls the System Bandgap in DeepSleep mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>Bandgap is always ON.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>Bandgap is OFF in DeepSleep mode (default).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREPOR_DIS</name>
+       <description>VDDC (Vcore) Power on reset Monitor Disable.This bit controls the Power-On Reset monitor on VDDC supply in
+        DeepSleep and BACKUP mode.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDO_DIS</name>
+       <description>Disable Main LDO</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORE_EXT</name>
+       <description>Use external VCORE for 1V supply</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>use Vcore for retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREMON_DIS</name>
+       <description>VDDC (Vcore) Monitor Disable. This bit controls the power monitor on the VCore supply in all operating modes.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDAMON_DIS</name>
+       <description>VDDA Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PORVDDMON_DIS</name>
+       <description>VDDIO Power-On Reset Monitor Disable. This bit controls the Power-On Reset monitor on VDDIO supply in all operating mods.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INRO_EN</name>
+       <description>INRO remains on in all power modes if this bit is set otherwise it is controled by the LP controller</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>XRTCO remains on in all power modes if this bit is set otherwise it is controled by the LP controller</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERTCO_PD</name>
+       <description>ERTCO Powerdown.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST0</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO0.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN0</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register derivedFrom="LPWKST0">
+     <name>LPWKST1</name>
+     <description>Low Power I/O Wakeup Status Register 1. This register indicates the low power wakeup status for GPIO1.</description>
+     <addressOffset>0x0C</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN1</name>
+     <description>Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup functionality for GPIO1.</description>
+     <addressOffset>0x10</addressOffset>
+    </register>
+    <register>
+     <name>LPPWKST</name>
+     <description>Low Power Peripheral Wakeup Status Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>LPTMR0</name>
+       <description>LPTM0 Wakeup Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPTMR1</name>
+       <description>LPTMR1 Wakeup Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPUART0</name>
+       <description>LPUART0 Wakeup Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWKEN</name>
+     <description>Low Power Peripheral Wakeup Enable Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>LPTMR0</name>
+       <description> TIMER4 Wakeup Enable. This bit allows wakeup from the TIMER4.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPTMR1</name>
+       <description> TIMER5 Wakeup Enable. This bit allows wakeup from the TIMER5.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPUART0</name>
+       <description> LPUART Wakeup Enable. This bit allows wakeup from the LPUART.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPMEMSD</name>
+     <description>Low Power Memory Shutdown Control.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM block 0 Shut Down.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>System RAM block 1 Shut Down.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>System RAM block 2 Shut Down.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>System RAM block 3 Shut Down.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GP0</name>
+     <description>General Purpose Register 0</description>
+     <addressOffset>0x48</addressOffset>
+    </register>
+    <register>
+     <name>GP1</name>
+     <description>General Purpose Register 1</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--PWRSEQ Power Sequencer / Low Power Control Register.-->
+  <peripheral>
+   <name>RTC</name>
+   <description>Real Time Clock and Alarm.</description>
+   <baseAddress>0x40106000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>RTC</name>
+    <description>RTC interrupt.</description>
+    <value>3</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC</name>
+       <description>Sub-Seconds Counter (12-bit).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TODA</name>
+     <description>Time-of-day Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-day Alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSECA</name>
+     <description>RTC sub-second alarm.  This register contains the reload value for the sub-second alarm.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>This register contains the reload value for the sub-second alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>RTC Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Real Time Clock Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM_IE</name>
+       <description>Alarm Time-of-Day Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM_IE</name>
+       <description>Alarm Sub-second Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>RTC Busy. This bit is set to 1 by hardware when changes to RTC registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>RTC Ready. This bit is set to 1 by hardware when the RTC count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the RTC count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY_IE</name>
+       <description>RTC Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-Day Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>Sub-second Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_SEL</name>
+       <description>Frequency Output Selection. When SQE=1, these bits specify the output frequency on the SQW pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq1Hz</name>
+         <description>1 Hz (Compensated).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq512Hz</name>
+         <description>512 Hz (Compensated).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq4KHz</name>
+         <description>4 KHz.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clkDiv8</name>
+         <description>RTC Input Clock / 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_EN</name>
+       <description>Asynchronous Counter Read Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_EN</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical RTC bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIM</name>
+     <description>RTC Trim Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>RTC Trim. This register contains the 2's complement value that specifies the trim resolution. Each increment or decrement of the bit adds or subtracts 1ppm at each 4KHz clock value, with a maximum correction of +/- 127ppm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VRTC_TMR</name>
+       <description>VBAT Timer Value. When RTC is running off of VBAT, this field is incremented every 32 seconds.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>RTC Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>FILTER_EN</name>
+       <description>Enables analog deglitch filter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_SEL</name>
+       <description>If IBIAS_EN is 1, selects 4x,2x mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HYST_EN</name>
+       <description>Enables high current hysteresis buffer.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_EN</name>
+       <description>Enables higher 4x,2x current modes.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYPASS</name>
+       <description>RTC Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SQW_32K</name>
+       <description>RTC 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--RTC Real Time Clock and Alarm.-->
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x40000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SIR_STATUS</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CFG_VALID</name>
+       <description>Configuration Valid Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CFG_ERR</name>
+       <description>Configuration Error Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SIR_ADDR</name>
+     <description>Read-only field set by the SIB block if a CRC error occurs during the read of the OTP memory. Contains the failing address in OTP memory (when CRCERR equals 1).</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIR System Initialization Registers.-->
+  <peripheral>
+   <name>SPI0</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x40046000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>16</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FIFO32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>FIFO16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>FIFO8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Start Select Control. Used in Master mode to control the behavior of the Slave Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DEASSERT</name>
+         <description>SPI De-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ASSERT</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_ACTIVE</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3</name>
+         <description>SS3 is selected.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Rising_Edge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Falling_Edge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin (s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_POL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3_high</name>
+         <description>SS3 active high.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSTIME</name>
+     <description>Register for controlling SPI peripheral/Slave Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PRE</name>
+       <description>Slave Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POST</name>
+       <description>Slave Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPI0 SPI peripheral.-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI1</name>
+   <description>SPI peripheral. 1</description>
+   <baseAddress>0x40047000</baseAddress>
+   <interrupt>
+    <name>SPI1</name>
+    <description>SPI1 IRQ</description>
+    <value>17</value>
+   </interrupt>
+  </peripheral>
+<!--SPI1 SPI peripheral. 1-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI2</name>
+   <description>SPI peripheral. 2</description>
+   <baseAddress>0x40048000</baseAddress>
+   <interrupt>
+    <name>SPI2</name>
+    <description>SPI2 IRQ</description>
+    <value>18</value>
+   </interrupt>
+  </peripheral>
+<!--SPI2 SPI peripheral. 2-->
+  <peripheral>
+   <name>TMR</name>
+   <description>Low-Power Configurable Timer</description>
+   <baseAddress>0x40010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR</name>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Timer Counter Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>The current count value for the timer. This field increments as the timer counts.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Timer Compare Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>Timer PWM Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PWM</name>
+       <description>Timer PWM Match:
+                In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
+                In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Timer Interrupt Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ_A</name>
+       <description>Interrupt Flag for Timer A.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_A</name>
+       <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_A</name>
+       <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IRQ_B</name>
+       <description>Interrupt Flag for Timer B.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_B</name>
+       <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_B</name>
+       <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MODE_A</name>
+       <description>Mode Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_A</name>
+       <description>Clock Divider Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_A</name>
+       <description>Timer Polarity for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_A</name>
+       <description>PWM Synchronization Mode for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_A</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_A</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_A</name>
+       <description>PWM Phase A-Prime Output Disable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_A</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Write 1 to Enable CLK_TMR for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_A</name>
+       <description>Enable for Timer A</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MODE_B</name>
+       <description>Mode Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_B</name>
+       <description>Clock Divider Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_B</name>
+       <description>Timer Polarity for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_B</name>
+       <description>PWM Synchronization Mode for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_B</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_B</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_B</name>
+       <description>PWM Phase A-Prime Output Disable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_B</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Write 1 to Enable CLK_TMR for Timer B</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_B</name>
+       <description>Enable for Timer B</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO_A</name>
+       <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_A</name>
+       <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>LO_B</name>
+       <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_B</name>
+       <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Timer Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKSEL_A</name>
+       <description>Timer Clock Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Timer A Enable Status</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_A</name>
+       <description>CLK_TMR Ready Flag for Timer A</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_A</name>
+       <description>Event Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_A</name>
+       <description>Negative Edge Trigger for Event for Timer A</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_A</name>
+       <description>Interrupt Enable for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_A</name>
+       <description>Capture Event Select for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_A</name>
+       <description>Software Capture Event for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_A</name>
+       <description>Wake-Up Enable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTEN_A</name>
+       <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTBEN_A</name>
+       <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads to the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKSEL_B</name>
+       <description>Timer Clock Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Timer B Enable Status</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_B</name>
+       <description>CLK_TMR Ready Flag for Timer B</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_B</name>
+       <description>Event Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_B</name>
+       <description>Negative Edge Trigger for Event for Timer B</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_B</name>
+       <description>Interrupt Enable for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_B</name>
+       <description>Capture Event Select for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_B</name>
+       <description>Software Capture Event for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_B</name>
+       <description>Wake-Up Enable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CASCADE</name>
+       <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Timer Wakeup Status Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>A</name>
+       <description>Wake-Up Flag for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>B</name>
+       <description>Wake-Up Flag for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TMR Low-Power Configurable Timer-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR1</name>
+   <description>Low-Power Configurable Timer 1</description>
+   <baseAddress>0x40011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+<!--TMR1 Low-Power Configurable Timer 1-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR2</name>
+   <description>Low-Power Configurable Timer 2</description>
+   <baseAddress>0x40012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+<!--TMR2 Low-Power Configurable Timer 2-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR3</name>
+   <description>Low-Power Configurable Timer 3</description>
+   <baseAddress>0x40013000</baseAddress>
+   <interrupt>
+    <name>TMR3</name>
+    <description>TMR3 IRQ</description>
+    <value>8</value>
+   </interrupt>
+  </peripheral>
+<!--TMR3 Low-Power Configurable Timer 3-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR4</name>
+   <description>Low-Power Configurable Timer 4</description>
+   <baseAddress>0x40114000</baseAddress>
+   <interrupt>
+    <name>TMR4</name>
+    <description>TMR4 IRQ</description>
+    <value>9</value>
+   </interrupt>
+  </peripheral>
+<!--TMR4 Low-Power Configurable Timer 4-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR5</name>
+   <description>Low-Power Configurable Timer 5</description>
+   <baseAddress>0x40115000</baseAddress>
+   <interrupt>
+    <name>TMR5</name>
+    <description>TMR5 IRQ</description>
+    <value>10</value>
+   </interrupt>
+  </peripheral>
+<!--TMR5 Low-Power Configurable Timer 5-->
+  <peripheral>
+   <name>ECC</name>
+   <description>Trim System Initilazation Registers. ECC Registers for MAX32670.</description>
+   <baseAddress>0x40105400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>EN</name>
+     <description>ECC Enable Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>SRAM</name>
+       <description>System RAM0 ECC Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC</name>
+       <description>ICC0 ECC Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH</name>
+       <description>Flash ECC Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ECC Trim System Initilazation Registers. ECC Registers for MAX32670.-->
+  <peripheral>
+   <name>TRNG</name>
+   <description>Random Number Generator.</description>
+   <baseAddress>0x4004D000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TRNG</name>
+    <description>TRNG interrupt.</description>
+    <value>4</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>TRNG Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000003</resetValue>
+     <fields>
+      <field>
+       <name>ODHT</name>
+       <description>Start On-Demand health test.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RND_IE</name>
+       <description>To enable IRQ generation when a new 32-bit Random number is ready.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HEALTH_EN</name>
+       <description>Enable IRQ generation when a health test fails.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYGEN</name>
+       <description>AES Key Generate. When enabled, the key for securing NVSRAM is generated and transferred to the secure key register automatically without user visibility or intervention. This bit is cleared by hardware once the key has been transferred to the secure key register.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>To wipe the Battery Backed key.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>RDY</name>
+       <description>32-bit random data is ready to read from TRNG_DATA register. Reading TRNG_DATA when RND_RDY=0 will return all 0's. IRQ is generated when RND_RDY=1 if TRNG_CN.RND_IRQ_EN=1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Busy</name>
+         <description>TRNG Busy</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Ready</name>
+         <description>32 bit random data is ready</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ODHT</name>
+       <description>On-Demand health test status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HT</name>
+       <description>Health test status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRCFAIL</name>
+       <description>Entropy source has failed.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AESKGD</name>
+       <description>AESKGD.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LD_CNT</name>
+       <description>LD_CNT.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data. The content of this register is valid only when RNG_IS =1. When TNRG is disabled, read returns 0x0000 0000.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRNG Random Number Generator.-->
+  <peripheral>
+   <name>UART</name>
+   <description>UART Low Power Registers</description>
+   <baseAddress>0x40042000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control register</description>
+     <addressOffset>0x0000</addressOffset>
+     <fields>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>This field specifies the depth of receive FIFO for interrupt generation (value 0 and &gt; 16 are ignored) </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EN</name>
+       <description>Parity Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EO</name>
+       <description>when PAREN=1 selects odd or even parity odd is 1 even is 0</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_MD</name>
+       <description>Selects parity based on 1s or 0s count (when PAREN=1) </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_DIS</name>
+       <description>CTS Sampling Disable </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Flushes the TX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Flushes the RX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHAR_SIZE</name>
+       <description>Selects UART character size</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5bits</name>
+         <description>5 bits</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6bits</name>
+         <description>6 bits</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7bits</name>
+         <description>7 bits</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8bits</name>
+         <description>8 bits</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPBITS</name>
+       <description>Selects the number of stop bits that will be generated</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HFC_EN</name>
+       <description>Enables/disables hardware flow control</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RTSDC</name>
+       <description>Hardware Flow Control RTS Mode</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKEN</name>
+       <description>Baud clock enable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKSRC</name>
+       <description>To select the UART clock source for the UART engine (except APB registers). Secondary clock (used for baud rate generator) can be asynchronous from APB clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Peripheral_Clock</name>
+         <description>apb clock</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>External_Clock</name>
+         <description>Clock 1</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK2</name>
+         <description>Clock 2</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK3</name>
+         <description>Clock 3</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPFE_EN</name>
+       <description>Data/Parity bit frame error detection enable</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKRDY</name>
+       <description>Baud clock Ready read only bit</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UCAGM</name>
+       <description>UART Clock Auto Gating mode</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FDM</name>
+       <description>Fractional Division Mode</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DESM</name>
+       <description>RX Dual Edge Sampling Mode</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TX_BUSY</name>
+       <description>Read-only flag indicating the UART transmit status</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_BUSY</name>
+       <description>Read-only flag indicating the UART receiver status</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Indicates the number of bytes currently in the RX FIFO (0-RX FIFO_ELTS) </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Indicates the number of bytes currently in the TX FIFO (0-TX FIFO_ELTS) </description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interrupt Enable control register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Enable Interrupt For RX Frame Error</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Enable Interrupt For RX Parity Error</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Enable Interrupt For CTS signal change Error</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Enable Interrupt For RX FIFO Overrun Error</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Enable Interrupt For RX FIFO reaches the number of bytes configured by RXTHD</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Enable Interrupt For TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Enable Interrupt For TX FIFO has half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Interrupt status flags Control register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Flag for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Flag for RX Parity Error interrupt</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Flag for CTS signal change interrupt (hardware flow control disabled) </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Flag for RX FIFO Overrun interrupt</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Flag for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Flag for interrupt when TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Flag for interrupt when TX FIFO is half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Clock Divider register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Baud rate divisor value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSR</name>
+     <description>Over Sampling Rate register</description>
+     <addressOffset>0x0014</addressOffset>
+     <fields>
+      <field>
+       <name>OSR</name>
+       <description>OSR</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXPEEK</name>
+     <description>TX FIFO Output Peek register</description>
+     <addressOffset>0x0018</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read TX FIFO next data. Reading from this field does not affect the contents of TX FIFO. Note that the parity bit is available from this field.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PNR</name>
+     <description> Pin register</description>
+     <addressOffset>0x001C</addressOffset>
+     <fields>
+      <field>
+       <name>CTS</name>
+       <description>Current sampled value of CTS IO</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RTS</name>
+       <description>This bit controls the value to apply on the RTS IO. If set to 1, the RTS IO is set to high level. If set to 0, the RTS IO is set to low level.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Read/Write register</description>
+     <addressOffset>0x0020</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Parity error flag for next byte to be read from FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration register</description>
+     <addressOffset>0x0030</addressOffset>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger If the TX FIFO level is less than this value, then the TX FIFO DMA interface will send a signal to system DMA to notify that TX FIFO is ready to receive data from memory.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX DMA channel enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Rx FIFO Level DMA Trigger If the RX FIFO level is greater than this value, then the RX FIFO DMA interface will send a signal to the system DMA to notify that RX FIFO has characters to transfer to memory.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX DMA channel enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wake up enable Control register</description>
+     <addressOffset>0x0034</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Enable for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Enable for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Enable for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wake up Flags register</description>
+     <addressOffset>0x0038</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Flag for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Flag for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Flag for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--UART UART Low Power Registers-->
+  <peripheral derivedFrom="UART">
+   <name>UART1</name>
+   <description>UART Low Power Registers 1</description>
+   <baseAddress>0x40043000</baseAddress>
+  </peripheral>
+<!--UART1 UART Low Power Registers 1-->
+  <peripheral derivedFrom="UART">
+   <name>UART2</name>
+   <description>UART Low Power Registers 2</description>
+   <baseAddress>0x40044000</baseAddress>
+  </peripheral>
+<!--UART2 UART Low Power Registers 2-->
+  <peripheral derivedFrom="UART">
+   <name>UART3</name>
+   <description>UART Low Power Registers 3</description>
+   <baseAddress>0x40145000</baseAddress>
+  </peripheral>
+<!--UART3 UART Low Power Registers 3-->
+  <peripheral>
+   <name>WDT</name>
+   <description>Windowed Watchdog Timer</description>
+   <baseAddress>0x40003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WWDT</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INT_LATE_VAL</name>
+       <description>Windowed Watchdog Interrupt Upper Limit. Sets the number of WDTCLK cycles until a windowed watchdog timer interrupt is generated (if enabled) if the CPU does not write the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE_VAL</name>
+       <description>Windowed Watchdog Reset Upper Limit. Sets the number of WDTCLK cycles until a system reset occurs (if enabled) if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Windowed Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_LATE</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Late.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_INT_EN</name>
+       <description>Windowed Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_RST_EN</name>
+       <description>Windowed Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Soon.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY_VAL</name>
+       <description>Windowed Watchdog Interrupt Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A windowed watchdog timer interrupt is generated (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY_VAL</name>
+       <description>Windowed Watchdog Reset Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A system reset occurs (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKRDY_IE</name>
+       <description>Switch Ready Interrupt Enable. Fires an interrupt when it is safe to swithc the clock.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY</name>
+       <description>Clock Status.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WIN_EN</name>
+       <description>Enables the Windowed Watchdog Function.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Windowed Mode Disabled (i.e. Compatibility Mode).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Windowed Mode Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Soon.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Late.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Windowed Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>RESET</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD_UPPER_LIMIT then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD_UPPER_LIMIT then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKSEL</name>
+     <description>Windowed Watchdog Timer Clock Select Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SOURCE</name>
+       <description>WWDT Clock Selection Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CNT</name>
+     <description>Windowed Watchdog Timer Count Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Current Value of the Windowed Watchdog Timer Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WDT Windowed Watchdog Timer-->
+  <peripheral derivedFrom="WDT">
+   <name>WDT1</name>
+   <description>Windowed Watchdog Timer 1</description>
+   <baseAddress>0x40003400</baseAddress>
+   <interrupt>
+    <name>WDT1</name>
+    <description>WDT1 IRQ</description>
+    <value>57</value>
+   </interrupt>
+  </peripheral>
+<!--WDT1 Windowed Watchdog Timer 1-->
+ </peripherals>
+</device>

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.svd
@@ -1,0 +1,13171 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max32672</name>
+ <series>ARMCM4</series>
+ <version>1.0</version>
+ <description>MAX32672 High-Reliability, Tiny, Ultra-Low-Power AEM Cortex-M4F Microcontroller with 12-bit 1MSPS ADC.</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>ADC</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>ADC</groupName>
+   <baseAddress>0x40034000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>ADC</name>
+    <description>ADC IRQ</description>
+    <value>20</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0</name>
+     <description>Control Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADC_EN</name>
+       <description>ADC Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable ADC.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable ADC.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BIAS_EN</name>
+       <description>Bias Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Bias.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Bias.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SKIP_CAL</name>
+       <description>Skip Calibration Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no_skip</name>
+         <description>Do not skip calibration.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>skip</name>
+         <description>Skip calibration.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CHOP_FORCE</name>
+       <description>Chop Force Control.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Do not force chop mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Force chop Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RESETB</name>
+       <description>Reset ADC.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>reset ADC.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activate</name>
+         <description>activate ADC.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Control Register 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Start conversion control.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>stop</name>
+         <description>Stop conversions.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start conversions.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TRIG_MODE</name>
+       <description>Trigger mode control.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>software</name>
+         <description>software trigger mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hardware</name>
+         <description>hardware trigger mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CNV_MODE</name>
+       <description>Conversion mode control.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>atomic</name>
+         <description>Do one conversion sequence.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Do continuous conversion sequences.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SAMP_CK_OFF</name>
+       <description>Sample clock off control.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>always</name>
+         <description>Sample clock always generated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cnv_only</name>
+         <description>Sample clock generated only when converting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TRIG_SEL</name>
+       <description>Hardware trigger source select.</description>
+       <bitRange>[6:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TS_SEL</name>
+       <description>Temp sensor select.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Temp sensor is not one of the slots in the sequence.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Temp sensor is one of the slots in the sequence.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AVG</name>
+       <description>Number of samples to average for each output data code.</description>
+       <bitRange>[10:8]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>avg1</name>
+         <description>1 Sample per output code.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg2</name>
+         <description>2 Samples per output code.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg4</name>
+         <description>4 Samples per output code.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg8</name>
+         <description>8 Samples per output code.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg16</name>
+         <description>16 Samples per output code.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg32</name>
+         <description>32 Samples per output code.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUM_SLOTS</name>
+       <description>Number of slots enabled for the conversion sequence</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>CLKSEL</name>
+       <description>Clock source select.</description>
+       <bitRange>[1:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>HCLK</name>
+         <description>Select HCLK.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK_ADC0</name>
+         <description>Select CLK_ADC0.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK_ADC1</name>
+         <description>Select CLK_ADC1.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK_ADC2</name>
+         <description>Select CLK_ADC2.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>Clock divider control.</description>
+       <bitRange>[6:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <description>Divide by 2.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <description>Divide by 4.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV8</name>
+         <description>Divide by 8.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV16</name>
+         <description>Divide by 16.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <description>Divide by 1.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAMPCLKCTRL</name>
+     <description>Sample Clock Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TRACK_CNT</name>
+       <description>Number of cycles for SAMPLE_CLK high time.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>IDLE_CNT</name>
+       <description>Number of cycles for SAMPLE_CLK low time.</description>
+       <bitRange>[31:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL0</name>
+     <description>Channel Select Register 0.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>slot0_id</name>
+       <description>channel assignment for slot 0.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot1_id</name>
+       <description>channel assignment for slot 1.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot2_id</name>
+       <description>channel assignment for slot 2.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot3_id</name>
+       <description>channel assignment for slot 3.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL1</name>
+     <description>Channel Select Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>slot4_id</name>
+       <description>channel assignment for slot 4.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot5_id</name>
+       <description>channel assignment for slot 5.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot6_id</name>
+       <description>channel assignment for slot 6.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot7_id</name>
+       <description>channel assignment for slot 7.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL2</name>
+     <description>Channel Select Register 2.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>slot8_id</name>
+       <description>channel assignment for slot 8.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot9_id</name>
+       <description>channel assignment for slot 9.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot10_id</name>
+       <description>channel assignment for slot 10.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot11_id</name>
+       <description>channel assignment for slot 11.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL3</name>
+     <description>Channel Select Register 3.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>slot12_id</name>
+       <description>channel assignment for slot 12.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot13_id</name>
+       <description>channel assignment for slot 13.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot14_id</name>
+       <description>channel assignment for slot 14.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot15_id</name>
+       <description>channel assignment for slot 15.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESTART</name>
+     <description>Restart Count Control Register</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Number of sample periods to skip before restarting a continuous mode sequence</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAFMT</name>
+     <description>Channel Data Format Register</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Data format control</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFODMACTRL</name>
+     <description>FIFO and DMA control</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>DMA_EN</name>
+       <description>DMA Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable DMA.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable DMA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>FIFO Flush.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal FIFO operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_FORMAT</name>
+       <description>DATA format control.</description>
+       <bitRange>[3:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>data_status</name>
+         <description>Data and Status in FIFO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>data_only</name>
+         <description>Only Data in FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>raw_data_only</name>
+         <description>Only Raw Data in FIFO.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THRESH</name>
+       <description>FIFO Threshold. These bits define the FIFO interrupt threshold.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data Register (FIFO).</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Conversion data.</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CHAN</name>
+       <description>Channel for the data.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>INVALID</name>
+       <description>Invalid status for the data.</description>
+       <bitRange>[24:24]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLIPPED</name>
+       <description>Clipped status for the data.</description>
+       <bitRange>[31:31]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>READY</name>
+       <description>Indication that the ADC is in ON power state</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EMPTY</name>
+       <description>FIFO Empty</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>FULL</name>
+       <description>FIFO full</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>FIFO_LEVEL</name>
+       <description>Number of entries in FIFO available to read</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSTATUS</name>
+     <description>Channel Status</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>CLIPPED</name>
+       <description />
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>READY</name>
+       <description>ADC is ready.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Conversion start is aborted.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>START_DET</name>
+       <description>Conversion start is detected.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SEQ_STARTED</name>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SEQ_DONE</name>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CONV_DONE</name>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLIPPED</name>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_LVL</name>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_UFL</name>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_OFL</name>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Interrupt Flags Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>READY</name>
+       <description>ADC is ready.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Conversion start is aborted.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>START_DET</name>
+       <description>Conversion start is detected.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>SEQ_STARTED</name>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>SEQ_DONE</name>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>CONV_DONE</name>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>CLIPPED</name>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>FIFO_LVL</name>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>FIFO_UFL</name>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>FIFO_OFL</name>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRADDROFFSET</name>
+     <description>SFR Address Offset Register</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>OFFSET</name>
+       <description>Address Offset for SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRADDR</name>
+     <description>SFR Address Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address to SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRWRDATA</name>
+     <description>SFR Write Data Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>DATA to SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRRDDATA</name>
+     <description>SFR Read Data Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>DATA from SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRSTATUS</name>
+     <description>SFR Status Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>NACK</name>
+       <description>NACK status for SAR Digital SFR communication</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ADC Inter-Integrated Circuit.-->
+  <peripheral>
+   <name>AES</name>
+   <description>AES Keys.</description>
+   <baseAddress>0x40207400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>AES Control Register</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>AES Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>DMA Request To Read Data Output FIFO</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>DMA Request To Write Data Input FIFO</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start AES Calculation</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FLUSH</name>
+       <description>Flush the data input FIFO</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FLUSH</name>
+       <description>Flush the data output FIFO</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_SIZE</name>
+       <description>Encryption Key Size</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AES128</name>
+         <description>128 Bits.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES192</name>
+         <description>192 Bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES256</name>
+         <description>256 Bits.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TYPE</name>
+       <description>Encryption Type Selection</description>
+       <bitRange>[9:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>AES Status Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>AES Busy Status</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_EM</name>
+       <description>Data input FIFO empty status</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FULL</name>
+       <description>Data input FIFO full status</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_EM</name>
+       <description>Data output FIFO empty status</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FULL</name>
+       <description>Data output FIFO full status</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>AES Interrupt Flag Register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>AES Interrupt Enable Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>AES Data Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>AES FIFO</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--AES AES Keys.-->
+  <peripheral>
+   <name>SYS_AESKEYS</name>
+   <description>System AES Key Registers.</description>
+   <baseAddress>0x40205000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>KEY0</name>
+     <description>AES Key 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY1</name>
+     <description>AES Key 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY2</name>
+     <description>AES Key 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY3</name>
+     <description>AES Key 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY4</name>
+     <description>AES Key 4.</description>
+     <addressOffset>0x10</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY5</name>
+     <description>AES Key 5.</description>
+     <addressOffset>0x14</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY6</name>
+     <description>AES Key 6.</description>
+     <addressOffset>0x18</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY7</name>
+     <description>AES Key 7.</description>
+     <addressOffset>0x1C</addressOffset>
+     <size>32</size>
+    </register>
+   </registers>
+  </peripheral>
+<!--SYS_AESKEYS System AES Key Registers.-->
+  <peripheral>
+   <name>USR_AESKEYS</name>
+   <description>User AES Key Registers.</description>
+   <baseAddress>0x40005000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SRAM_KEY</name>
+     <description>AES SRAM KEY</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CODE_KEY</name>
+     <description>AES CODE Key </description>
+     <addressOffset>0x20</addressOffset>
+    </register>
+    <register>
+     <name>DATA_KEY</name>
+     <description>AES DATA KEY</description>
+     <addressOffset>0x40</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--USR_AESKEYS User AES Key Registers.-->
+  <peripheral>
+   <name>CTB</name>
+   <description>The Cryptographic Toolbox is a combination of cryptographic engines and a secure cryptographic accelerator (SCA) used to provide advanced cryptographic security.</description>
+   <baseAddress>0x40001000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Crypto_Engine</name>
+    <description>Crypto Engine interrupt.</description>
+    <value>27</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Crypto Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0xC0000000</resetValue>
+     <fields>
+      <field>
+       <name>RST</name>
+       <description>Reset. This bit is used to reset the crypto accelerator.  All crypto internal states and related registers are reset to their default reset values. Control register such as CRYPTO_CTRL, CIPHER_CTRL, HASH_CTRL, CRC_CTRL, MAA_CTRL (with the exception of the STC bit), HASH_MSG_SZ_[3:0] and MAA_MAWS will retain their values. This bit will automatically clear itself after one cycle.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_write</name>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>Starts reset operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INTR</name>
+       <description>Interrupt Enable. Generates an interrupt when done or error set.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRC</name>
+       <description>Source Select.  This bit selects the hash function and CRC generator input source.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inputFIFO</name>
+         <description>Input FIFO</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputFIFO</name>
+         <description>Output FIFO</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="INTR">
+       <name>BSO</name>
+       <description>Byte Swap Output. Note. No byte swap will occur if there is not a full word.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="INTR">
+       <name>BSI</name>
+       <description>Byte Swap Input. Note. No byte swap will occur if there is not a full word.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="INTR">
+       <name>WAIT_EN</name>
+       <description>Wait Pin Enable. This can be used to hold off the crypto DMA until an external memory is ready. This is useful for transferring pages from NAND flash which may take several microseconds to become ready.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WAIT_POL</name>
+       <description>Wait Pin Polarity. When the wait pin is enabled, this bit selects its active state.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRSRC</name>
+       <description>Write FIFO Source Select. This field determines where data written to the write FIFO comes from. When data is written to the write FIFO, it is always written out the DMA. To decrypt or encrypt data, the write FIFO source should be set to the cipher output. To implement memcpy() or memset() functions, or to fill memory with random data, the write FIFO source should be set to the read FIFO. When calculating a HASH or CMAC, the write FIFO should be disabled.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>none</name>
+         <description>None.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cipherOutput</name>
+         <description>Cipher Output.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>readFIFO</name>
+         <description>Read FIFO.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDSRC</name>
+       <description>Read FIFO Source Select. This field selects the source of the read FIFO. Typically, it is set to use the DMA. To implement a memset() function, the read FIFO DMA should be disabled. To fill memory with random data or to hash random numbers, the read FIFO source should be set to the random number generator.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dmaDisabled</name>
+         <description>DMA Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dmaOrApb</name>
+         <description>DMA Or APB.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rng</name>
+         <description>RNG.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLAG_MODE</name>
+       <description>Done Flag Mode. This bit configures the access behavior of the individual CRYPTO_CTRL Done flags (CRYPTO_CTRL[27:24]). This bit is cleared only on reset to limit upkeep, i.e. once set, it will remain set until a reset occurs.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unres_wr</name>
+         <description>Unrestricted write (0 or 1) of CRYPTO_CTRL[27:24] flags.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>res_wr</name>
+         <description>Access to CRYPTO_CTRL[27:24] are write 1 to clear/write 0 no effect.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMADNEMSK</name>
+       <description>DMA Done Flag Mask. This bit masks the DMA_DONE flag from being used to generate the CRYPTO_CTRL.DONE flag, and this disables a DMA_DONE condition from generating and interrupt. The DMA_DONE flag itself is unaffected and still may be monitored. This allows more optimal interrupt-driven crypto operations using DMA.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_used</name>
+         <description>DMA_DONE not used in setting CRYPTO_CTRL.DONE bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>used</name>
+         <description>DMA_DONE used in setting CRYPTO_CTRL.DONE bit.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMA_DONE</name>
+       <description>DMA Done. DMA write/read operation is complete. This bit must be cleared before starting a DMA operation.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notDone</name>
+         <description>Not Done.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>done</name>
+         <description>Done.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>GLS_DONE</name>
+       <description>Galois Done. FIFO is full and CRC or Hamming Code Generator is enabled. This bit must be cleared before starting a CRC operation Note that DMA_DONE must be polled instead of this bit to determine the end of DMA operation during the utilization of Hamming Code Generator.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>HSH_DONE</name>
+       <description>Hash Done. SHA operation is complete. This bit must be cleared before starting a HASH operation.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>CPH_DONE</name>
+       <description>Cipher Done. Either AES or DES encryption/decryption operation is complete. This bit must be cleared before starting a cipher operation.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERR</name>
+       <description>AHB Bus Error. This bit is set when the DMA encounters a bus error during a read or write operation. Once this bit is set, the DMA will stop. This bit can only be cleared by resetting the crypto block.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Ready. Crypto block ready for more data.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>DONE</name>
+       <description>Done. One or more cryptographic calculations complete (logical OR of done flags).</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CIPHER_CTRL</name>
+     <description>Cipher Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ENC</name>
+       <description>Encrypt. Select encryption or decryption of input data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>encrypt</name>
+         <description>Encrypt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>decrypt</name>
+         <description>Decrypt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEY</name>
+       <description>Load Key from crypto DMA. This bit is automatically cleared by hardware after the DMA has completed loading the key. When the DMA operation is done, it sets the appropriate crypto DMA Done flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRC</name>
+       <description>Source of Random key.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>cipherKey</name>
+         <description>User cipher key (0x4000_1060).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>regFile</name>
+         <description>Key from battery-backed register file (0x4000_5000 to 0x4000_501F).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>qspiKey_regFile</name>
+         <description>Key from battery-backed register file (0x4000_5020 to 0x4000_502F).</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CIPHER</name>
+       <description>Cipher Operation Select.  Symmetric Block Cipher algorithm selection or memory operation.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes128</name>
+         <description>AES 128.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes192</name>
+         <description>AES 192.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes256</name>
+         <description>AES 256.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>des</name>
+         <description>DES.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>tdes</name>
+         <description>Triple DES.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description>Mode Select. Mode of operation for block cipher or memory operation. DES/TDES cannot be used in CFB, OFB or CTR modes.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ECB</name>
+         <description>ECB Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CBC</name>
+         <description>CBC Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CFB</name>
+         <description>CFB (AES only).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>OFB</name>
+         <description>OFB (AES only).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CTR</name>
+         <description>CTR (AES only).</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HVC</name>
+       <description>H Vector Computation.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DTYPE</name>
+       <description>GCM/CCM data type.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CCMM</name>
+       <description>CCM M Parameter.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CCML</name>
+       <description>CCM L Parameter.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HASH_CTRL</name>
+     <description>HASH Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>INIT</name>
+       <description>Initialize. Initializes hash registers with standard constants.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>XOR</name>
+       <description>XOR data with IV from cipher block. Useful when calculating HMAC to XOR the input pad and output pad.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HASH</name>
+       <description>Hash function selection.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha1</name>
+         <description>SHA-1.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha224</name>
+         <description>SHA 224.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha256</name>
+         <description>SHA 256.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha384</name>
+         <description>SHA 384.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha512</name>
+         <description>SHA 512.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LAST</name>
+       <description>Last Message Bit. This bit shall be set along with the HASH_MSG_SZ register prior to hashing the last 512 or 1024-bit block of the message data. It will allow automatic preprocessing of the last message padding, which includes the trailing bit 1, followed by the respective number of zero bits for the last block size and finally the message length represented in bytes. The bit will be automatically cleared at the same time the HASH DONE is set, designating the completion of the last message hash.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEffect</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>lastMsgData</name>
+         <description>Last Message Data.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_CTRL</name>
+     <description>CRC Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>CRC</name>
+       <description>Cyclic Redundancy Check Enable. The CRC cannot be enabled if the PRNG is enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MSB</name>
+       <description>MSB select. This bit selects the order of calculating CRC on data.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lsbFirst</name>
+         <description>LSB First.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>msbFirst</name>
+         <description>MSB First.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CRC">
+       <name>PRNG</name>
+       <description>Pseudo Random Number Generator Enable. If entropy is disabled, this outputs one byte of pseudo random data per clock cycle. If entropy is enabled, data is output at a rate of one bit per clock cycle.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CRC">
+       <name>ENT</name>
+       <description>Entropy Enable. If the PRNG is enabled, this mixes the high frequency ring oscillator with the LFSR. If the PRNG is disabled, the raw entropy data is output at a rate of 1 bit per clock. This makes it possible to characterize the quality of the entropy source.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CRC">
+       <name>HAM</name>
+       <description>Hamming Code Enable. Enable hamming code calculation.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HRST</name>
+       <description>Hamming Reset. Reset Hamming code ECC generator for next block.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+       <enumeratedValues>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>Starts reset operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_SRC</name>
+     <description>Crypto DMA Source Address.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>DMA Source Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_DEST</name>
+     <description>Crypto DMA Destination Address.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>DMA Destination Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_CNT</name>
+     <description>Crypto DMA Byte Count.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>DMA Byte Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DIN[%s]</name>
+     <description>Crypto Data Input. Data input can be written to this register instead of using the DMA. This register writes to the FIFO. This register occupies four successive words to allow the use of multi-store instructions. Words can be written to any location, they will be placed in the FIFO in the order they are written. The endian swap input control bit affects this register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Crypto Data Input. Input can be written to this register instead of using DMA.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DOUT[%s]</name>
+     <description>Crypto Data Output. Resulting data from cipher calculation. Data is placed in the lower words of these four registers depending on the algorithm. For block cipher modes, this register holds the result of most recent encryption or decryption operation. These registers are affected by the endian swap bits.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Crypto Data Output. Resulting data from cipher calculation. Data is placed in the lower words of these four registers depending on algorithm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_POLY</name>
+     <description>CRC Polynomial. The polynomial to be used for Galois Field calculations (CRC or LFSR) should be written to this register. This register is affected by the MSB control bit.</description>
+     <addressOffset>0x40</addressOffset>
+     <resetValue>0xEDB88320</resetValue>
+     <fields>
+      <field>
+       <name>POLY</name>
+       <description>CRC Polynomial. The polynomial to be used for Galois Field calculations (CRC or LFSR) should be written to this register. This register is affected by the MSB control bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_VAL</name>
+     <description>CRC Value. This is the state for the Galois Field. This register holds the result of a CRC calculation or the current state of the LFSR. This register is affected by the MSB control bit.</description>
+     <addressOffset>0x44</addressOffset>
+     <resetValue>0xFFFFFFFF</resetValue>
+     <fields>
+      <field>
+       <name>VAL</name>
+       <description>CRC Value. This is the state for the Galois Field. This register holds the result of a CRC calculation or the current state of LFSR. This register is affected by the MSB control bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HAM_ECC</name>
+     <description>Hamming ECC Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>ECC</name>
+       <description>Hamming ECC Value. These bits are the even parity of their corresponding bit groups.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PAR</name>
+       <description>Parity. This is the parity of the entire array.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>even</name>
+         <description>Even.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>odd</name>
+         <description>Odd.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CIPHER_INIT[%s]</name>
+     <description>Initial Vector. For block cipher operations that use CBC, CFB, OFB, or CNTR modes, this register holds the initial value. This register is updated with each encryption or decryption operation. This register is affected by the endian swap bits.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>IVEC</name>
+       <description>Initial Vector. For block cipher operations that use CBC, CFB, OFB, or CNTR modes, this register holds the initial value. This register is updated with each encryption or decryption operation. This register is affected by the endian swap bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CIPHER_KEY[%s]</name>
+     <description>Cipher Key.  This register holds the key used for block cipher operations. The lower words are used for block ciphers that use shorter key lengths. This register is affected by the endian swap input control bits.</description>
+     <addressOffset>0x60</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>KEY</name>
+       <description>Cipher Key. This register holds the key used for block cipher operations. The lower words are used for block ciphers that use shorter kye lengths. This register is affected by the endian swap input control bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>16</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>HASH_DIGEST[%s]</name>
+     <description>This register holds the calculated hash value. This register is affected by the endian swap bits.</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>HASH</name>
+       <description>This register holds the calculated hash value. This register is affected by the endian swap bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>HASH_MSG_SZ[%s]</name>
+     <description>Message Size. This register holds the lowest 32-bit of message size in bytes.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>MSGSZ</name>
+       <description>Message Size. This register holds the lowest 32-bit of message size in bytes.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>AAD_LENGTH[%s]</name>
+     <description>AAD Length Registers.</description>
+     <addressOffset>0xD0</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>LENGTH</name>
+       <description>AAD length in bytes for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>PLD_LENGTH[%s]</name>
+     <description>PLD Length Registers.</description>
+     <addressOffset>0xD8</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>LENGTH</name>
+       <description>PLD length in bytes for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>TAGMIC[%s]</name>
+     <description>TAG/MIC Registers.</description>
+     <addressOffset>0xE0</addressOffset>
+     <fields>
+      <field>
+       <name>LENGTH</name>
+       <description>TAG/MIC output for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_CTRL0</name>
+     <description>SCA Control 0 Register.</description>
+     <addressOffset>0x100</addressOffset>
+     <fields>
+      <field>
+       <name>STC</name>
+       <description>Start Calculation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCAIE</name>
+       <description>SCA Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Abort Operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERMEM</name>
+       <description>Erase Cryptographic Memory.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MANPARAM</name>
+       <description>ECC Parameter Source.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HWKEY</name>
+       <description>Hardware Key Select.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OPCODE</name>
+       <description>SCA Opcode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>MODADDR</name>
+       <description>MODULO Address Offset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>ECCSIZE</name>
+       <description>ECC Size.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_CTRL1</name>
+     <description>SCA Control 1 Register.</description>
+     <addressOffset>0x104</addressOffset>
+     <fields>
+      <field>
+       <name>MAN</name>
+       <description>SCA Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>auto</name>
+         <description>Auto Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>manual</name>
+         <description>Manual Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTOCARRY</name>
+       <description>Automatically propagate the carry for the next operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PLUSONE</name>
+       <description>Enable Carry propagation for the next operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NRNG</name>
+       <description>NRNG.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARRYPOS</name>
+       <description>To set Carry location.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_STAT</name>
+     <description>SCA Status Register.</description>
+     <addressOffset>0x108</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SCA Busy.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCAIF</name>
+       <description>SCA Interrupt Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PVF1</name>
+       <description>Point 1 Verification Failed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PVF2</name>
+       <description>Point 2 Verification Failed.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FSMERR</name>
+       <description>FSM Transition Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>COMPERR</name>
+       <description>EC Computation Error.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MEMERR</name>
+       <description>SCA Memory Access Error.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARRY</name>
+       <description>Carry on ongoing operation.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GTE2I2</name>
+       <description>Modulo 2x Result.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ALUNEG1</name>
+       <description>ALU 2 SubSign of the subtraction result for ALU_2.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ALUNEG2</name>
+       <description>ALU 2 SubSign of the subtraction result for ALU_2.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PPX_ADDR</name>
+     <description>PPX Coordinate Data Pointer Register.</description>
+     <addressOffset>0x10C</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point P Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PPY_ADDR</name>
+     <description>PPY Coordinate Data Pointer Register.</description>
+     <addressOffset>0x110</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point P Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PPZ_ADDR</name>
+     <description>PPZ Coordinate Data Pointer Register.</description>
+     <addressOffset>0x114</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point P Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PQX_ADDR</name>
+     <description>PQX Coordinate Data Pointer Register.</description>
+     <addressOffset>0x118</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point Q Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PQY_ADDR</name>
+     <description>PQY Coordinate Data Pointer Register.</description>
+     <addressOffset>0x11C</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point Q Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_PQZ_ADDR</name>
+     <description>PQZ Coordinate Data Pointer Register.</description>
+     <addressOffset>0x120</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Point Q Coordinate Data Pointer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_RDSA_ADDR</name>
+     <description>SCA RDSA Address Register.</description>
+     <addressOffset>0x124</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>The starting address of the R portion for R, S ECDSA signature.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_RES_ADDR</name>
+     <description>SCA Result Address Register.</description>
+     <addressOffset>0x128</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Starting address of result storage.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_OP_BUFF_ADDR</name>
+     <description>SCA Operation Buffer Address Register.</description>
+     <addressOffset>0x12C</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Starting address of operation buffer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_MODDATA</name>
+     <description>SCA Modulo Data Input Register.</description>
+     <addressOffset>0x130</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Used to load the SCA modulo for modular operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SCA_NRNG</name>
+     <description>Starting address for NRNG stored in SRAM.</description>
+     <addressOffset>0x134</addressOffset>
+     <resetValue>0x0</resetValue>
+    </register>
+   </registers>
+  </peripheral>
+<!--CTB The Cryptographic Toolbox is a combination of cryptographic engines and a secure cryptographic accelerator (SCA) used to provide advanced cryptographic security.-->
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0</name>
+    <value>28</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1</name>
+    <value>29</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA2</name>
+    <value>30</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA3</name>
+    <value>31</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA4</name>
+    <value>68</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA5</name>
+    <value>69</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA6</name>
+    <value>70</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA7</name>
+    <value>71</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA8</name>
+    <value>72</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA9</name>
+    <value>73</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA10</name>
+    <value>74</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA11</name>
+    <value>75</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>INTEN</name>
+     <description>DMA Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel 0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <description>Channel 1 Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <description>Channel 2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <description>Channel 3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH4</name>
+       <description>Channel 4 Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH5</name>
+       <description>Channel 5 Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH6</name>
+       <description>Channel 6 Interrupt Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH7</name>
+       <description>Channel 7 Interrupt Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>DMA Interrupt Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel Interrupt. To clear an interrupt, all active interrupt bits of the DMA_ST must be cleared. The interrupt bits are set only if their corresponding interrupt enable bits are set in DMA_CN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>12</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CTRL</name>
+      <description>DMA Channel Control Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>EN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQUEST</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0RX</name>
+          <description>SPI0 RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1RX</name>
+          <description>SPI1 RX</description>
+          <value>0x02</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI2RX</name>
+          <description>SPI2 RX</description>
+          <value>0x03</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0RX</name>
+          <description>UART0 RX</description>
+          <value>0x04</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1RX</name>
+          <description>UART1 RX</description>
+          <value>0x05</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0RX</name>
+          <description>I2C0 RX</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1RX</name>
+          <description>I2C1 RX</description>
+          <value>0x08</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>ADC</name>
+          <description>ADC</description>
+          <value>0x09</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2RX</name>
+          <description>I2C2 RX</description>
+          <value>0x0A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2RX</name>
+          <description>UART2 RX</description>
+          <value>0x0E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI3RX</name>
+          <description>SPI3 RX</description>
+          <value>0x0F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESRX</name>
+          <description>AES RX</description>
+          <value>0x10</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3RX</name>
+          <description>UART3 RX</description>
+          <value>0x1C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2SRX</name>
+          <description>I2S RX</description>
+          <value>0x1E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0TX</name>
+          <description>SPI0 TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1TX</name>
+          <description>SPI1 TX</description>
+          <value>0x22</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI2TX</name>
+          <description>SPI2 TX</description>
+          <value>0x23</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0TX</name>
+          <description>UART0 TX</description>
+          <value>0x24</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1TX</name>
+          <description>UART1 TX</description>
+          <value>0x25</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0TX</name>
+          <description>I2C0 TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1TX</name>
+          <description>I2C1 TX</description>
+          <value>0x28</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2TX</name>
+          <description>I2C2 TX</description>
+          <value>0x2A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>CRCTX</name>
+          <description>CRC TX</description>
+          <value>0x2C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2TX</name>
+          <description>UART2 TX</description>
+          <value>0x2E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI3TX</name>
+          <description>SPI3 TX</description>
+          <value>0x2F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESTX</name>
+          <description>AES TX</description>
+          <value>0x30</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3TX</name>
+          <description>UART3 TX</description>
+          <value>0x3C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2STX</name>
+          <description>I2S TX</description>
+          <value>0x3E</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_WAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_PER</name>
+        <description>Timeout Period Select.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_CLKDIV</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BURST_SIZE</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>DIS_IE</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IE</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>STATUS</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>STATUS</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IF</name>
+        <description>Count-to-Zero (CTZ) Interrupt Flag</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>RLD_IF</name>
+        <description>Reload Event Interrupt Flag.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>TO_IF</name>
+        <description>Time-Out Event Interrupt Flag.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRCRLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DSTRLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNTRLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>EN</name>
+        <description>Reload Enable. This bit should be set after the address reload registers have been programmed. This bit is automatically cleared to 0 when reload occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+<!--DMA DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral>
+   <name>FCR</name>
+   <description>Function Control Register.</description>
+   <baseAddress>0x40000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>FCTRL0</name>
+     <description>Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ERFO_RANGE_SEL</name>
+       <description>14MHz-32MHz ERFO Frequency Range Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>KEYWIPE_SYS</name>
+       <description>KEYWIPE_SYS.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C0_SDA_FILTER_EN</name>
+       <description>I2C0 SDA Glitch Filter Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="I2C0_SDA_FILTER_EN">
+       <name>I2C0_SCL_FILTER_EN</name>
+       <description>I2C0 SCL Glitch Filter Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C0_SDA_FILTER_EN">
+       <name>I2C1_SDA_FILTER_EN</name>
+       <description>I2C1 SDA Glitch Filter Enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C0_SDA_FILTER_EN">
+       <name>I2C1_SCL_FILTER_EN</name>
+       <description>I2C1 SCL Glitch Filter Enable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C0_SDA_FILTER_EN">
+       <name>I2C2_SDA_FILTER_EN</name>
+       <description>I2C2 SDA Glitch Filter Enable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C0_SDA_FILTER_EN">
+       <name>I2C2_SCL_FILTER_EN</name>
+       <description>I2C2 SCL Glitch Filter Enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL0</name>
+     <description>Register 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SEL</name>
+       <description>Auto-calibration Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Autocalibration Run.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOAD</name>
+       <description>Load Trim.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INVERT</name>
+       <description>Invert Gain.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>do Not invert trim step.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>invert</name>
+         <description>Invert trim step.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ATOMIC</name>
+       <description>Atomic mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GAIN</name>
+       <description>MU value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>TRIM</name>
+       <description>150MHz HFIO Auto Calibration Trim</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL1</name>
+     <description>Register 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INITIAL</name>
+       <description>100MHz IPO Trim Automatic Calibration Initial Trim.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL2</name>
+     <description>Register 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RUNTIME</name>
+       <description>100MHz IPO Trim Automatic Calibration Run Time.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>DIV</name>
+       <description>100MHz IPO Trim Automatic Calibration Divide Factor.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TS0</name>
+     <description>Register 4.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GAIN</name>
+       <description>Unsigned gain for temp sensor normalization</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TS1</name>
+     <description>Register 5.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>OFFSET</name>
+       <description>Signed offset for temp sensor correction</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCREFTRIM0</name>
+     <description>ADC Reference Trim 0</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VREFP</name>
+       <description>Trimming code for VREFP output of reference buffer</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VREFM</name>
+       <description>Trimming code for VREFM output of reference buffer</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VCM</name>
+       <description>Trimming code for VCM output of reference buffer</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>VX2_TUNE</name>
+       <description>Controls tuning capacitor in fine DAC (offset binary)</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCREFTRIM1</name>
+     <description>ADC Reference Trim 1</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VREFP</name>
+       <description>Trimming code for VREFP output of reference buffer</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VREFM</name>
+       <description>Trimming code for VREFM output of reference buffer</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VCM</name>
+       <description>Trimming code for VCM output of reference buffer</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>VX2_TUNE</name>
+       <description>Controls tuning capacitor in fine DAC (offset binary)</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCREFTRIM2</name>
+     <description>ADC Reference Trim 2</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IDRV_1P25</name>
+       <description>Trimming code for reference buffer drive strength. 1.25V</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IBOOST_1P25</name>
+       <description>Trimming value for extra drive current in reference buffer outputs. 2.048V</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IDRV_2P048</name>
+       <description>Trimming code for reference buffer drive strength. 2.048V</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IBOOST_2P048</name>
+       <description>Trimming value for extra drive current in reference buffer outputs. 2.048V</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VCM</name>
+       <description>Trimming code for VCM output of reference buffer</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>VX2_TUNE</name>
+       <description>Controls tuning capacitor in fine DAC (offset binary)</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ERFOKS</name>
+     <description>External Radio Frequency Oscillator Kick Start Control Register.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CTRL</name>
+       <description>Kickstart Control for ERFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FCR Function Control Register.-->
+  <peripheral>
+   <name>FLC</name>
+   <description>Flash Memory Control.</description>
+   <prependToName>FLSH_</prependToName>
+   <baseAddress>0x40029000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Flash_Controller</name>
+    <description>Flash Controller interrupt.</description>
+    <value>23</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ADDR</name>
+     <description>Flash Write Address.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address for next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Flash Clock Divide. The clock (PLL0) is divided by this value to generate a 1 MHz clock for Flash controller.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000064</resetValue>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Flash Clock Divide. The clock is divided by this value to generate a 1MHz clock for flash controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Flash Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WR</name>
+       <description>Write.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="WR">
+       <name>ME</name>
+       <description>Mass Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="WR">
+       <name>PGE</name>
+       <description>Page Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERASE_CODE</name>
+       <description>Erase Code.  The ERASE_CODE must be set up property before erase operation can be initiated. These bits are automatically cleared after the operation is complete.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>erasePage</name>
+         <description>Enable Page Erase.</description>
+         <value>0x55</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>eraseAll</name>
+         <description>Enable Mass Erase. The debug port must be enabled.</description>
+         <value>0xAA</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PEND</name>
+       <description>Flash Pending.  When Flash operation is in progress (busy), Flash reads and writes will fail. When PEND is set, write to all Flash registers, with exception of the Flash interrupt register, are ignored.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LVE</name>
+       <description>Low Voltage enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNLOCK</name>
+       <description>Flash Unlock.  The correct unlock code must be written to these four bits before any Flash write or erase operation is allowed.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Flash Unlocked.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Flash Locked.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Flash Interrupt Register.</description>
+     <addressOffset>0x024</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Flash Done Interrupt.  This bit is set to 1 upon Flash write or erase completion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AF</name>
+       <description>Flash Access Fail.  This bit is set when an attempt is made to write the flash while the flash is busy or the flash is locked. This bit can only be set to 1 by hardware.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONEIE</name>
+       <description>Flash Done Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DONEIE">
+       <name>AFIE</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCDATA</name>
+     <description>ECC Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>EVEN</name>
+       <description>Error Correction Code Odd Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>ODD</name>
+       <description>Error Correction Code Even Data.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA[%s]</name>
+     <description>Flash Write Data.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACTRL</name>
+     <description>Access Control Register. Writing the ACTRL register with the following values in the order shown, allows read and write access to the system and user Information block:
+    pflc-actrl = 0x3a7f5ca3;
+    pflc-actrl = 0xa1e34f20;
+    pflc-actrl = 0x9608b2c1. When unlocked, a write of any word will disable access to system and user information block. Readback of this register is always zero.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ACTRL</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR0</name>
+     <description>WELR0</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>WELR0</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR1</name>
+     <description>WELR1</description>
+     <addressOffset>0x88</addressOffset>
+     <fields>
+      <field>
+       <name>WELR1</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR0</name>
+     <description>RLR0</description>
+     <addressOffset>0x90</addressOffset>
+     <fields>
+      <field>
+       <name>RLR0</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR1</name>
+     <description>RLR1</description>
+     <addressOffset>0x98</addressOffset>
+     <fields>
+      <field>
+       <name>RLR1</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FLC Flash Memory Control.-->
+  <peripheral derivedFrom="FLC">
+   <name>FLC1</name>
+   <description>Flash Memory Control. 1</description>
+   <baseAddress>0x40029400</baseAddress>
+   <interrupt>
+    <name>FLC1</name>
+    <description>FLC1 IRQ</description>
+    <value>87</value>
+   </interrupt>
+  </peripheral>
+<!--FLC1 Flash Memory Control. 1-->
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x40000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SYSCTRL</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>SBUSARB</name>
+       <description>System bus abritration scheme. These bits are used to select between Fixed-burst abritration and Round-Robin scheme. The Round-Robin scheme is selected by default. These bits are reset by the system reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Fix</name>
+         <description>Fixed Burst abritration.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Round</name>
+         <description>Round-robin scheme.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLASH_PAGE_FLIP</name>
+       <description>.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Physical layout matches logical layout.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Bottom half mapped to logical top half and vice versa.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FPU_DIS</name>
+       <description>Cortex M4 Floating Point Disable This bit is used to disable the floating-point unit of the Cortex-M4</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>FPU Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>FPU Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICC0_FLUSH</name>
+       <description>Internal Cache Controller Flush. This bit is used to flush the code caches and the instruction buffer of the Cortex-M4. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CCHK</name>
+       <description>Compute ROM Checksum. This bit is self-cleared when calculation is completed. Once set, software clearing this bit is ignored and the bit will remain set until the operation is completed.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SWD_DIS</name>
+       <description> Serial Wire Debug Disable. This bit is used to disable the serial wire debug interface This bit is only writeable if (FMV lock word is not programmed) or if (ICE lock word is not programmed and the ROM_DONE bit is not set)
+				</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SWD Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SWD Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CHKRES</name>
+       <description>ROM Checksum Result. This bit is only valid when CHKRD=1.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pass</name>
+         <description>ROM Checksum Correct.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fail</name>
+         <description>ROM Checksum Fail.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA">
+       <name>WDT0</name>
+       <description>Watchdog Timer Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO1</name>
+       <description>GPIO1 Reset. Setting this bit to 1 resets GPIO1 pins to their default states.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR0</name>
+       <description>Timer0 Reset. Setting this bit to 1 resets Timer 0 blocks.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR1</name>
+       <description>Timer1 Reset. Setting this bit to 1 resets Timer 1 blocks.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR2</name>
+       <description>Timer2 Reset. Setting this bit to 1 resets Timer 2 blocks.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR3</name>
+       <description>Timer3 Reset. Setting this bit to 1 resets Timer 3 blocks.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART0</name>
+       <description>UART0 Reset. Setting this bit to 1 resets all UART 0 blocks.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART1</name>
+       <description>UART1 Reset. Setting this bit to 1 resets all UART 1 blocks.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI0</name>
+       <description>SPI0 Reset. Setting this bit to 1 resets all SPI 0 blocks.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI1</name>
+       <description>SPI1 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI2</name>
+       <description>SPI2 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>I2C0</name>
+       <description>I2C0 Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>CTB</name>
+       <description>Crypto Toolbox Reset.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TRNG</name>
+       <description>TRNG Reset.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>ADC</name>
+       <description>ADC Reset.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART2</name>
+       <description>UART2 Reset. Setting this bit to 1 resets all UART 2 blocks.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SOFT</name>
+       <description>Soft Reset. Setting this bit to 1 resets everything except the CPU and the watchdog timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>PERIPH</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SYS</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>SYSCLK_DIV</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the PLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_SEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ERFO</name>
+         <description>32MHz Crystal is used for the system clock.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INRO</name>
+         <description>80kHz LIRC is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>The internal 96 MHz oscillator is used for the system clock.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBRO</name>
+         <description>The internal 8 MHz oscillator is used for the system clock.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERTCO</name>
+         <description> 32kHz is used for the system clock.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EXTCLK</name>
+         <description> External clock on gpio0 28 (AF4).</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_RDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IPO_DIV</name>
+       <description>Divides the HIRC96M clock before the system clock prescaler, will affect HIRC96M Autocalibration.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>divide clock by 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>divide clock by 2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>divide clock by 4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>divide clock by 8</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_EN</name>
+       <description>32MHz Crystal Oscillator Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERFO_EN">
+       <name>IPO_EN</name>
+       <description>96MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_EN">
+       <name>IBRO_EN</name>
+       <description>8MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_VS</name>
+       <description>8MHz High Frequency Internal Reference Clock Voltage Select. This register bit is used to select the power supply to the HIRC8M.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1V</name>
+         <description>Dedicated 1v regulated supply.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vcor</name>
+         <description>VCore Supply</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_RDY</name>
+       <description>32MHz Crystal Oscillator Ready</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERTCO_RDY</name>
+       <description>32kHz Crystal Oscillator Ready</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>IPO_RDY</name>
+       <description>96MHz HIRC Ready.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>IBRO_RDY</name>
+       <description>8MHz HIRC Ready.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>INRO_RDY</name>
+       <description>8kHz Low Frequency Reference Clock Ready.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>EXTCLK_RDY</name>
+       <description>External Clock (GPIO0[11] AF2) </description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PM</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This three bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>backup</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO_WE</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wake Up Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wake Up Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>RTC_WE</name>
+       <description>RTC Alarm Wake Up Enable. This bit enables RTC alarm as wakeup source. If enabled, the desired RTC alarm must be configured via the RTC control registers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>LPTMR0_WE</name>
+       <description>TIMER4 Wake Up Enable. This bit enables TIMER4 as wakeup source. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>LPTMR1_WE</name>
+       <description>TIMER5 Wake Up Enable. This bit enables TIMER5 as wakeup source. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>LPUART0_WE</name>
+       <description>LPUART3 Wake Up Enable. This bit enables LPUART3 as wakeup source. </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>AINCOMP_WE</name>
+       <description>AINCOMP Wake Up Enable. This bit enables AINCOMP as wakeup source. </description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_PD</name>
+       <description>32MHz power down. This bit selects 32MHz Crystal power state in DEEPSLEEP mode.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERFO_PD">
+       <name>IPO_PD</name>
+       <description>96MHz power down. This bit selects 96MHz HIRC power state in DEEPSLEEP mode. </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_PD">
+       <name>IBRO_PD</name>
+       <description>8MHz power down. This bit selects 8MHz HIRC power state in DEEPSLEEP mode. </description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_BP</name>
+       <description>32MHz Oscillator Bypass</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Bypass Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Bypass Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIV</name>
+     <description>Peripheral Clock Divider.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>AON_CLKDIV</name>
+       <description>Always-ON (AON) domain Clock Divider. These bits define the AON domain clock divider</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div4</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DIV_CLK_OUT_CTRL</name>
+       <description>DIV_CLK_OUT Control</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>off</name>
+         <description>HART clock off.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>HART clock HIRC8M Div 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>HART clock XO32M Div 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>HART clock XO32M Div 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DIV_CLK_OUT_EN</name>
+       <description>DIV_CLK_OUT Enable</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HART clock Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HART clock Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0</name>
+       <description>GPIO0 Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>GPIO1</name>
+       <description>GPIO1 Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>DMA</name>
+       <description>DMA Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI0</name>
+       <description>SPI 0 Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI1</name>
+       <description>SPI 1 Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI2</name>
+       <description>SPI 2 Disable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART0</name>
+       <description>UART 0 Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART1</name>
+       <description>UART 1 Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C0</name>
+       <description>I2C 0 Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>CTB</name>
+       <description>Crypto Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR0</name>
+       <description>Timer 0 Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR1</name>
+       <description>Timer 1 Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR2</name>
+       <description>Timer 2 Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR3</name>
+       <description>Timer 3 Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>ADC</name>
+       <description>ADC Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C1</name>
+       <description>I2C 1 Disable.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCTRL</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 2.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>RAMWS_EN</name>
+       <description>System RAM Wait State enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>no SRAM wait state.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SRAM wait state enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM0LS_EN</name>
+       <description>System RAM 0 Light Sleep Mode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM1LS_EN</name>
+       <description>System RAM 1 Light Sleep Mode.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM2LS_EN</name>
+       <description>System RAM 2 Light Sleep Mode.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM3LS_EN</name>
+       <description>System RAM 3 Light Sleep Mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>ICC0LS_EN</name>
+       <description>ICache RAM Light Sleep Mode.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>ROMLS_EN</name>
+       <description>ROM Light Sleep Mode.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMZ</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM 0 Block.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM1</name>
+       <description>System RAM 1 zeroization.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM2</name>
+       <description>System RAM 2 zeroization.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAMCB</name>
+       <description>System RAM check bit zeroization.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICC0</name>
+       <description>Instruction Cache.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSST</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICELOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>I2C1</name>
+       <description>I2C1 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>Reset.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>WDT1</name>
+       <description>WDT1 Reset.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AES</name>
+       <description>WDT1 Reset.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AC</name>
+       <description>AC Reset.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2C2</name>
+       <description>I2C2 Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2S</name>
+       <description>I2S Reset.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>QDEC</name>
+       <description>QDEC Reset.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>UART2</name>
+       <description>UART2 Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="UART2">
+       <name>TRNG</name>
+       <description>TRNG Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>WDT0</name>
+       <description>WDT0  Disable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>WDT1</name>
+       <description>WDT1  Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>ICC0</name>
+       <description>ICACHE Disable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>AES</name>
+       <description>AES Clock Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>I2C2</name>
+       <description>I2C2 Disable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>I2S</name>
+       <description>I2S Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>QDEC</name>
+       <description>Quadrature Decoder Interface Clock Disable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVENTEN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Event Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Event Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Enable RXEV pin event. When this bit is set, a logic high of GPIO0[20] (AF1) will cause an RXEV event to wake the CPU from WFE sleep mode. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Event Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Event Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO[21] (AF1).</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Event Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Event Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REVISION</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSIE</name>
+     <description>System Status Interrupt Enable Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEUNLOCK</name>
+       <description>ARM ICE Unlock Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCERR</name>
+     <description>ECC Error Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0_1</name>
+       <description>ECC System RAM0 and RAM1 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>ECC System RAM2 Error Flag. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>ECC System RAM3 Error Flag. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0</name>
+       <description>ECC Icache Error Flag. Write 1 to clear.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH0</name>
+       <description>ECC Flash0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH1</name>
+       <description>ECC Flash1 Error Flag. Write 1 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCCED</name>
+     <description>ECC Correctable Error Detect Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0_1</name>
+       <description>ECC System RAM0 and RAM1 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>ECC System RAM2 Error Flag. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>ECC System RAM3 Error Flag. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0</name>
+       <description>ECC Icache Error Flag. Write 1 to clear.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH0</name>
+       <description>ECC Flash0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH1</name>
+       <description>ECC Flash1 Error Flag. Write 1 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCIE</name>
+     <description>ECC IRQ Enable Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0_1</name>
+       <description>ECC System RAM0 and RAM1 Error interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0_1">
+       <name>RAM2</name>
+       <description>ECC System RAM2 Error interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0_1">
+       <name>RAM3</name>
+       <description>ECC System RAM3 Error interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0_1">
+       <name>ICC0</name>
+       <description>ECC Icache Error interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0_1">
+       <name>FLASH0</name>
+       <description>ECC Flash0 Error interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0_1">
+       <name>FLASH1</name>
+       <description>ECC Flash1 Error interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCADDR</name>
+     <description>ECC Error Address Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>DATARAMADDR</name>
+       <description>ECC Error Address/TAG RAM Error Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>DATARAMBANK</name>
+       <description>ECC Error Address/DATA RAM Error Bank.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATARAMERR</name>
+       <description>ECC Error Address/DATA RAM Error Address.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMADDR</name>
+       <description>ECC Error Address/TAG RAM Error Address.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMBANK</name>
+       <description>ECC Error Address/TAG RAM Error Bank.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMERR</name>
+       <description>ECC Error Address/TAG RAM Error.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCR Global Control Registers.-->
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x40008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN0</name>
+     <description>GPIO Function Enable Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_SET</name>
+     <description>GPIO Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_OUT bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_IN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTMODE</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTMODE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTPOL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTPOL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INEN</name>
+     <description>GPIO Input Enable</description>
+     <addressOffset>0x30</addressOffset>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_INTFL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WKEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DUALEDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DUALEDGE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL0</name>
+     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL0</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL1</name>
+     <description>GPIO Input Mode Config 2. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL1</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_SET</name>
+     <description>GPIO Alternate Function Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN2</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_SET</name>
+     <description>GPIO Alternate Function 2 Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN2 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_CLR</name>
+     <description>GPIO Wake Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN2 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x7C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HYSEN</name>
+     <description>GPIO Input Hysteresis Enable.</description>
+     <addressOffset>0xA8</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_HYSEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SRSEL</name>
+     <description>GPIO Slew Rate Enable Register.</description>
+     <addressOffset>0xAC</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_SRSEL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>FAST</name>
+         <description>Fast Slew Rate selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SLOW</name>
+         <description>Slow Slew Rate selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS0</name>
+     <description>GPIO Drive Strength  Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS0</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ld</name>
+         <description>GPIO port pin is in low-drive mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hd</name>
+         <description>GPIO port pin is in high-drive mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PS</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VSSEL</name>
+     <description>GPIO Voltage Select.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GPIO0 Individual I/O for each GPIO-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO1</name>
+   <description>Individual I/O for each GPIO 1</description>
+   <baseAddress>0x40009000</baseAddress>
+   <interrupt>
+    <name>GPIO1</name>
+    <description>GPIO1 IRQ</description>
+    <value>25</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO1 Individual I/O for each GPIO 1-->
+  <peripheral>
+   <name>I2C0</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>I2C</groupName>
+   <baseAddress>0x4001D000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2C0</name>
+    <description>I2C0 IRQ</description>
+    <value>13</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>I2C Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable I2C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable I2C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave_mode</name>
+         <description>Slave Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master_mode</name>
+         <description>Master Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_EN</name>
+       <description>General Call Address Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Ignore Gneral Call Address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Acknowledge general call address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_EN</name>
+       <description>Interactive Receive Mode.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interactive Receive Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interactive Receive Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_ACK</name>
+       <description>Data Acknowledge. This bit defines the acknowledge bit returned by the I2C receiver while IRXM = 1 HW forces ACK to 0 when IRXM = 0.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ack</name>
+         <description>return ACK (pulling SDA LOW).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>return NACK (leaving SDA HIGH).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_OUT</name>
+       <description>SCL Output. This bits control SCL output when SWOE =1.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_scl_low</name>
+         <description>Drive SCL low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_scl</name>
+         <description>Release SCL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDA_OUT</name>
+       <description>SDA Output. This bits control SDA output when SWOE = 1. </description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_sda_low</name>
+         <description>Drive SDA low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_sda</name>
+         <description>Release SDA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL</name>
+       <description>SCL status. This bit reflects the logic gate of SCL signal. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDA</name>
+       <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BB_MODE</name>
+       <description>Software Output Enable.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>outputs_disable</name>
+         <description>I2C Outputs SCLO and SDAO disabled. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputs_enable</name>
+         <description>I2C Outputs SCLO and SDAO enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read. This bit reflects the R/W bit of an address match (AMI = 1) or general call match (GCI = 1). This bit is valid 3 cycles after the relevant interrupt bit is set.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKSTR_DIS</name>
+       <description>This bit will disable slave clock stretching when set.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Slave clock stretching enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Slave clock stretching disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ONE_MST_MODE</name>
+       <description>SCL Push-Pull Mode. This bit controls whether SCL is operated in a the I2C standard open-drain mode, or in a non-standard push-pull mode where the Hi-Z output isreplaced with Drive-1. The non-standard mode should only be used when operating as a master and communicating with slaves that are guaranteed to never drive SCL low. </description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Standard open-drain operation:
+					drive low for 0, Hi-Z for 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Non-standard push-pull operation:
+					drive low for 0, drive high for 1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HS_EN</name>
+       <description>High speed mode enable</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>Bus Status.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>I2C Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>I2C Bus Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>RX empty.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX Full.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX Empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>TX Full.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_BUSY</name>
+       <description>Clock Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_actively_driving_scl_clock</name>
+         <description>Device not actively driving SCL clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>actively_driving_scl_clock</name>
+         <description>Device operating as master and actively driving SCL clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL0</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <name>INT_FL0_Done</name>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Interactive Receive Interrupt.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave General Call Address Match Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave Address Match Interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Receive Threshold Interrupt. This bit is automaticcaly cleared when RX_FIFO is below the threshold level.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. RX_FIFO equal or more bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>Transmit Threshold Interrupt. This bit is automaticcaly cleared when TX_FIFO is above the threshold level.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP Interrupt.</description>
+       <bitRange>[6:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Address Acknowledge Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Arbritation error Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>timeout Error Interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Address NACK Error Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Data NACK Error Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Do Not Respond Error Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Start Error Interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Stop Error Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>Transmit Lock Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN0</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when DONE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Description not available.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when RX_MODE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave mode general call address match received input enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when GEN_CTRL_ADDR = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave mode incoming address match interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when ADDR_MATCH = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Above Treshold Level Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Below Treshold Level Interrupt Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Stop Interrupt Enable</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when STOP = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Received Address ACK from Slave Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Master Mode Arbitration Lost Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>Timeout Error Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Master Mode Address NACK Received Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Master Mode Data NACK Received Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Slave Mode Do Not Respond Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Out of Sequence START condition detected interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Out of Sequence STOP condition detected interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>TX FIFO Locked Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL1</name>
+     <description>Interrupt Status Register 1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt. When operating as a slave receiver, this bit is set when you reach the first data bit and the RX FIFO and shift register are both full.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt. When operating as a slave transmitter, this bit is set when you reach the first data bit and the TX FIFO is empty and the master is still asking for more data (i.e the master hasn't sent a NACK yet).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Status Flag.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN1</name>
+     <description>Interrupt Staus Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOLEN</name>
+     <description>FIFO Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RX_DEPTH</name>
+       <description>Receive FIFO Length.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DEPTH</name>
+       <description>Transmit FIFO Length.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL0</name>
+     <description>Receive Control Register 0.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>DNR</name>
+       <description>Do Not Respond.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Always respond to address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>not_respond_rx_fifo_empty</name>
+         <description>Do not respond to address match when RX_FIFO is not empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Receive FIFO Flush. This bit is automatically cleared to 0 after the operation. Setting this bit to 1 will affect RX_FIFO status.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush RX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_LVL</name>
+       <description>Receive FIFO Threshold. These bits define the RX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL1</name>
+     <description>Receive Control Register 1.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Receive Count Bits. These bits define the number of bytes to be received in a transaction, except for the case RXCNT = 0. RXCNT = 0 means 256 bytes to be received in a transaction.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Receive FIFO Count. These bits reflect the number of byte in the RX_FIFO. These bits are flushed when I2CEN = 0.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL0</name>
+     <description>Transmit Control Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_MODE</name>
+       <description>Transmit FIFO Preaload Mode. Setting this bit will allow for high speed application to preload the transmit FIFO prior to Slave Address Match.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TX_READY_MODE</name>
+       <description>Transmit FIFO Ready Manual Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW control of I2CTXRDY enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW control of I2CTXRDY disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO General Call Address Match Auto Flush Disable.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Write Auto Flush Disable.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Read Auto Flush Disable.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NACK_FLUSH_DIS</name>
+       <description>TX FIFO received NACK Auto Flush Disable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Transmit FIFO Flush. This bit is automatically cleared to 0 after the operation.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush TX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_LVL</name>
+       <description>Transmit FIFO Threshold. These bits define the TX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL1</name>
+     <description>Transmit Control Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_RDY</name>
+       <description>Transmit FIFO Preload Ready.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Transmit FIFO Count. These bits reflect the number of bytes in the TX_FIFO.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MSTCTRL</name>
+     <description>Master Control Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Setting this bit to 1 will start a master transfer.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>RESTART</name>
+       <description>Setting this bit to 1 will generate a repeated START.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Setting this bit to 1 will generate a STOP condition.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>EX_ADDR_EN</name>
+       <description>Slave Extend Address Select.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKLO</name>
+     <description>Clock Low Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock low. In master mode, these bits define the SCL low period. In slave mode, these bits define the time SCL will be held low after data is outputted.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKHI</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>HI</name>
+       <description>Clock High. In master mode, these bits define the SCL high period.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HSCLK</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock Low. This field sets the Hs-Mode clock low count. In Slave mode, this is the time SCL is held low after data is output on SDA.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Clock High. This field sets the Hs-Mode clock high count. In Slave mode, this is the time SCL is held high after data is output on SDA</description>
+       <bitRange>[15:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TIMEOUT</name>
+     <description>Timeout Register</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_TO_VAL</name>
+       <description>Timeout</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>SLAVE_MULTI[%s]</name>
+     <description>Slave Address Register.</description>
+     <alternateRegister>SLAVE0</alternateRegister>
+     <addressOffset>0x4C</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Slave Address.</description>
+       <bitRange>[9:0]</bitRange>
+      </field>
+      <field>
+       <name>DIS</name>
+       <description>Slave Disable.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>EXT_ADDR_EN</name>
+       <description>Extended Address Select.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLAVE0</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE1</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x50</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE2</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x54</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE3</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x58</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2C0 Inter-Integrated Circuit.-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C1</name>
+   <description>Inter-Integrated Circuit. 1</description>
+   <baseAddress>0x4001E000</baseAddress>
+   <interrupt>
+    <name>I2C1</name>
+    <description>I2C1 IRQ</description>
+    <value>36</value>
+   </interrupt>
+  </peripheral>
+<!--I2C1 Inter-Integrated Circuit. 1-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C2</name>
+   <description>Inter-Integrated Circuit. 2</description>
+   <baseAddress>0x4001F000</baseAddress>
+   <interrupt>
+    <name>I2C2</name>
+    <description>I2C2 IRQ</description>
+    <value>62</value>
+   </interrupt>
+  </peripheral>
+<!--I2C2 Inter-Integrated Circuit. 2-->
+  <peripheral>
+   <name>I2S</name>
+   <description>Inter-IC Sound Interface.</description>
+   <groupName>I2S</groupName>
+   <baseAddress>0x40060000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2S</name>
+    <description>I2S IRQ</description>
+    <value>99</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0CH0</name>
+     <description>Global mode channel.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>LSB_FIRST</name>
+       <description>LSB Transmit Receive First.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_FILT</name>
+       <description>PDM Filter.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_EN</name>
+       <description>PDM Enable.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>USEDDR</name>
+       <description>DDR.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_INV</name>
+       <description>Invert PDM.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_MODE</name>
+       <description>SCK Select.</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>WS_POL</name>
+       <description>WS polarity select. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB_LOC</name>
+       <description>MSB location. </description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ALIGN</name>
+       <description>Align to MSB or LSB.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EXT_SEL</name>
+       <description>External SCK/WS selection.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>STEREO</name>
+       <description>Stereo mode of I2S.</description>
+       <bitRange>[13:12]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WSIZE</name>
+       <description>Data size when write to FIFO.</description>
+       <bitRange>[15:14]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable. </description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable. </description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Flushes the TX/RX FIFO buffer. </description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RST</name>
+       <description>Write 1 to reset channel. </description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_LSB</name>
+       <description>Bit Field Control. </description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>depth of receive FIFO for threshold interrupt generation. </description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1CH0</name>
+     <description>Local channel Setup.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>BITS_WORD</name>
+       <description>I2S word length.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>I2S clock enable.</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SMP_SIZE</name>
+       <description>I2S sample size length.</description>
+       <bitRange>[13:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ADJUST</name>
+       <description>LSB/MSB Justify.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>I2S clock frequency divisor.</description>
+       <bitRange>[31:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FILTCH0</name>
+     <description>Filter.</description>
+     <addressOffset>0x20</addressOffset>
+    </register>
+    <register>
+     <name>DMACH0</name>
+     <description>DMA Control.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DMA_TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger.</description>
+       <bitRange>[6:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA channel enable.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_THD_VAL</name>
+       <description>RX FIFO Level DMA Trigger.</description>
+       <bitRange>[14:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA channel enable.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Number of data word in the TX FIFO.</description>
+       <bitRange>[23:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Number of data word in the RX FIFO.</description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOCH0</name>
+     <description>I2S Fifo.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>ISR Status.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Status for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Status for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Status for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Status for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Enable for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Enable for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Enable for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Enable for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EXTSETUP</name>
+     <description>Ext Control.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>EXT_BITS_WORD</name>
+       <description>Word Length for ch_mode.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wakeup Enable.</description>
+     <addressOffset>0x5C</addressOffset>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wakeup Flags.</description>
+     <addressOffset>0x60</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2S Inter-IC Sound Interface.-->
+  <peripheral>
+   <name>ICC0</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x4002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x800</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>INFO</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SZ</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCH</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEM</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ICC0 Instruction Cache Controller Registers-->
+  <peripheral>
+   <name>MCR</name>
+   <description>Misc Control.</description>
+   <baseAddress>0x40106C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RST</name>
+     <description>Low Power Reset Control Register</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>LPTMR0</name>
+       <description>Low Power Timer0 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="LPTMR0">
+       <name>LPTMR1</name>
+       <description>Low Power Timer1 Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="LPTMR0">
+       <name>LPUART0</name>
+       <description>Low Power UART0 Reset.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="LPTMR0">
+       <name>RTC</name>
+       <description>RTC Reset.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ERTCO_PD</name>
+       <description>32KHz Crystal Oscillator Power Down.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>32KHz Crystal Oscillator Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AINCOMP</name>
+     <description>AIN Comparator.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>PD</name>
+       <description>AIN Comparator Power Down control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>HYST</name>
+       <description>AIN Comparator Hysteresis control.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>NSEL_COMP0</name>
+       <description>Negative input select for AIN Comparator 0.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>PSEL_COMP0</name>
+       <description>Positive input select for AIN Comparator 0</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>NSEL_COMP1</name>
+       <description>Negative input select for AIN Comparator 1</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>PSEL_COMP1</name>
+       <description>Positive input select for AIN Comparator 1</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPIOCTRL</name>
+     <description>Low Power Peripheral IO Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>LPTMR0_I</name>
+       <description>Enable control for LPTMR0 input.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPTMR0_O</name>
+       <description>Enable control for LPTMR0 output.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPTMR1_I</name>
+       <description>Enable control for LPTMR1 input.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPTMR1_O</name>
+       <description>Enable control for LPTMR1 output.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPUART0_RX</name>
+       <description>Enable control for LPUART0 RX.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPUART0_TX</name>
+       <description>Enable control for LPUART0 TX.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPUART0_CTS</name>
+       <description>Enable control for LPUART0 CTS.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPUART0_RTS</name>
+       <description>Enable control for LPUART0 RTS.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS</name>
+     <description>Low Power Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>LPTMR0</name>
+       <description>Low Power Timer0 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="LPTMR0">
+       <name>LPTMR1</name>
+       <description>Low Power Timer1 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="LPTMR0">
+       <name>LPUART0</name>
+       <description>Low Power UART0 Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AESKEY</name>
+     <description>AES Key Pointer and Status.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>PTR</name>
+       <description>AESKEY Pointer and Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADC_CFG0</name>
+     <description>ADC Cfig Register0.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>LP_5K_DIS</name>
+       <description>Disable 5K divider option in low power modes</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LP_50K_DIS</name>
+       <description>Disable 50K divider option in low power modes</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXT_REF</name>
+       <description>External Reference</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>REF_SEL</name>
+       <description>Reference Select</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADC_CFG1</name>
+     <description>ADC Config Register1.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>CH0_PU_DYN</name>
+       <description>ADC PU Dynamic Control for CH0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>divider select always used.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>divider select only used when channel is selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0_PU_DYN">
+       <name>CH1_PU_DYN</name>
+       <description>ADC PU Dynamic Control for CH1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_PU_DYN">
+       <name>CH2_PU_DYN</name>
+       <description>ADC PU Dynamic Control for CH2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_PU_DYN">
+       <name>CH3_PU_DYN</name>
+       <description>ADC PU Dynamic Control for CH3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_PU_DYN">
+       <name>CH4_PU_DYN</name>
+       <description>ADC PU Dynamic Control for CH4</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_PU_DYN">
+       <name>CH5_PU_DYN</name>
+       <description>ADC PU Dynamic Control for CH5</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_PU_DYN">
+       <name>CH6_PU_DYN</name>
+       <description>ADC PU Dynamic Control for CH6</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_PU_DYN">
+       <name>CH7_PU_DYN</name>
+       <description>ADC PU Dynamic Control for CH7</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_PU_DYN">
+       <name>CH8_PU_DYN</name>
+       <description>ADC PU Dynamic Control for CH8</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_PU_DYN">
+       <name>CH9_PU_DYN</name>
+       <description>ADC PU Dynamic Control for CH9</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_PU_DYN">
+       <name>CH10_PU_DYN</name>
+       <description>ADC PU Dynamic Control for CH10</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_PU_DYN">
+       <name>CH11_PU_DYN</name>
+       <description>ADC PU Dynamic Control for CH11</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0_PU_DYN">
+       <name>CH12_PU_DYN</name>
+       <description>ADC PU Dynamic Control for CH12</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADC_CFG2</name>
+     <description>ADC Config Register2.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Divider Select for channel 0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Pass through, no divider.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2_5k</name>
+         <description>Divide by 2, 5Kohm.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2_50k</name>
+         <description>Divide by 2, 50Kohm.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <description>Divider Select for channel 1</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <description>Divider Select for channel 2</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <description>Divider Select for channel 3</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH4</name>
+       <description>Divider Select for channel 4</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH5</name>
+       <description>Divider Select for channel 5</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH6</name>
+       <description>Divider Select for channel 6</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH7</name>
+       <description>Divider Select for channel 7</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH8</name>
+       <description>Divider Select for channel 8</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH9</name>
+       <description>Divider Select for channel 9</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH10</name>
+       <description>Divider Select for channel 10</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH11</name>
+       <description>Divider Select for channel 11</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH12</name>
+       <description>Divider Select for channel 12</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADC_CFG3</name>
+     <description>ADC Config Register3.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>VREFM</name>
+       <description>VREFM</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VREFP</name>
+       <description>VREFP</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>IDRV</name>
+       <description>IDRV</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>VCM</name>
+       <description>VCM</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>ATB</name>
+       <description>ATB</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>D_IBOOST</name>
+       <description>D_IBOOST</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--MCR Misc Control.-->
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x40106800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>LPCN</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0RET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 0 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM1RET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 1 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM2RET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 2 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM3RET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OVR</name>
+       <description>Operating Voltage Range</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_9V</name>
+         <description>0.9V 12MHz</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0V</name>
+         <description>1.0V 48MHz</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1V</name>
+         <description>1.1V 96MHz</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORE_DET_BYPASS</name>
+       <description>Block Auto-Detect</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FVDDEN</name>
+       <description>Flash VDD Enable, force the flash VDD to remain enabled during LP modes.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>enable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>disable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RETREG_EN</name>
+       <description>Retention Regulator Enable. This bit controls the retention regulator in BACKUP mode. </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STORAGE_EN</name>
+       <description>STORAGE Mode ENable. This bit allows low-power background mode operations, while the CPU is in DeepSleep.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FASTWK_EN</name>
+       <description>Fast Wake-Up Mode. This bit enables fast wake-up from DeepSleep mode. (5uS typical). </description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BG_DIS</name>
+       <description>Bandgap OFF. This controls the System Bandgap in DeepSleep mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>Bandgap is always ON.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>Bandgap is OFF in DeepSleep mode (default).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREPOR_DIS</name>
+       <description>VDDC (Vcore) Power on reset Monitor Disable.This bit controls the Power-On Reset monitor on VDDC supply in DeepSleep and BACKUP mode.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDO_DIS</name>
+       <description>Disable Main LDO</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORE_EXT</name>
+       <description>Use external VCORE for 1V supply</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>use Vcore for retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREMON_DIS</name>
+       <description>VDDC (Vcore) Monitor Disable. This bit controls the power monitor on the VCore supply in all operating modes.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDAMON_DIS</name>
+       <description>VDDA Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PORVDDMON_DIS</name>
+       <description>VDDIO Power-On Reset Monitor Disable. This bit controls the Power-On Reset monitor on VDDIO supply in all operating mods.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VBBMON_DIS</name>
+       <description>VBB Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INRO_EN</name>
+       <description>INRO remains on in all power modes if this bit is set otherwise it is controled by the LP controller</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>XRTCO remains on in all power modes if this bit is set otherwise it is controled by the LP controller</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TM_LPMODE</name>
+       <description>TBD</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TM_PWRSEQ</name>
+       <description>TBD</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST0</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO0.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN0</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register derivedFrom="LPWKST0">
+     <name>LPWKST1</name>
+     <description>Low Power I/O Wakeup Status Register 1. This register indicates the low power wakeup status for GPIO1.</description>
+     <addressOffset>0x0C</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN1</name>
+     <description>Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup functionality for GPIO1.</description>
+     <addressOffset>0x10</addressOffset>
+    </register>
+    <register>
+     <name>LPPWKST</name>
+     <description>Low Power Peripheral Wakeup Status Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>LPTMR0</name>
+       <description>LPTM0 Wakeup Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>LPTMR1</name>
+       <description>LPTMR1 Wakeup Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>LPUART0</name>
+       <description>LPUART0 Wakeup Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>AINCOMP0</name>
+       <description>AINCOMP0 Wakeup Flag.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>AINCOMP1</name>
+       <description>AINCOMP1 Wakeup Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>AINCOMP0_OUT</name>
+       <description>AINCOMP0 Status.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>AINCOMP1_OUT</name>
+       <description>AINCOMP1 Status.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BACKUP</name>
+       <description>BBMODE Wakeup Flag.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWKEN</name>
+     <description>Low Power Peripheral Wakeup Enable Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>LPTMR0</name>
+       <description> TIMER4 Wakeup Enable. This bit allows wakeup from the TIMER4.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>LPTMR1</name>
+       <description> TIMER5 Wakeup Enable. This bit allows wakeup from the TIMER5.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>LPUART0</name>
+       <description> LPUART Wakeup Enable. This bit allows wakeup from the LPUART.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>AINCOMP0</name>
+       <description> AINCOMP0 Wakeup Enable. This bit allows wakeup from the AINCOMP0.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>AINCOMP1</name>
+       <description> AINCOMP1 Wakeup Enable. This bit allows wakeup from the AINCOMP1.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPMEMSD</name>
+     <description>Low Power Memory Shutdown Control.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM block 0 Shut Down.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>System RAM block 1 Shut Down.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>System RAM block 2 Shut Down.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>System RAM block 3 Shut Down.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPR0</name>
+     <description>General Purpose Register 0.</description>
+     <addressOffset>0x48</addressOffset>
+    </register>
+    <register>
+     <name>GPR1</name>
+     <description>General Purpose Register 1.</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--PWRSEQ Power Sequencer / Low Power Control Register.-->
+  <peripheral>
+   <name>QDEC</name>
+   <description>Quadrature Encoder Interface</description>
+   <baseAddress>0x40063000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <fields>
+      <field>
+       <name>en</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <name>enum</name>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0x0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <value>0x1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>mode</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <name>enum</name>
+        <enumeratedValue>
+         <name>x1mode</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>x2mode</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>x4mode</name>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>swap</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>filter</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <name>enum</name>
+        <enumeratedValue>
+         <name>1_sample</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_samples</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_samples</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_samples</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>rst_index</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>rst_maxcnt</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>sticky</name>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>psc</name>
+       <bitOffset>16</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <name>enum</name>
+        <enumeratedValue>
+         <name>div1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Interrupt Flag Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>index</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>qerr</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>compare</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>maxcnt</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>capture</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>dir</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>move</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>index</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>qerr</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>compare</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>maxcnt</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>capture</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>dir</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>move</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAXCNT</name>
+     <description>Maximum Count Register.</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>maxcnt</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INITIAL</name>
+     <description>Initial Count Register.</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>initial</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>COMPARE</name>
+     <description>Compare Register.</description>
+     <addressOffset>0x0014</addressOffset>
+     <fields>
+      <field>
+       <name>compare</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INDEX</name>
+     <description>Index Register. count captured when QEI fired</description>
+     <addressOffset>0x0018</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>index</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CAPTURE</name>
+     <description>Capture Register. counter captured when QES fired</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>capture</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x0020</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>dir</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>POSITION</name>
+     <description>Count Register. raw counter value</description>
+     <addressOffset>0x0024</addressOffset>
+     <fields>
+      <field>
+       <name>position</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CAPDLY</name>
+     <description>delay CAPTURE</description>
+     <addressOffset>0x0028</addressOffset>
+     <fields>
+      <field>
+       <name>capdly</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--QDEC Quadrature Encoder Interface-->
+  <peripheral>
+   <name>RTC</name>
+   <description>Real Time Clock and Alarm.</description>
+   <baseAddress>0x40106000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>RTC</name>
+    <description>RTC interrupt.</description>
+    <value>3</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC</name>
+       <description>Sub-Seconds Counter (12-bit).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TODA</name>
+     <description>Time-of-day Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-day Alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSECA</name>
+     <description>RTC sub-second alarm.  This register contains the reload value for the sub-second alarm.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>This register contains the reload value for the sub-second alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>RTC Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Real Time Clock Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM_IE</name>
+       <description>Alarm Time-of-Day Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM_IE</name>
+       <description>Alarm Sub-second Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>RTC Busy. This bit is set to 1 by hardware when changes to RTC registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>RTC Ready. This bit is set to 1 by hardware when the RTC count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the RTC count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY_IE</name>
+       <description>RTC Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-Day Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>Sub-second Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_SEL</name>
+       <description>Frequency Output Selection. When SQE=1, these bits specify the output frequency on the SQW pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq1Hz</name>
+         <description>1 Hz (Compensated).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq512Hz</name>
+         <description>512 Hz (Compensated).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq4KHz</name>
+         <description>4 KHz.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clkDiv8</name>
+         <description>RTC Input Clock / 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_EN</name>
+       <description>Asynchronous Counter Read Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_EN</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical RTC bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIM</name>
+     <description>RTC Trim Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>RTC Trim. This register contains the 2's complement value that specifies the trim resolution. Each increment or decrement of the bit adds or subtracts 1ppm at each 4KHz clock value, with a maximum correction of +/- 127ppm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VRTC_TMR</name>
+       <description>VBAT Timer Value. When RTC is running off of VBAT, this field is incremented every 32 seconds.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>RTC Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>FILTER_EN</name>
+       <description>Enables analog deglitch filter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_SEL</name>
+       <description>If IBIAS_EN is 1, selects 4x,2x mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HYST_EN</name>
+       <description>Enables high current hysteresis buffer.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_EN</name>
+       <description>Enables higher 4x,2x current modes.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYPASS</name>
+       <description>RTC Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SQW_32K</name>
+       <description>RTC 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--RTC Real Time Clock and Alarm.-->
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x40000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>STATUS</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CFG_VALID</name>
+       <description>Configuration Valid Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CFG_ERR</name>
+       <description>Configuration Error Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>USER_CFG_ERR</name>
+       <description>User Configuration Error Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADDR</name>
+     <description>Read-only field set by the SIB block if a CRC error occurs during the read of the OTP memory. Contains the failing address in OTP memory (when CRCERR equals 1).</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FSTAT</name>
+     <description>Function Status Register.</description>
+     <addressOffset>0x100</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>FPU</name>
+       <description>FPU Function.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRNG</name>
+       <description>TRNG Function.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DS_ACK</name>
+       <description>DeepSleep Acknowledge.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFSTAT</name>
+     <description>Security Function Status Register.</description>
+     <addressOffset>0x104</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SECFUNC0</name>
+       <description>Secure Function 0 Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIR System Initialization Registers.-->
+  <peripheral>
+   <name>SPI0</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x40046000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>16</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FIFO32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>FIFO16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>FIFO8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Start Select Control. Used in Master mode to control the behavior of the Slave Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DEASSERT</name>
+         <description>SPI De-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ASSERT</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_ACTIVE</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3</name>
+         <description>SS3 is selected.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Rising_Edge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Falling_Edge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLK_FB_INV</name>
+       <description>SCLK_FB_INV.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin (s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_POL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3_high</name>
+         <description>SS3 active high.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSTIME</name>
+     <description>Register for controlling SPI peripheral/Slave Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PRE</name>
+       <description>Slave Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POST</name>
+       <description>Slave Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPI0 SPI peripheral.-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI1</name>
+   <description>SPI peripheral. 1</description>
+   <baseAddress>0x40047000</baseAddress>
+   <interrupt>
+    <name>SPI1</name>
+    <description>SPI1 IRQ</description>
+    <value>17</value>
+   </interrupt>
+  </peripheral>
+<!--SPI1 SPI peripheral. 1-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI2</name>
+   <description>SPI peripheral. 2</description>
+   <baseAddress>0x40048000</baseAddress>
+   <interrupt>
+    <name>SPI2</name>
+    <description>SPI2 IRQ</description>
+    <value>18</value>
+   </interrupt>
+  </peripheral>
+<!--SPI2 SPI peripheral. 2-->
+  <peripheral>
+   <name>TMR</name>
+   <description>Low-Power Configurable Timer</description>
+   <baseAddress>0x40010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR</name>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Timer Counter Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>The current count value for the timer. This field increments as the timer counts.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Timer Compare Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>Timer PWM Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PWM</name>
+       <description>Timer PWM Match:
+                In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
+                In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Timer Interrupt Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ_A</name>
+       <description>Interrupt Flag for Timer A.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_A</name>
+       <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_A</name>
+       <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IRQ_B</name>
+       <description>Interrupt Flag for Timer B.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_B</name>
+       <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_B</name>
+       <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MODE_A</name>
+       <description>Mode Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_A</name>
+       <description>Clock Divider Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_A</name>
+       <description>Timer Polarity for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_A</name>
+       <description>PWM Synchronization Mode for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_A</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_A</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_A</name>
+       <description>PWM Phase A-Prime Output Disable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_A</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Write 1 to Enable CLK_TMR for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_A</name>
+       <description>Enable for Timer A</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MODE_B</name>
+       <description>Mode Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_B</name>
+       <description>Clock Divider Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_B</name>
+       <description>Timer Polarity for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_B</name>
+       <description>PWM Synchronization Mode for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_B</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_B</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_B</name>
+       <description>PWM Phase A-Prime Output Disable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_B</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Write 1 to Enable CLK_TMR for Timer B</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_B</name>
+       <description>Enable for Timer B</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO_A</name>
+       <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_A</name>
+       <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>LO_B</name>
+       <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_B</name>
+       <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Timer Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKSEL_A</name>
+       <description>Timer Clock Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Timer A Enable Status</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_A</name>
+       <description>CLK_TMR Ready Flag for Timer A</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_A</name>
+       <description>Event Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_A</name>
+       <description>Negative Edge Trigger for Event for Timer A</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_A</name>
+       <description>Interrupt Enable for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_A</name>
+       <description>Capture Event Select for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_A</name>
+       <description>Software Capture Event for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_A</name>
+       <description>Wake-Up Enable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTEN_A</name>
+       <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTBEN_A</name>
+       <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads to the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKSEL_B</name>
+       <description>Timer Clock Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Timer B Enable Status</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_B</name>
+       <description>CLK_TMR Ready Flag for Timer B</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_B</name>
+       <description>Event Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_B</name>
+       <description>Negative Edge Trigger for Event for Timer B</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_B</name>
+       <description>Interrupt Enable for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_B</name>
+       <description>Capture Event Select for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_B</name>
+       <description>Software Capture Event for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_B</name>
+       <description>Wake-Up Enable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CASCADE</name>
+       <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Timer Wakeup Status Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>A</name>
+       <description>Wake-Up Flag for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>B</name>
+       <description>Wake-Up Flag for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TMR Low-Power Configurable Timer-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR1</name>
+   <description>Low-Power Configurable Timer 1</description>
+   <baseAddress>0x40011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+<!--TMR1 Low-Power Configurable Timer 1-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR2</name>
+   <description>Low-Power Configurable Timer 2</description>
+   <baseAddress>0x40012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+<!--TMR2 Low-Power Configurable Timer 2-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR3</name>
+   <description>Low-Power Configurable Timer 3</description>
+   <baseAddress>0x40013000</baseAddress>
+   <interrupt>
+    <name>TMR3</name>
+    <description>TMR3 IRQ</description>
+    <value>8</value>
+   </interrupt>
+  </peripheral>
+<!--TMR3 Low-Power Configurable Timer 3-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR4</name>
+   <description>Low-Power Configurable Timer 4</description>
+   <baseAddress>0x40114000</baseAddress>
+   <interrupt>
+    <name>TMR4</name>
+    <description>TMR4 IRQ</description>
+    <value>9</value>
+   </interrupt>
+  </peripheral>
+<!--TMR4 Low-Power Configurable Timer 4-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR5</name>
+   <description>Low-Power Configurable Timer 5</description>
+   <baseAddress>0x40115000</baseAddress>
+   <interrupt>
+    <name>TMR5</name>
+    <description>TMR5 IRQ</description>
+    <value>10</value>
+   </interrupt>
+  </peripheral>
+<!--TMR5 Low-Power Configurable Timer 5-->
+  <peripheral>
+   <name>TRIMSIR</name>
+   <description>Trim System Initilazation Registers</description>
+   <baseAddress>0x40105400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>BB_SIR2</name>
+     <description>System Init. Configuration Register 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TRIM_IBRO_RBIAS</name>
+       <description>HIRC8M Trim</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RAM0_1ECCEN</name>
+       <description>RAM 0 and RAM 1 ECC Enable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>ECC Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>ECC Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0_1ECCEN">
+       <name>RAM2ECCEN</name>
+       <description>RAM 2 ECC Enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0_1ECCEN">
+       <name>RAM3ECCEN</name>
+       <description>RAM 3 ECC Enable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0_1ECCEN">
+       <name>ICC0ECCEN</name>
+       <description>ICC 0 ECC Enable</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0_1ECCEN">
+       <name>FL0ECCEN</name>
+       <description>Flash 0 ECC Enable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0_1ECCEN">
+       <name>FL1ECCEN</name>
+       <description>Flash 1 ECC Enable</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRIM_IBRO</name>
+       <description>HIRC8M Trim</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BB_SIR3</name>
+     <description>System Init. Configuration Register 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>BB_SIR6</name>
+     <description>System Init. Configuration Register 6.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RTCX1TRIM</name>
+       <description>RTCX1 Trim</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RTCX2TRIM</name>
+       <description>RTCX2 Trim</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRIMSIR Trim System Initilazation Registers-->
+  <peripheral>
+   <name>TRNG</name>
+   <description>Random Number Generator.</description>
+   <baseAddress>0x4004D000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TRNG</name>
+    <description>TRNG interrupt.</description>
+    <value>4</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>TRNG Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000003</resetValue>
+     <fields>
+      <field>
+       <name>ODHT</name>
+       <description>Start On-Demand health test.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RND_IE</name>
+       <description>To enable IRQ generation when a new 32-bit Random number is ready.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HEALTH_EN</name>
+       <description>Enable IRQ generation when a health test fails.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AESKG_USR</name>
+       <description>AES Key Generate. When enabled, the key for securing NVSRAM is generated and transferred to the secure key register automatically without user visibility or intervention. This bit is cleared by hardware once the key has been transferred to the secure key register.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AESKG_SYS</name>
+       <description>AESKG_SYS.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>To wipe the Battery Backed key.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>RDY</name>
+       <description>32-bit random data is ready to read from TRNG_DATA register. Reading TRNG_DATA when RND_RDY=0 will return all 0's. IRQ is generated when RND_RDY=1 if TRNG_CN.RND_IRQ_EN=1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Busy</name>
+         <description>TRNG Busy</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Ready</name>
+         <description>32 bit random data is ready</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ODHT</name>
+       <description>On-Demand health test status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HT</name>
+       <description>Health test status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRCFAIL</name>
+       <description>Entropy source has failed.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AESKGD</name>
+       <description>AESKGD.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LD_CNT</name>
+       <description>LD_CNT.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data. The content of this register is valid only when RNG_IS =1. When TNRG is disabled, read returns 0x0000 0000.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRNG Random Number Generator.-->
+  <peripheral>
+   <name>UART</name>
+   <description>UART Low Power Registers</description>
+   <baseAddress>0x40042000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control register</description>
+     <addressOffset>0x0000</addressOffset>
+     <fields>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>This field specifies the depth of receive FIFO for interrupt generation (value 0 and &gt; 16 are ignored) </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EN</name>
+       <description>Parity Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EO</name>
+       <description>when PAREN=1 selects odd or even parity odd is 1 even is 0</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_MD</name>
+       <description>Selects parity based on 1s or 0s count (when PAREN=1) </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_DIS</name>
+       <description>CTS Sampling Disable </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Flushes the TX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Flushes the RX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHAR_SIZE</name>
+       <description>Selects UART character size</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5bits</name>
+         <description>5 bits</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6bits</name>
+         <description>6 bits</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7bits</name>
+         <description>7 bits</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8bits</name>
+         <description>8 bits</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPBITS</name>
+       <description>Selects the number of stop bits that will be generated</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HFC_EN</name>
+       <description>Enables/disables hardware flow control</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RTSDC</name>
+       <description>Hardware Flow Control RTS Mode</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKEN</name>
+       <description>Baud clock enable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKSRC</name>
+       <description>To select the UART clock source for the UART engine (except APB registers). Secondary clock (used for baud rate generator) can be asynchronous from APB clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Peripheral_Clock</name>
+         <description>apb clock</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK1</name>
+         <description>Clock 1</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK2</name>
+         <description>Clock 2</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK3</name>
+         <description>Clock 3</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPFE_EN</name>
+       <description>Data/Parity bit frame error detection enable</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKRDY</name>
+       <description>Baud clock Ready read only bit</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UCAGM</name>
+       <description>UART Clock Auto Gating mode</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FDM</name>
+       <description>Fractional Division Mode</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DESM</name>
+       <description>RX Dual Edge Sampling Mode</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TX_BUSY</name>
+       <description>Read-only flag indicating the UART transmit status</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_BUSY</name>
+       <description>Read-only flag indicating the UART receiver status</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Indicates the number of bytes currently in the RX FIFO (0-RX FIFO_ELTS) </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Indicates the number of bytes currently in the TX FIFO (0-TX FIFO_ELTS) </description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interrupt Enable control register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Enable Interrupt For RX Frame Error</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Enable Interrupt For RX Parity Error</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Enable Interrupt For CTS signal change Error</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Enable Interrupt For RX FIFO Overrun Error</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Enable Interrupt For RX FIFO reaches the number of bytes configured by RXTHD</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Enable Interrupt For TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Enable Interrupt For TX FIFO has half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Interrupt status flags Control register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Flag for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Flag for RX Parity Error interrupt</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Flag for CTS signal change interrupt (hardware flow control disabled) </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Flag for RX FIFO Overrun interrupt</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Flag for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Flag for interrupt when TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Flag for interrupt when TX FIFO is half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Clock Divider register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Baud rate divisor value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSR</name>
+     <description>Over Sampling Rate register</description>
+     <addressOffset>0x0014</addressOffset>
+     <fields>
+      <field>
+       <name>OSR</name>
+       <description>OSR</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXPEEK</name>
+     <description>TX FIFO Output Peek register</description>
+     <addressOffset>0x0018</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read TX FIFO next data. Reading from this field does not affect the contents of TX FIFO. Note that the parity bit is available from this field.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PNR</name>
+     <description> Pin register</description>
+     <addressOffset>0x001C</addressOffset>
+     <fields>
+      <field>
+       <name>CTS</name>
+       <description>Current sampled value of CTS IO</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RTS</name>
+       <description>This bit controls the value to apply on the RTS IO. If set to 1, the RTS IO is set to high level. If set to 0, the RTS IO is set to low level.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Read/Write register</description>
+     <addressOffset>0x0020</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Parity error flag for next byte to be read from FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration register</description>
+     <addressOffset>0x0030</addressOffset>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger If the TX FIFO level is less than this value, then the TX FIFO DMA interface will send a signal to system DMA to notify that TX FIFO is ready to receive data from memory.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX DMA channel enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Rx FIFO Level DMA Trigger If the RX FIFO level is greater than this value, then the RX FIFO DMA interface will send a signal to the system DMA to notify that RX FIFO has characters to transfer to memory.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX DMA channel enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wake up enable Control register</description>
+     <addressOffset>0x0034</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Enable for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Enable for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Enable for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wake up Flags register</description>
+     <addressOffset>0x0038</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Flag for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Flag for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Flag for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--UART UART Low Power Registers-->
+  <peripheral derivedFrom="UART">
+   <name>UART1</name>
+   <description>UART Low Power Registers 1</description>
+   <baseAddress>0x40043000</baseAddress>
+  </peripheral>
+<!--UART1 UART Low Power Registers 1-->
+  <peripheral derivedFrom="UART">
+   <name>UART2</name>
+   <description>UART Low Power Registers 2</description>
+   <baseAddress>0x40044000</baseAddress>
+  </peripheral>
+<!--UART2 UART Low Power Registers 2-->
+  <peripheral derivedFrom="UART">
+   <name>UART3</name>
+   <description>UART Low Power Registers 3</description>
+   <baseAddress>0x40145000</baseAddress>
+  </peripheral>
+<!--UART3 UART Low Power Registers 3-->
+  <peripheral>
+   <name>WDT</name>
+   <description>Windowed Watchdog Timer</description>
+   <baseAddress>0x40003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WWDT</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INT_LATE_VAL</name>
+       <description>Windowed Watchdog Interrupt Upper Limit. Sets the number of WDTCLK cycles until a windowed watchdog timer interrupt is generated (if enabled) if the CPU does not write the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE_VAL</name>
+       <description>Windowed Watchdog Reset Upper Limit. Sets the number of WDTCLK cycles until a system reset occurs (if enabled) if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Windowed Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_LATE</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Late.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_INT_EN</name>
+       <description>Windowed Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_RST_EN</name>
+       <description>Windowed Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Soon.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY_VAL</name>
+       <description>Windowed Watchdog Interrupt Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A windowed watchdog timer interrupt is generated (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY_VAL</name>
+       <description>Windowed Watchdog Reset Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A system reset occurs (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKRDY_IE</name>
+       <description>Switch Ready Interrupt Enable. Fires an interrupt when it is safe to swithc the clock.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY</name>
+       <description>Clock Status.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WIN_EN</name>
+       <description>Enables the Windowed Watchdog Function.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Windowed Mode Disabled (i.e. Compatibility Mode).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Windowed Mode Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Soon.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Late.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Windowed Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>RESET</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD_UPPER_LIMIT then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD_UPPER_LIMIT then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKSEL</name>
+     <description>Windowed Watchdog Timer Clock Select Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SOURCE</name>
+       <description>WWDT Clock Selection Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CNT</name>
+     <description>Windowed Watchdog Timer Count Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Current Value of the Windowed Watchdog Timer Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WDT Windowed Watchdog Timer-->
+  <peripheral derivedFrom="WDT">
+   <name>WDT1</name>
+   <description>Windowed Watchdog Timer 1</description>
+   <baseAddress>0x40003400</baseAddress>
+   <interrupt>
+    <name>WDT1</name>
+    <description>WDT1 IRQ</description>
+    <value>57</value>
+   </interrupt>
+  </peripheral>
+<!--WDT1 Windowed Watchdog Timer 1-->
+ </peripherals>
+</device>

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.svd
@@ -1,0 +1,9983 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max32675</name>
+ <series>ARMCM4</series>
+ <version>1.0</version>
+ <description>MAX32675 32-bit ARM Cortex-M4 microcontroller, 1024KB of flash, 760KB of system RAM, 128KB of Boot ROM.</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>AESKEYS</name>
+   <description>AES Key Registers.</description>
+   <baseAddress>0x40007800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>KEY0</name>
+     <description>AES Key 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY1</name>
+     <description>AES Key 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY2</name>
+     <description>AES Key 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY3</name>
+     <description>AES Key 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY4</name>
+     <description>AES Key 4.</description>
+     <addressOffset>0x10</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY5</name>
+     <description>AES Key 5.</description>
+     <addressOffset>0x14</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY6</name>
+     <description>AES Key 6.</description>
+     <addressOffset>0x18</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY7</name>
+     <description>AES Key 7.</description>
+     <addressOffset>0x1C</addressOffset>
+     <size>32</size>
+    </register>
+   </registers>
+  </peripheral>
+<!--AESKEYS AES Key Registers.-->
+  <peripheral>
+   <name>AES</name>
+   <description>AES Keys.</description>
+   <baseAddress>0x40007400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>AES Control Register</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>AES Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>DMA Request To Read Data Output FIFO</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>DMA Request To Write Data Input FIFO</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start AES Calculation</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FLUSH</name>
+       <description>Flush the data input FIFO</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FLUSH</name>
+       <description>Flush the data output FIFO</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_SIZE</name>
+       <description>Encryption Key Size</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AES128</name>
+         <description>128 Bits.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES192</name>
+         <description>192 Bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES256</name>
+         <description>256 Bits.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TYPE</name>
+       <description>Encryption Type Selection</description>
+       <bitRange>[9:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>AES Status Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>AES Busy Status</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_EM</name>
+       <description>Data input FIFO empty status</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FULL</name>
+       <description>Data input FIFO full status</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_EM</name>
+       <description>Data output FIFO empty status</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FULL</name>
+       <description>Data output FIFO full status</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>AES Interrupt Flag Register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>AES Interrupt Enable Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>AES Data Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>AES FIFO</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--AES AES Keys.-->
+  <peripheral>
+   <name>CRC</name>
+   <description>CRC Registers.</description>
+   <baseAddress>0x4000F000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>CRC Control</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>CRC Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_EN</name>
+       <description>DMA Request Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB</name>
+       <description>MSB Select</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BYTE_SWAP_IN</name>
+       <description>Byte Swap CRC Data Input</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BYTE_SWAP_OUT</name>
+       <description>Byte Swap CRC Value Output</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>CRC Busy</description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN32</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN16</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN8</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>POLY</name>
+     <description>CRC Polynomial</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>POLY</name>
+       <description>CRC Polynomial</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VAL</name>
+     <description>Current CRC Value</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>VALUE</name>
+       <description>Current CRC Value</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CRC CRC Registers.-->
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0</name>
+    <value>28</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1</name>
+    <value>29</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA2</name>
+    <value>30</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA3</name>
+    <value>31</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA4</name>
+    <value>68</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA5</name>
+    <value>69</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA6</name>
+    <value>70</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA7</name>
+    <value>71</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA8</name>
+    <value>72</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA9</name>
+    <value>73</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA10</name>
+    <value>74</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA11</name>
+    <value>75</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA12</name>
+    <value>76</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA13</name>
+    <value>77</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA14</name>
+    <value>78</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA15</name>
+    <value>79</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>INTEN</name>
+     <description>DMA Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel 0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <description>Channel 1 Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <description>Channel 2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <description>Channel 3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH4</name>
+       <description>Channel 4 Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH5</name>
+       <description>Channel 5 Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH6</name>
+       <description>Channel 6 Interrupt Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH7</name>
+       <description>Channel 7 Interrupt Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>DMA Interrupt Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel Interrupt. To clear an interrupt, all active interrupt bits of the DMA_ST must be cleared. The interrupt bits are set only if their corresponding interrupt enable bits are set in DMA_CN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>8</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CTRL</name>
+      <description>DMA Channel Control Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>EN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQUEST</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0RX</name>
+          <description>SPI0 RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1RX</name>
+          <description>SPI1 RX</description>
+          <value>0x02</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI2RX</name>
+          <description>SPI2 RX</description>
+          <value>0x03</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0RX</name>
+          <description>UART0 RX</description>
+          <value>0x04</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1RX</name>
+          <description>UART1 RX</description>
+          <value>0x05</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0RX</name>
+          <description>I2C0 RX</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1RX</name>
+          <description>I2C1 RX</description>
+          <value>0x08</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2RX</name>
+          <description>I2C2 RX</description>
+          <value>0x0A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2RX</name>
+          <description>UART2 RX</description>
+          <value>0x0E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI3RX</name>
+          <description>SPI3 RX</description>
+          <value>0x0F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESRX</name>
+          <description>AES RX</description>
+          <value>0x10</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3RX</name>
+          <description>UART3 RX</description>
+          <value>0x1C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2SRX</name>
+          <description>I2S RX</description>
+          <value>0x1E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0TX</name>
+          <description>SPI0 TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1TX</name>
+          <description>SPI1 TX</description>
+          <value>0x22</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI2TX</name>
+          <description>SPI2 TX</description>
+          <value>0x23</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0TX</name>
+          <description>UART0 TX</description>
+          <value>0x24</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1TX</name>
+          <description>UART1 TX</description>
+          <value>0x25</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0TX</name>
+          <description>I2C0 TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1TX</name>
+          <description>I2C1 TX</description>
+          <value>0x28</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2TX</name>
+          <description>I2C2 TX</description>
+          <value>0x2A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>CRCTX</name>
+          <description>CRC TX</description>
+          <value>0x2C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2TX</name>
+          <description>UART2 TX</description>
+          <value>0x2E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI3TX</name>
+          <description>SPI3 TX</description>
+          <value>0x2F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESTX</name>
+          <description>AES TX</description>
+          <value>0x30</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3TX</name>
+          <description>UART3 TX</description>
+          <value>0x3C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2STX</name>
+          <description>I2S TX</description>
+          <value>0x3E</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_WAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_PER</name>
+        <description>Timeout Period Select.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_CLKDIV</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BURST_SIZE</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>DIS_IE</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IE</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>STATUS</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>STATUS</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IF</name>
+        <description>Count-to-Zero (CTZ) Interrupt Flag</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>RLD_IF</name>
+        <description>Reload Event Interrupt Flag.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>TO_IF</name>
+        <description>Time-Out Event Interrupt Flag.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRCRLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DSTRLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNTRLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>EN</name>
+        <description>Reload Enable. This bit should be set after the address reload registers have been programmed. This bit is automatically cleared to 0 when reload occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+<!--DMA DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral>
+   <name>FCR</name>
+   <description>Function Control Register.</description>
+   <baseAddress>0x40000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>FCTRL0</name>
+     <description>Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ERFO_RANGE_SEL</name>
+       <description>14MHz-32MHz ERFO Frequency Range Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>I2C0_SDA_FILTER_EN</name>
+       <description>I2C0 SDA Glitch Filter Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0_SCL_FILTER_EN</name>
+       <description>I2C0 SCL Glitch Filter Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1_SDA_FILTER_EN</name>
+       <description>I2C1 SDA Glitch Filter Enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1_SCL_FILTER_EN</name>
+       <description>I2C1 SCL Glitch Filter Enable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2_SDA_FILTER_EN</name>
+       <description>I2C2 SDA Glitch Filter Enable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2_SCL_FILTER_EN</name>
+       <description>I2C2 SCL Glitch Filter Enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Filter disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Filter enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL0</name>
+     <description>Register 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SEL</name>
+       <description>Auto-calibration Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Autocalibration Run.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOAD</name>
+       <description>Load Trim.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INVERT</name>
+       <description>Invert Gain.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ATOMIC</name>
+       <description>Atomic mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GAIN</name>
+       <description>MU value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>TRIM</name>
+       <description>150MHz HFIO Auto Calibration Trim</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL1</name>
+     <description>Register 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INITIAL</name>
+       <description>100MHz IPO Trim Automatic Calibration Initial Trim.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL2</name>
+     <description>Register 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RUNTIME</name>
+       <description>100MHz IPO Trim Automatic Calibration Run Time.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>DIV</name>
+       <description>100MHz IPO Trim Automatic Calibration Divide Factor.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FCR Function Control Register.-->
+  <peripheral>
+   <name>FLC</name>
+   <description>Flash Memory Control.</description>
+   <prependToName>FLSH_</prependToName>
+   <baseAddress>0x40029000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Flash_Controller</name>
+    <description>Flash Controller interrupt.</description>
+    <value>23</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ADDR</name>
+     <description>Flash Write Address.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address for next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Flash Clock Divide. The clock (PLL0) is divided by this value to generate a 1 MHz clock for Flash controller.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000064</resetValue>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Flash Clock Divide. The clock is divided by this value to generate a 1MHz clock for flash controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Flash Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WR</name>
+       <description>Write.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="WR">
+       <name>ME</name>
+       <description>Mass Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="WR">
+       <name>PGE</name>
+       <description>Page Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERASE_CODE</name>
+       <description>Erase Code.  The ERASE_CODE must be set up property before erase operation can be initiated. These bits are automatically cleared after the operation is complete.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>erasePage</name>
+         <description>Enable Page Erase.</description>
+         <value>0x55</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>eraseAll</name>
+         <description>Enable Mass Erase. The debug port must be enabled.</description>
+         <value>0xAA</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PEND</name>
+       <description>Flash Pending.  When Flash operation is in progress (busy), Flash reads and writes will fail. When PEND is set, write to all Flash registers, with exception of the Flash interrupt register, are ignored.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LVE</name>
+       <description>Low Voltage enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNLOCK</name>
+       <description>Flash Unlock.  The correct unlock code must be written to these four bits before any Flash write or erase operation is allowed.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Flash Unlocked.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Flash Locked.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Flash Interrupt Register.</description>
+     <addressOffset>0x024</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Flash Done Interrupt.  This bit is set to 1 upon Flash write or erase completion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AF</name>
+       <description>Flash Access Fail.  This bit is set when an attempt is made to write the flash while the flash is busy or the flash is locked. This bit can only be set to 1 by hardware.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONEIE</name>
+       <description>Flash Done Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DONEIE">
+       <name>AFIE</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCDATA</name>
+     <description>ECC Data Register.</description>
+     <addressOffset>0x028</addressOffset>
+     <fields>
+      <field>
+       <name>EVEN</name>
+       <description>Error Correction Code Odd Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>ODD</name>
+       <description>Error Correction Code Even Data.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA[%s]</name>
+     <description>Flash Write Data.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACTRL</name>
+     <description>Access Control Register. Writing the ACTRL register with the following values in the order shown, allows read and write access to the system and user Information block:
+    pflc-actrl = 0x3a7f5ca3;
+    pflc-actrl = 0xa1e34f20;
+    pflc-actrl = 0x9608b2c1. When unlocked, a write of any word will disable access to system and user information block. Readback of this register is always zero.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ACTRL</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR0</name>
+     <description>WELR0</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>WELR0</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR1</name>
+     <description>WELR1</description>
+     <addressOffset>0x88</addressOffset>
+     <fields>
+      <field>
+       <name>WELR1</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR0</name>
+     <description>RLR0</description>
+     <addressOffset>0x90</addressOffset>
+     <fields>
+      <field>
+       <name>RLR0</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR1</name>
+     <description>RLR1</description>
+     <addressOffset>0x98</addressOffset>
+     <fields>
+      <field>
+       <name>RLR1</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FLC Flash Memory Control.-->
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x40000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SYSCTRL</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>SBUSARB</name>
+       <description>System bus abritration scheme. These bits are used to select between Fixed-burst abritration and Round-Robin scheme. The Round-Robin scheme is selected by default. These bits are reset by the system reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>fix</name>
+         <description>Fixed Burst abritration.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>round</name>
+         <description>Round-robin scheme.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FPU_DIS</name>
+       <description>Cortex M4 Floating Point Disable This bit is used to disable the floating-point unit of the Cortex-M4</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0_FLUSH</name>
+       <description>Code Cache Flush. This bit is used to flush the code caches and the instruction buffer of the Cortex-M4. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROMDONE</name>
+       <description>ROM_DONE status. Used to disable SWD interface during system initialization procedure</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CCHK</name>
+       <description>Compute ROM Checksum. This bit is self-cleared when calculation is completed. Once set, software clearing this bit is ignored and the bit will remain set until the operation is completed.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SWD_DIS</name>
+       <description> Serial Wire Debug Disable. This bit is used to disable the serial wire debug interface This bit is only writeable if (FMV lock word is not programmed) or if (ICE lock word is not programmed and the ROM_DONE bit is not set)
+				</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHKRES</name>
+       <description>ROM Checksum Result. This bit is only valid when CHKRD=1.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pass</name>
+         <description>ROM Checksum Correct.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fail</name>
+         <description>ROM Checksum Fail.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA">
+       <name>WDT0</name>
+       <description>Watchdog Timer Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO1</name>
+       <description>GPIO1 Reset. Setting this bit to 1 resets GPIO1 pins to their default states.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR0</name>
+       <description>Timer0 Reset. Setting this bit to 1 resets Timer 0 blocks.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR1</name>
+       <description>Timer1 Reset. Setting this bit to 1 resets Timer 1 blocks.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR2</name>
+       <description>Timer2 Reset. Setting this bit to 1 resets Timer 2 blocks.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR3</name>
+       <description>Timer3 Reset. Setting this bit to 1 resets Timer 3 blocks.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART0</name>
+       <description>UART0 Reset. Setting this bit to 1 resets all UART 0 blocks.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART1</name>
+       <description>UART1 Reset. Setting this bit to 1 resets all UART 1 blocks.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI0</name>
+       <description>SPI0 Reset. Setting this bit to 1 resets all SPI 0 blocks.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI1</name>
+       <description>SPI1 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI2</name>
+       <description>SPI2 Reset. Setting this bit to 1 resets all SPI 2 blocks.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>I2C0</name>
+       <description>I2C0 Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>RTC</name>
+       <description>Real Time Clock Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TRNG</name>
+       <description>TRNG Reset.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART2</name>
+       <description>UART2 Reset. Setting this bit to 1 resets all UART 2 blocks.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SOFT</name>
+       <description>Soft Reset. Setting this bit to 1 resets everything except the CPU and the watchdog timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>PERIPH</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SYS</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>SYSCLK_DIV</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the PLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_SEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ERFO</name>
+         <description>32MHz Crystal is used for the system clock.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INRO</name>
+         <description>80kHz LIRC is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>The internal 96 MHz oscillator is used for the system clock.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBRO</name>
+         <description>The internal 8 MHz oscillator is used for the system clock.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERTCO</name>
+         <description> 32kHz is used for the system clock.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EXTCLK</name>
+         <description> External clock on gpio0 11.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_RDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IPO_DIV</name>
+       <description>Divides the HIRC96M clock before the system clock prescaler, will affect HIRC96M Autocalibration.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>divide clock by 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>divide clock by 2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>divide clock by 4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>divide clock by 8</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_EN</name>
+       <description>32MHz Crystal Oscillator Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>32kHz Crystal Oscillator Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>IPO_EN</name>
+       <description>96MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>IBRO_EN</name>
+       <description>8MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_VS</name>
+       <description>8MHz High Frequency Internal Reference Clock Voltage Select. This register bit is used to select the power supply to the HIRC8M.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Vcor</name>
+         <description>VCore Supply</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1V</name>
+         <description>Dedicated 1v regulated supply.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_RDY</name>
+       <description>32MHz Crystal Oscillator Ready</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERTCO_RDY</name>
+       <description>32kHz Crystal Oscillator Ready</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>IPO_RDY</name>
+       <description>96MHz HIRC Ready.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>IBRO_RDY</name>
+       <description>8MHz HIRC Ready.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>INRO_RDY</name>
+       <description>8kHz Low Frequency Reference Clock Ready.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>EXTCLK_RDY</name>
+       <description>External Clock (GPIO0[11] AF2) </description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PM</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This two bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>backup</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO_WE</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wake Up Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wake Up Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>RTC_WE</name>
+       <description>RTC Alarm Wake Up Enable. This bit enables RTC alarm as wakeup source. If enabled, the desired RTC alarm must be configured via the RTC control registers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>LPTMR0_WE</name>
+       <description>TIMER4 Wake Up Enable. This bit enables TIMER4 as wakeup source. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>LPTMR1_WE</name>
+       <description>TIMER5 Wake Up Enable. This bit enables TIMER5 as wakeup source. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>LPUART0_WE</name>
+       <description>LPUART3 Wake Up Enable. This bit enables LPUART3 as wakeup source. </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_PD</name>
+       <description>32MHz power down. This bit selects 32MHz Crystal power state in DEEPSLEEP mode.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERFO_PD">
+       <name>IPO_PD</name>
+       <description>96MHz power down. This bit selects 96MHz HIRC power state in DEEPSLEEP mode. </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_PD">
+       <name>IBRO_PD</name>
+       <description>8MHz power down. This bit selects 8MHz HIRC power state in DEEPSLEEP mode. </description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_BP</name>
+       <description>32MHz Oscillator Bypass</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIV</name>
+     <description>Peripheral Clock Divider.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>AON_CLKDIV</name>
+       <description>Always-ON (AON) domain Clock Divider. These bits define the AON domain clock divider</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div4</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DIV_CLK_OUT_CTRL</name>
+       <description>DIV_CLK_OUT Control</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>DIV_CLK_OUT_EN</name>
+       <description>DIV_CLK_OUT Enable</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0</name>
+       <description>GPIO0 Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>GPIO1</name>
+       <description>GPIO1 Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>DMA</name>
+       <description>DMA Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI0</name>
+       <description>SPI 0 Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI1</name>
+       <description>SPI 1 Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI2</name>
+       <description>SPI 2 Disable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART0</name>
+       <description>UART 0 Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART1</name>
+       <description>UART 1 Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C0</name>
+       <description>I2C 0 Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR0</name>
+       <description>Timer 0 Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR1</name>
+       <description>Timer 1 Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR2</name>
+       <description>Timer 2 Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR3</name>
+       <description>Timer 3 Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C1</name>
+       <description>I2C 1 Disable.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCTRL</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 2.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>RAMWS_EN</name>
+       <description>System RAM Wait State enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM0LS_EN</name>
+       <description>System RAM 0 Light Sleep Mode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>RAM is active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>light_sleep</name>
+         <description>RAM is in Light Sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM1LS_EN</name>
+       <description>System RAM 1 Light Sleep Mode.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM2LS_EN</name>
+       <description>System RAM 2 Light Sleep Mode.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>RAM3LS_EN</name>
+       <description>System RAM 3 Light Sleep Mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>ICC0LS_EN</name>
+       <description>ICache RAM Light Sleep Mode.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0LS_EN">
+       <name>ROMLS_EN</name>
+       <description>ROM Light Sleep Mode.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMZ</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>System RAM Block.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM">
+       <name>RAMCB</name>
+       <description>System RAM check bit zeroization.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM">
+       <name>ICC0</name>
+       <description>Instruction Cache.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSST</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICELOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>I2C1</name>
+       <description>I2C1 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>WDT1</name>
+       <description>WDT1 Reset.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>CRC</name>
+       <description>CRC Reset.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AES</name>
+       <description>AES Reset.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AC</name>
+       <description>AC Reset.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2C2</name>
+       <description>I2C2 Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2S</name>
+       <description>I2S Reset.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AFE</name>
+       <description>AFE Reset.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>UART2</name>
+       <description>UART2 Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="UART2">
+       <name>TRNG</name>
+       <description>TRNG Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>WWDT0</name>
+       <description>WDT0  Disable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>WWDT1</name>
+       <description>WDT1  Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>ICC0</name>
+       <description>ICACHE Disable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>CRC</name>
+       <description>CRC Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>AES</name>
+       <description>AES Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>I2C2</name>
+       <description>I2C2 Disable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>I2S</name>
+       <description>I2S Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVENTEN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Enable RXEV pin event. When this bit is set, a logic high of GPIO0[20] will cause an RXEV event to wake the CPU from WFE sleep mode. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO[21].</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REVISION</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSIE</name>
+     <description>System Status Interrupt Enable Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEUNLOCK</name>
+       <description>ARM ICE Unlock Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCERR</name>
+     <description>ECC Error Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0</name>
+       <description>ECC Icache Error Flag. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH</name>
+       <description>ECC Flash Error Flag. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCCED</name>
+     <description>ECC Not Double Error Detect Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0</name>
+       <description>ECC Icache Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH</name>
+       <description>ECC Flash0 Not Double Error Detect. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCIE</name>
+     <description>ECC IRQ Enable Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Interrup Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC0</name>
+       <description>ECC Icache0 Error Interrup Enable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH</name>
+       <description>ECC Flash0 NError Interrup Enable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCADDR</name>
+     <description>ECC Error Address Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>DATARAMADDR</name>
+       <description>ECC Error Address/TAG RAM Error Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>DATARAMBANK</name>
+       <description>ECC Error Address/DATA RAM Error Bank.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATARAMERR</name>
+       <description>ECC Error Address/DATA RAM Error Address.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMADDR</name>
+       <description>ECC Error Address/TAG RAM Error Address.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMBANK</name>
+       <description>ECC Error Address/TAG RAM Error Bank.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAGRAMERR</name>
+       <description>ECC Error Address/TAG RAM Error.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCR Global Control Registers.-->
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x40008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN0</name>
+     <description>GPIO Function Enable Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_SET</name>
+     <description>GPIO Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_OUT bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_IN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTMODE</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTMODE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTPOL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTPOL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INEN</name>
+     <description>GPIO Input Enable</description>
+     <addressOffset>0x30</addressOffset>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_INTFL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WKEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DUALEDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DUALEDGE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL0</name>
+     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL0</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL1</name>
+     <description>GPIO Input Mode Config 2. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL1</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_SET</name>
+     <description>GPIO Alternate Function Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN2</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_SET</name>
+     <description>GPIO Alternate Function 2 Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN2 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_CLR</name>
+     <description>GPIO Wake Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN2 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x7C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HYSEN</name>
+     <description>GPIO Input Hysteresis Enable.</description>
+     <addressOffset>0xA8</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_HYSEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SRSEL</name>
+     <description>GPIO Slew Rate Enable Register.</description>
+     <addressOffset>0xAC</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_SRSEL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>FAST</name>
+         <description>Fast Slew Rate selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SLOW</name>
+         <description>Slow Slew Rate selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS0</name>
+     <description>GPIO Drive Strength  Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS0</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ld</name>
+         <description>GPIO port pin is in low-drive mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hd</name>
+         <description>GPIO port pin is in high-drive mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PS</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GPIO0 Individual I/O for each GPIO-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO1</name>
+   <description>Individual I/O for each GPIO 1</description>
+   <baseAddress>0x40009000</baseAddress>
+   <interrupt>
+    <name>GPIO1</name>
+    <description>GPIO1 IRQ</description>
+    <value>25</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO1 Individual I/O for each GPIO 1-->
+  <peripheral>
+   <name>I2C0</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>I2C</groupName>
+   <baseAddress>0x4001D000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2C0</name>
+    <description>I2C0 IRQ</description>
+    <value>13</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>I2C Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable I2C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable I2C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave_mode</name>
+         <description>Slave Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master_mode</name>
+         <description>Master Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_EN</name>
+       <description>General Call Address Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Ignore Gneral Call Address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Acknowledge general call address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_EN</name>
+       <description>Interactive Receive Mode.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interactive Receive Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interactive Receive Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_ACK</name>
+       <description>Data Acknowledge. This bit defines the acknowledge bit returned by the I2C receiver while IRXM = 1 HW forces ACK to 0 when IRXM = 0.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ack</name>
+         <description>return ACK (pulling SDA LOW).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>return NACK (leaving SDA HIGH).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_OUT</name>
+       <description>SCL Output. This bits control SCL output when SWOE =1.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_scl_low</name>
+         <description>Drive SCL low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_scl</name>
+         <description>Release SCL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDA_OUT</name>
+       <description>SDA Output. This bits control SDA output when SWOE = 1. </description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_sda_low</name>
+         <description>Drive SDA low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_sda</name>
+         <description>Release SDA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL</name>
+       <description>SCL status. This bit reflects the logic gate of SCL signal. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDA</name>
+       <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BB_MODE</name>
+       <description>Software Output Enable.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>outputs_disable</name>
+         <description>I2C Outputs SCLO and SDAO disabled. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputs_enable</name>
+         <description>I2C Outputs SCLO and SDAO enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read. This bit reflects the R/W bit of an address match (AMI = 1) or general call match (GCI = 1). This bit is valid 3 cycles after the relevant interrupt bit is set.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKSTR_DIS</name>
+       <description>This bit will disable slave clock stretching when set.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Slave clock stretching enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Slave clock stretching disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ONE_MST_MODE</name>
+       <description>SCL Push-Pull Mode. This bit controls whether SCL is operated in a the I2C standard open-drain mode, or in a non-standard push-pull mode where the Hi-Z output isreplaced with Drive-1. The non-standard mode should only be used when operating as a master and communicating with slaves that are guaranteed to never drive SCL low. </description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Standard open-drain operation:
+					drive low for 0, Hi-Z for 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Non-standard push-pull operation:
+					drive low for 0, drive high for 1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HS_EN</name>
+       <description>High speed mode enable</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>IRXM
+    </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>Bus Status.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>I2C Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>I2C Bus Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>RX empty.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX Full.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX Empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>TX Full.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_BUSY</name>
+       <description>Clock Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_actively_driving_scl_clock</name>
+         <description>Device not actively driving SCL clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>actively_driving_scl_clock</name>
+         <description>Device operating as master and actively driving SCL clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL0</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <name>INT_FL0_Done</name>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Interactive Receive Interrupt.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave General Call Address Match Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave Address Match Interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Receive Threshold Interrupt. This bit is automaticcaly cleared when RX_FIFO is below the threshold level.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. RX_FIFO equal or more bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>Transmit Threshold Interrupt. This bit is automaticcaly cleared when TX_FIFO is above the threshold level.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP Interrupt.</description>
+       <bitRange>[6:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Address Acknowledge Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Arbritation error Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>timeout Error Interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Address NACK Error Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Data NACK Error Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Do Not Respond Error Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Start Error Interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Stop Error Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>Transmit Lock Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN0</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when DONE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Description not available.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when RX_MODE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave mode general call address match received input enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when GEN_CTRL_ADDR = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave mode incoming address match interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when ADDR_MATCH = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Above Treshold Level Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Below Treshold Level Interrupt Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Stop Interrupt Enable</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when STOP = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Received Address ACK from Slave Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Master Mode Arbitration Lost Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>Timeout Error Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Master Mode Address NACK Received Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Master Mode Data NACK Received Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Slave Mode Do Not Respond Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Out of Sequence START condition detected interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Out of Sequence STOP condition detected interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>TX FIFO Locked Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL1</name>
+     <description>Interrupt Status Register 1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt. When operating as a slave receiver, this bit is set when you reach the first data bit and the RX FIFO and shift register are both full.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt. When operating as a slave transmitter, this bit is set when you reach the first data bit and the TX FIFO is empty and the master is still asking for more data (i.e the master hasn't sent a NACK yet).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Status Flag.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN1</name>
+     <description>Interrupt Staus Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOLEN</name>
+     <description>FIFO Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RX_DEPTH</name>
+       <description>Receive FIFO Length.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DEPTH</name>
+       <description>Transmit FIFO Length.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL0</name>
+     <description>Receive Control Register 0.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>DNR</name>
+       <description>Do Not Respond.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Always respond to address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>not_respond_rx_fifo_empty</name>
+         <description>Do not respond to address match when RX_FIFO is not empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Receive FIFO Flush. This bit is automatically cleared to 0 after the operation. Setting this bit to 1 will affect RX_FIFO status.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush RX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_LVL</name>
+       <description>Receive FIFO Threshold. These bits define the RX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL1</name>
+     <description>Receive Control Register 1.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Receive Count Bits. These bits define the number of bytes to be received in a transaction, except for the case RXCNT = 0. RXCNT = 0 means 256 bytes to be received in a transaction.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Receive FIFO Count. These bits reflect the number of byte in the RX_FIFO. These bits are flushed when I2CEN = 0.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL0</name>
+     <description>Transmit Control Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_MODE</name>
+       <description>Transmit FIFO Preaload Mode. Setting this bit will allow for high speed application to preload the transmit FIFO prior to Slave Address Match.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TX_READY_MODE</name>
+       <description>Transmit FIFO Ready Manual Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW control of I2CTXRDY enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW control of I2CTXRDY disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO General Call Address Match Auto Flush Disable.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Write Auto Flush Disable.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Read Auto Flush Disable.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NACK_FLUSH_DIS</name>
+       <description>TX FIFO received NACK Auto Flush Disable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Transmit FIFO Flush. This bit is automatically cleared to 0 after the operation.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush TX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_VAL</name>
+       <description>Transmit FIFO Threshold. These bits define the TX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL1</name>
+     <description>Transmit Control Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_RDY</name>
+       <description>Transmit FIFO Preload Ready.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Transmit FIFO Count. These bits reflect the number of bytes in the TX_FIFO.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MSTCTRL</name>
+     <description>Master Control Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Setting this bit to 1 will start a master transfer.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>RESTART</name>
+       <description>Setting this bit to 1 will generate a repeated START.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Setting this bit to 1 will generate a STOP condition.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>EX_ADDR_EN</name>
+       <description>Slave Extend Address Select.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKLO</name>
+     <description>Clock Low Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock low. In master mode, these bits define the SCL low period. In slave mode, these bits define the time SCL will be held low after data is outputted.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKHI</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>HI</name>
+       <description>Clock High. In master mode, these bits define the SCL high period.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HSCLK</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock Low. This field sets the Hs-Mode clock low count. In Slave mode, this is the time SCL is held low after data is output on SDA.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Clock High. This field sets the Hs-Mode clock high count. In Slave mode, this is the time SCL is held high after data is output on SDA</description>
+       <bitRange>[15:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TIMEOUT</name>
+     <description>Timeout Register</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_TO_VAL</name>
+       <description>Timeout</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLAVE</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Slave Address.</description>
+       <bitRange>[9:0]</bitRange>
+      </field>
+      <field>
+       <name>DIS</name>
+       <description>Slave Address Disable.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>IDX</name>
+       <description>Slave Address Index.</description>
+       <bitRange>[14:11]</bitRange>
+      </field>
+      <field>
+       <name>EXT_ADDR_EN</name>
+       <description>Extended Address Select.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2C0 Inter-Integrated Circuit.-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C1</name>
+   <description>Inter-Integrated Circuit. 1</description>
+   <baseAddress>0x4001E000</baseAddress>
+   <interrupt>
+    <name>I2C1</name>
+    <description>I2C1 IRQ</description>
+    <value>36</value>
+   </interrupt>
+  </peripheral>
+<!--I2C1 Inter-Integrated Circuit. 1-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C2</name>
+   <description>Inter-Integrated Circuit. 2</description>
+   <baseAddress>0x4001F000</baseAddress>
+   <interrupt>
+    <name>I2C2</name>
+    <description>I2C2 IRQ</description>
+    <value>62</value>
+   </interrupt>
+  </peripheral>
+<!--I2C2 Inter-Integrated Circuit. 2-->
+  <peripheral>
+   <name>I2S</name>
+   <description>Inter-IC Sound Interface.</description>
+   <groupName>I2S</groupName>
+   <baseAddress>0x40060000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2S</name>
+    <description>I2S IRQ</description>
+    <value>99</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0CH0</name>
+     <description>Global mode channel.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>LSB_FIRST</name>
+       <description>LSB Transmit Receive First.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_MODE</name>
+       <description>SCK Select.</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>WS_POL</name>
+       <description>WS polarity select. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB_LOC</name>
+       <description>MSB location. </description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ALIGN</name>
+       <description>Align to MSB or LSB.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EXT_SEL</name>
+       <description>External SCK/WS selection.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>STEREO</name>
+       <description>Stereo mode of I2S.</description>
+       <bitRange>[13:12]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WSIZE</name>
+       <description>Data size when write to FIFO.</description>
+       <bitRange>[15:14]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable. </description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable. </description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Flushes the TX/RX FIFO buffer. </description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RST</name>
+       <description>Write 1 to reset channel. </description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_LSB</name>
+       <description>Bit Field Control. </description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>depth of receive FIFO for threshold interrupt generation. </description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1CH0</name>
+     <description>Local channel Setup.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>BITS_WORD</name>
+       <description>I2S word length.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>I2S clock enable.</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SMP_SIZE</name>
+       <description>I2S sample size length.</description>
+       <bitRange>[13:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ADJST</name>
+       <description>LSB/MSB Justify.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>I2S clock frequency divisor.</description>
+       <bitRange>[31:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMACH0</name>
+     <description>DMA Control.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DMA_TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger.</description>
+       <bitRange>[6:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA channel enable.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_THD_VAL</name>
+       <description>RX FIFO Level DMA Trigger.</description>
+       <bitRange>[14:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA channel enable.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Number of data word in the TX FIFO.</description>
+       <bitRange>[23:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Number of data word in the RX FIFO.</description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOCH0</name>
+     <description>I2S Fifo.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>ISR Status.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Status for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Status for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Status for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Status for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Enable for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Enable for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Enable for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Enable for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EXTSETUP</name>
+     <description>Ext Control.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>EXT_BITS_WORD</name>
+       <description>Word Length for ch_mode.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2S Inter-IC Sound Interface.-->
+  <peripheral>
+   <name>ICC0</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x4002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x800</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>INFO</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SZ</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCH</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEM</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ICC0 Instruction Cache Controller Registers-->
+  <peripheral>
+   <name>MCR</name>
+   <description>Miscellaneous Control Registers.</description>
+   <baseAddress>0x40106C00</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RST</name>
+     <description>Reset control register 0.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0</resetMask>
+     <fields>
+      <field>
+       <name>lptmr0</name>
+       <description>Setting this bit will reset LPTMR0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>rst</name>
+         <description>Reset LPTMR0.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>lptmr1</name>
+       <description>Setting this bit will reset LPTMR1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>rst</name>
+         <description>Reset LPTMR1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>lpuart0</name>
+       <description>Setting this bit will reset LPUART0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>rst</name>
+         <description>Reset LPUART0.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>rtc</name>
+       <description>Setting this bit will reset the Real-Time Clock.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>rst</name>
+         <description>Reset Real-Time Clock.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPIOCTRL</name>
+     <description>Low-power peripheral IO control.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetMask>0</resetMask>
+     <fields>
+      <field>
+       <name>LPTMR0_I</name>
+       <description>Setting this bit will enable the low-power timer 0 (timer 4) input pin while operating in low-power modes.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPTMR0 input pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPTMR0 input pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPTMR0_O</name>
+       <description>Setting this bit will enable the low-power timer 0 (timer 4) output pin while operating in low-power modes.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPTMR0 output pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPTMR0 output pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPTMR1_I</name>
+       <description>Setting this bit will enable the low-power timer 1 (timer 5) input pin while operating in low-power modes.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPTMR1 input pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPTMR1 input pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPTMR1_O</name>
+       <description>Setting this bit will enable the low-power timer 1 (timer 5) output pin while operating in low-power modes.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPTMR1 output pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPTMR1 output pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPUART0_RX</name>
+       <description>Setting this bit will enable the low-power UART 0 (UART3) RX pin while operating in low-power modes.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPUART0 RX pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPUART0 RX pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPUART0_TX</name>
+       <description>Setting this bit will enable the low-power UART 0 (UART3) TX pin while operating in low-power modes.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPUART0 TX pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPUART0 TX pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPUART0_CTS</name>
+       <description>Setting this bit will enable the low-power UART 0 (UART3) CTS pin while operating in low-power modes.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPUART0 CTS pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPUART0 CTS pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPUART0_RTS</name>
+       <description>Setting this bit will enable the low-power UART 0 (UART3) RTS pin while operating in low-power modes.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPUART0 RTS pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPUART0 RTS pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIS</name>
+     <description>Peripheral clock control register.</description>
+     <addressOffset>0x24</addressOffset>
+     <resetMask>0xFFFFFFFF</resetMask>
+     <fields>
+      <field>
+       <name>lptmr0</name>
+       <description>Clearing this bit will enable the low-power timer 0 (timer 4) peripheral clock.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPTMR0 clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPTMR0 clock.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>lptmr1</name>
+       <description>Clearing this bit will enable the low-power timer 1 (timer 5) peripheral clock.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPTMR1 clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPTMR1 clock.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>lpuart0</name>
+       <description>Clearing this bit will enable the low-power UART 0 (UART3) peripheral clock.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable LPUART0 clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable LPUART0 clock.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--MCR Miscellaneous Control Registers.-->
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x40106800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>LPCN</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0RET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 0 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM1RET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 1 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM2RET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 2 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM3RET_EN</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OVR</name>
+       <description>Operating Voltage Range</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_9V</name>
+         <description>0.9V 24MHz</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0V</name>
+         <description>1.0V 48MHz</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1V</name>
+         <description>1.1V 96MHz</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORE_DET_BYPASS</name>
+       <description>Block Auto-Detect</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>enabled</name>
+         <description>enable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Disable</name>
+         <description>disable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RETREG_EN</name>
+       <description>Retention Regulator Enable. This bit controls the retention regulator in BACKUP mode. </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STORAGE_EN</name>
+       <description>STORAGE Mode ENable. This bit allows low-power background mode operations, while the CPU is in DeepSleep.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FASTWK_EN</name>
+       <description>Fast Wake-Up Mode. This bit enables fast wake-up from DeepSleep mode. (5uS typical). </description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BG_DIS</name>
+       <description>Bandgap OFF. This controls the System Bandgap in DeepSleep mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>Bandgap is always ON.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>Bandgap is OFF in DeepSleep mode (default).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREPOR_DIS</name>
+       <description>VDDC (Vcore) Power on reset Monitor Disable.This bit controls the Power-On Reset monitor on VDDC supply in
+        DeepSleep and BACKUP mode.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDO_DIS</name>
+       <description>Disable Main LDO</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORE_EXT</name>
+       <description>Use external VCORE for 1V supply</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>use Vcore for retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREMON_DIS</name>
+       <description>VDDC (Vcore) Monitor Disable. This bit controls the power monitor on the VCore supply in all operating modes.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDAMON_DIS</name>
+       <description>VDDA Monitor Disable. This bit controls the power monitor of the Analog Supply in all operating modes.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable if Bandgap is ON (default) </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PORVDDMON_DIS</name>
+       <description>VDDIO Power-On Reset Monitor Disable. This bit controls the Power-On Reset monitor on VDDIO supply in all operating mods.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INRO_EN</name>
+       <description>INRO remains on in all power modes if this bit is set otherwise it is controled by the LP controller</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>XRTCO remains on in all power modes if this bit is set otherwise it is controled by the LP controller</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERTCO_PD</name>
+       <description>ERTCO Powerdown.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST0</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO0.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN0</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register derivedFrom="LPWKST0">
+     <name>LPWKST1</name>
+     <description>Low Power I/O Wakeup Status Register 1. This register indicates the low power wakeup status for GPIO1.</description>
+     <addressOffset>0x0C</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN1</name>
+     <description>Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup functionality for GPIO1.</description>
+     <addressOffset>0x10</addressOffset>
+    </register>
+    <register>
+     <name>LPPWKST</name>
+     <description>Low Power Peripheral Wakeup Status Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>LPTMR0</name>
+       <description>LPTM0 Wakeup Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPTMR1</name>
+       <description>LPTMR1 Wakeup Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPUART0</name>
+       <description>LPUART0 Wakeup Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWKEN</name>
+     <description>Low Power Peripheral Wakeup Enable Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>LPTMR0</name>
+       <description> TIMER4 Wakeup Enable. This bit allows wakeup from the TIMER4.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPTMR1</name>
+       <description> TIMER5 Wakeup Enable. This bit allows wakeup from the TIMER5.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPUART0</name>
+       <description> LPUART Wakeup Enable. This bit allows wakeup from the LPUART.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPMEMSD</name>
+     <description>Low Power Memory Shutdown Control.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM block 0 Shut Down.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>System RAM block 1 Shut Down.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>System RAM block 2 Shut Down.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>System RAM block 3 Shut Down.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Operating Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>shutdown</name>
+         <description>Shutdown Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GP0</name>
+     <description>General Purpose Register 0</description>
+     <addressOffset>0x48</addressOffset>
+    </register>
+    <register>
+     <name>GP1</name>
+     <description>General Purpose Register 1</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--PWRSEQ Power Sequencer / Low Power Control Register.-->
+  <peripheral>
+   <name>RTC</name>
+   <description>Real Time Clock and Alarm.</description>
+   <baseAddress>0x40106000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>RTC</name>
+    <description>RTC interrupt.</description>
+    <value>3</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC</name>
+       <description>Sub-Seconds Counter (12-bit).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TODA</name>
+     <description>Time-of-day Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-day Alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSECA</name>
+     <description>RTC sub-second alarm.  This register contains the reload value for the sub-second alarm.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>This register contains the reload value for the sub-second alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>RTC Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Real Time Clock Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM_IE</name>
+       <description>Alarm Time-of-Day Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM_IE</name>
+       <description>Alarm Sub-second Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>RTC Busy. This bit is set to 1 by hardware when changes to RTC registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>RTC Ready. This bit is set to 1 by hardware when the RTC count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the RTC count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY_IE</name>
+       <description>RTC Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-Day Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>Sub-second Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_SEL</name>
+       <description>Frequency Output Selection. When SQE=1, these bits specify the output frequency on the SQW pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq1Hz</name>
+         <description>1 Hz (Compensated).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq512Hz</name>
+         <description>512 Hz (Compensated).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq4KHz</name>
+         <description>4 KHz.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clkDiv8</name>
+         <description>RTC Input Clock / 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_EN</name>
+       <description>Asynchronous Counter Read Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_EN</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical RTC bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIM</name>
+     <description>RTC Trim Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>RTC Trim. This register contains the 2's complement value that specifies the trim resolution. Each increment or decrement of the bit adds or subtracts 1ppm at each 4KHz clock value, with a maximum correction of +/- 127ppm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VRTC_TMR</name>
+       <description>VBAT Timer Value. When RTC is running off of VBAT, this field is incremented every 32 seconds.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>RTC Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>FILTER_EN</name>
+       <description>Enables analog deglitch filter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_SEL</name>
+       <description>If IBIAS_EN is 1, selects 4x,2x mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HYST_EN</name>
+       <description>Enables high current hysteresis buffer.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_EN</name>
+       <description>Enables higher 4x,2x current modes.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYPASS</name>
+       <description>RTC Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SQW_32K</name>
+       <description>RTC 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--RTC Real Time Clock and Alarm.-->
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x40000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SIR_STATUS</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CFG_VALID</name>
+       <description>Configuration Valid Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CFG_ERR</name>
+       <description>Configuration Error Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SIR_ADDR</name>
+     <description>Read-only field set by the SIB block if a CRC error occurs during the read of the OTP memory. Contains the failing address in OTP memory (when CRCERR equals 1).</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIR System Initialization Registers.-->
+  <peripheral>
+   <name>SPI0</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x40046000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>16</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FIFO32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>FIFO16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>FIFO8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Start Select Control. Used in Master mode to control the behavior of the Slave Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DEASSERT</name>
+         <description>SPI De-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ASSERT</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_ACTIVE</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3</name>
+         <description>SS3 is selected.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Rising_Edge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Falling_Edge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin (s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_POL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3_high</name>
+         <description>SS3 active high.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSTIME</name>
+     <description>Register for controlling SPI peripheral/Slave Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PRE</name>
+       <description>Slave Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POST</name>
+       <description>Slave Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPI0 SPI peripheral.-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI1</name>
+   <description>SPI peripheral. 1</description>
+   <baseAddress>0x40047000</baseAddress>
+   <interrupt>
+    <name>SPI1</name>
+    <description>SPI1 IRQ</description>
+    <value>17</value>
+   </interrupt>
+  </peripheral>
+<!--SPI1 SPI peripheral. 1-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI2</name>
+   <description>SPI peripheral. 2</description>
+   <baseAddress>0x40048000</baseAddress>
+   <interrupt>
+    <name>SPI2</name>
+    <description>SPI2 IRQ</description>
+    <value>18</value>
+   </interrupt>
+  </peripheral>
+<!--SPI2 SPI peripheral. 2-->
+  <peripheral>
+   <name>TMR</name>
+   <description>Low-Power Configurable Timer</description>
+   <baseAddress>0x40010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR</name>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Timer Counter Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>The current count value for the timer. This field increments as the timer counts.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Timer Compare Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>Timer PWM Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PWM</name>
+       <description>Timer PWM Match:
+                In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
+                In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Timer Interrupt Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ_A</name>
+       <description>Interrupt Flag for Timer A.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_A</name>
+       <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_A</name>
+       <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IRQ_B</name>
+       <description>Interrupt Flag for Timer B.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_B</name>
+       <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_B</name>
+       <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MODE_A</name>
+       <description>Mode Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_A</name>
+       <description>Clock Divider Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_A</name>
+       <description>Timer Polarity for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_A</name>
+       <description>PWM Synchronization Mode for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_A</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_A</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_A</name>
+       <description>PWM Phase A-Prime Output Disable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_A</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Write 1 to Enable CLK_TMR for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_A</name>
+       <description>Enable for Timer A</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MODE_B</name>
+       <description>Mode Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_B</name>
+       <description>Clock Divider Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_B</name>
+       <description>Timer Polarity for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_B</name>
+       <description>PWM Synchronization Mode for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_B</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_B</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_B</name>
+       <description>PWM Phase A-Prime Output Disable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_B</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Write 1 to Enable CLK_TMR for Timer B</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_B</name>
+       <description>Enable for Timer B</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO_A</name>
+       <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_A</name>
+       <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>LO_B</name>
+       <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_B</name>
+       <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Timer Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKSEL_A</name>
+       <description>Timer Clock Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Timer A Enable Status</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_A</name>
+       <description>CLK_TMR Ready Flag for Timer A</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_A</name>
+       <description>Event Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_A</name>
+       <description>Negative Edge Trigger for Event for Timer A</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_A</name>
+       <description>Interrupt Enable for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_A</name>
+       <description>Capture Event Select for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_A</name>
+       <description>Software Capture Event for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_A</name>
+       <description>Wake-Up Enable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTEN_A</name>
+       <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTBEN_A</name>
+       <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads to the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKSEL_B</name>
+       <description>Timer Clock Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Timer B Enable Status</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_B</name>
+       <description>CLK_TMR Ready Flag for Timer B</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_B</name>
+       <description>Event Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_B</name>
+       <description>Negative Edge Trigger for Event for Timer B</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_B</name>
+       <description>Interrupt Enable for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_B</name>
+       <description>Capture Event Select for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_B</name>
+       <description>Software Capture Event for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_B</name>
+       <description>Wake-Up Enable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CASCADE</name>
+       <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Timer Wakeup Status Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>A</name>
+       <description>Wake-Up Flag for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>B</name>
+       <description>Wake-Up Flag for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TMR Low-Power Configurable Timer-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR1</name>
+   <description>Low-Power Configurable Timer 1</description>
+   <baseAddress>0x40011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+<!--TMR1 Low-Power Configurable Timer 1-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR2</name>
+   <description>Low-Power Configurable Timer 2</description>
+   <baseAddress>0x40012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+<!--TMR2 Low-Power Configurable Timer 2-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR3</name>
+   <description>Low-Power Configurable Timer 3</description>
+   <baseAddress>0x40013000</baseAddress>
+   <interrupt>
+    <name>TMR3</name>
+    <description>TMR3 IRQ</description>
+    <value>8</value>
+   </interrupt>
+  </peripheral>
+<!--TMR3 Low-Power Configurable Timer 3-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR4</name>
+   <description>Low-Power Configurable Timer 4</description>
+   <baseAddress>0x40114000</baseAddress>
+   <interrupt>
+    <name>TMR4</name>
+    <description>TMR4 IRQ</description>
+    <value>9</value>
+   </interrupt>
+  </peripheral>
+<!--TMR4 Low-Power Configurable Timer 4-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR5</name>
+   <description>Low-Power Configurable Timer 5</description>
+   <baseAddress>0x40115000</baseAddress>
+   <interrupt>
+    <name>TMR5</name>
+    <description>TMR5 IRQ</description>
+    <value>10</value>
+   </interrupt>
+  </peripheral>
+<!--TMR5 Low-Power Configurable Timer 5-->
+  <peripheral>
+   <name>ECC</name>
+   <description>Trim System Initilazation Registers. ECC Registers for MAX32670.</description>
+   <baseAddress>0x40105400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>EN</name>
+     <description>ECC Enable Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>SRAM</name>
+       <description>System RAM0 ECC Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICC</name>
+       <description>ICC0 ECC Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH</name>
+       <description>Flash ECC Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ECC Trim System Initilazation Registers. ECC Registers for MAX32670.-->
+  <peripheral>
+   <name>TRNG</name>
+   <description>Random Number Generator.</description>
+   <baseAddress>0x4004D000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TRNG</name>
+    <description>TRNG interrupt.</description>
+    <value>4</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>TRNG Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000003</resetValue>
+     <fields>
+      <field>
+       <name>ODHT</name>
+       <description>Start On-Demand health test.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RND_IE</name>
+       <description>To enable IRQ generation when a new 32-bit Random number is ready.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HEALTH_EN</name>
+       <description>Enable IRQ generation when a health test fails.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AESKG_USR</name>
+       <description>AES Key Generate. When enabled, the key for securing NVSRAM is generated and transferred to the secure key register automatically without user visibility or intervention. This bit is cleared by hardware once the key has been transferred to the secure key register.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AESKG_SYS</name>
+       <description>AESKG_SYS.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>To wipe the Battery Backed key.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>RDY</name>
+       <description>32-bit random data is ready to read from TRNG_DATA register. Reading TRNG_DATA when RND_RDY=0 will return all 0's. IRQ is generated when RND_RDY=1 if TRNG_CN.RND_IRQ_EN=1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Busy</name>
+         <description>TRNG Busy</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Ready</name>
+         <description>32 bit random data is ready</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ODHT</name>
+       <description>On-Demand health test status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HT</name>
+       <description>Health test status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SRCFAIL</name>
+       <description>Entropy source has failed.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AESKGD</name>
+       <description>AESKGD.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LD_CNT</name>
+       <description>LD_CNT.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data. The content of this register is valid only when RNG_IS =1. When TNRG is disabled, read returns 0x0000 0000.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRNG Random Number Generator.-->
+  <peripheral>
+   <name>UART</name>
+   <description>UART Low Power Registers</description>
+   <baseAddress>0x40042000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control register</description>
+     <addressOffset>0x0000</addressOffset>
+     <fields>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>This field specifies the depth of receive FIFO for interrupt generation (value 0 and &gt; 16 are ignored) </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EN</name>
+       <description>Parity Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EO</name>
+       <description>when PAREN=1 selects odd or even parity odd is 1 even is 0</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_MD</name>
+       <description>Selects parity based on 1s or 0s count (when PAREN=1) </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_DIS</name>
+       <description>CTS Sampling Disable </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Flushes the TX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Flushes the RX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHAR_SIZE</name>
+       <description>Selects UART character size</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5bits</name>
+         <description>5 bits</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6bits</name>
+         <description>6 bits</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7bits</name>
+         <description>7 bits</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8bits</name>
+         <description>8 bits</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPBITS</name>
+       <description>Selects the number of stop bits that will be generated</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HFC_EN</name>
+       <description>Enables/disables hardware flow control</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RTSDC</name>
+       <description>Hardware Flow Control RTS Mode</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKEN</name>
+       <description>Baud clock enable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKSRC</name>
+       <description>To select the UART clock source for the UART engine (except APB registers). Secondary clock (used for baud rate generator) can be asynchronous from APB clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Peripheral_Clock</name>
+         <description>apb clock</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>External_Clock</name>
+         <description>Clock 1</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK2</name>
+         <description>Clock 2</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK3</name>
+         <description>Clock 3</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPFE_EN</name>
+       <description>Data/Parity bit frame error detection enable</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKRDY</name>
+       <description>Baud clock Ready read only bit</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UCAGM</name>
+       <description>UART Clock Auto Gating mode</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FDM</name>
+       <description>Fractional Division Mode</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DESM</name>
+       <description>RX Dual Edge Sampling Mode</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TX_BUSY</name>
+       <description>Read-only flag indicating the UART transmit status</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_BUSY</name>
+       <description>Read-only flag indicating the UART receiver status</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Indicates the number of bytes currently in the RX FIFO (0-RX FIFO_ELTS) </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Indicates the number of bytes currently in the TX FIFO (0-TX FIFO_ELTS) </description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interrupt Enable control register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Enable Interrupt For RX Frame Error</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Enable Interrupt For RX Parity Error</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Enable Interrupt For CTS signal change Error</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Enable Interrupt For RX FIFO Overrun Error</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Enable Interrupt For RX FIFO reaches the number of bytes configured by RXTHD</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Enable Interrupt For TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Enable Interrupt For TX FIFO has half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Interrupt status flags Control register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Flag for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Flag for RX Parity Error interrupt</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Flag for CTS signal change interrupt (hardware flow control disabled) </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Flag for RX FIFO Overrun interrupt</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Flag for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Flag for interrupt when TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Flag for interrupt when TX FIFO is half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Clock Divider register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Baud rate divisor value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSR</name>
+     <description>Over Sampling Rate register</description>
+     <addressOffset>0x0014</addressOffset>
+     <fields>
+      <field>
+       <name>OSR</name>
+       <description>OSR</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXPEEK</name>
+     <description>TX FIFO Output Peek register</description>
+     <addressOffset>0x0018</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read TX FIFO next data. Reading from this field does not affect the contents of TX FIFO. Note that the parity bit is available from this field.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PNR</name>
+     <description> Pin register</description>
+     <addressOffset>0x001C</addressOffset>
+     <fields>
+      <field>
+       <name>CTS</name>
+       <description>Current sampled value of CTS IO</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RTS</name>
+       <description>This bit controls the value to apply on the RTS IO. If set to 1, the RTS IO is set to high level. If set to 0, the RTS IO is set to low level.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Read/Write register</description>
+     <addressOffset>0x0020</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Parity error flag for next byte to be read from FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration register</description>
+     <addressOffset>0x0030</addressOffset>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger If the TX FIFO level is less than this value, then the TX FIFO DMA interface will send a signal to system DMA to notify that TX FIFO is ready to receive data from memory.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX DMA channel enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Rx FIFO Level DMA Trigger If the RX FIFO level is greater than this value, then the RX FIFO DMA interface will send a signal to the system DMA to notify that RX FIFO has characters to transfer to memory.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX DMA channel enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wake up enable Control register</description>
+     <addressOffset>0x0034</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Enable for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Enable for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Enable for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wake up Flags register</description>
+     <addressOffset>0x0038</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Flag for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Flag for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Flag for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--UART UART Low Power Registers-->
+  <peripheral derivedFrom="UART">
+   <name>UART1</name>
+   <description>UART Low Power Registers 1</description>
+   <baseAddress>0x40043000</baseAddress>
+  </peripheral>
+<!--UART1 UART Low Power Registers 1-->
+  <peripheral derivedFrom="UART">
+   <name>UART2</name>
+   <description>UART Low Power Registers 2</description>
+   <baseAddress>0x40044000</baseAddress>
+  </peripheral>
+<!--UART2 UART Low Power Registers 2-->
+  <peripheral derivedFrom="UART">
+   <name>UART3</name>
+   <description>UART Low Power Registers 3</description>
+   <baseAddress>0x40145000</baseAddress>
+  </peripheral>
+<!--UART3 UART Low Power Registers 3-->
+  <peripheral>
+   <name>WDT</name>
+   <description>Windowed Watchdog Timer</description>
+   <baseAddress>0x40003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WWDT</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INT_LATE_VAL</name>
+       <description>Windowed Watchdog Interrupt Upper Limit. Sets the number of WDTCLK cycles until a windowed watchdog timer interrupt is generated (if enabled) if the CPU does not write the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE_VAL</name>
+       <description>Windowed Watchdog Reset Upper Limit. Sets the number of WDTCLK cycles until a system reset occurs (if enabled) if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Windowed Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_LATE</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Late.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_INT_EN</name>
+       <description>Windowed Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_RST_EN</name>
+       <description>Windowed Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Soon.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY_VAL</name>
+       <description>Windowed Watchdog Interrupt Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A windowed watchdog timer interrupt is generated (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY_VAL</name>
+       <description>Windowed Watchdog Reset Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A system reset occurs (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKRDY_IE</name>
+       <description>Switch Ready Interrupt Enable. Fires an interrupt when it is safe to swithc the clock.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY</name>
+       <description>Clock Status.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WIN_EN</name>
+       <description>Enables the Windowed Watchdog Function.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Windowed Mode Disabled (i.e. Compatibility Mode).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Windowed Mode Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Soon.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Late.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Windowed Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>RESET</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD_UPPER_LIMIT then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD_UPPER_LIMIT then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKSEL</name>
+     <description>Windowed Watchdog Timer Clock Select Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SOURCE</name>
+       <description>WWDT Clock Selection Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CNT</name>
+     <description>Windowed Watchdog Timer Count Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Current Value of the Windowed Watchdog Timer Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WDT Windowed Watchdog Timer-->
+  <peripheral derivedFrom="WDT">
+   <name>WDT1</name>
+   <description>Windowed Watchdog Timer 1</description>
+   <baseAddress>0x40003400</baseAddress>
+   <interrupt>
+    <name>WDT1</name>
+    <description>WDT1 IRQ</description>
+    <value>57</value>
+   </interrupt>
+  </peripheral>
+<!--WDT1 Windowed Watchdog Timer 1-->
+ </peripherals>
+</device>

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32680/Include/max32680.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32680/Include/max32680.svd
@@ -1,0 +1,12812 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max32680</name>
+ <series>ARMCM4</series>
+ <version>1.0</version>
+ <description>MAX32680 32-bit ARM Cortex-M4 microcontroller, 1024KB of flash, 760KB of system RAM, 128KB of Boot ROM.</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>ADC</name>
+   <description>10-bit Analog to Digital Converter</description>
+   <baseAddress>0x40034000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>ADC</name>
+    <description>ADC IRQ</description>
+    <value>20</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>ADC Control</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>start</name>
+       <description>Start ADC Conversion</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pwr</name>
+       <description>ADC Power Up</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>refbuf_pwr</name>
+       <description>ADC Reference Buffer Power Up</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ref_sel</name>
+       <description>ADC Reference Select</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ref_scale</name>
+       <description>ADC Reference Scale</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>scale</name>
+       <description>ADC Scale</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>clk_en</name>
+       <description>ADC Clock Enable</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_sel</name>
+       <description>ADC Channel Select</description>
+       <bitRange>[16:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AIN0</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN1</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN2</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN3</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN4</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN5</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN6</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN7</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VcoreA</name>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VcoreB</name>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vrxout</name>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vtxout</name>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VddA</name>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VddB</name>
+         <description>VddB/4</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vddio</name>
+         <description>Vddio/4</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vddioh</name>
+         <description>Vddioh/4</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VregI</name>
+         <description>VregI/4</description>
+         <value>16</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>adc_divsel</name>
+       <description>Scales the external inputs, all inputs are scaled the same</description>
+       <bitRange>[18:17]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV3</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>data_align</name>
+       <description>ADC Data Alignment Select</description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>ADC Status</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>active</name>
+       <description>ADC Conversion In Progress</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>afe_pwr_up_active</name>
+       <description>AFE Power Up Delay Active</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>overflow</name>
+       <description>ADC Overflow</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>ADC Output Data</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>adc_data</name>
+       <description>ADC Converted Sample Data Output</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>ADC Interrupt Control Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>done_ie</name>
+       <description>ADC Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ref_ready_ie</name>
+       <description>ADC Reference Ready Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>hi_limit_ie</name>
+       <description>ADC Hi Limit Monitor Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>lo_limit_ie</name>
+       <description>ADC Lo Limit Monitor Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>overflow_ie</name>
+       <description>ADC Overflow Interrupt Enable</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>done_if</name>
+       <description>ADC Done Interrupt Flag</description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>ref_ready_if</name>
+       <description>ADC Reference Ready Interrupt Flag</description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>hi_limit_if</name>
+       <description>ADC Hi Limit Monitor Interrupt Flag</description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>lo_limit_if</name>
+       <description>ADC Lo Limit Monitor Interrupt Flag</description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>overflow_if</name>
+       <description>ADC Overflow Interrupt Flag</description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>pending</name>
+       <description>ADC Interrupt Pending Status</description>
+       <bitRange>[22:22]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>LIMIT[%s]</name>
+     <description>ADC Limit</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ch_lo_limit</name>
+       <description>Low Limit Threshold</description>
+       <bitRange>[9:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_hi_limit</name>
+       <description>High Limit Threshold</description>
+       <bitRange>[21:12]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_sel</name>
+       <description>ADC Channel Select</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_lo_limit_en</name>
+       <description>Low Limit Monitoring Enable</description>
+       <bitRange>[29:29]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_hi_limit_en</name>
+       <description>High Limit Monitoring Enable</description>
+       <bitRange>[30:30]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ADC 10-bit Analog to Digital Converter-->
+  <peripheral>
+   <name>AESKEYS</name>
+   <description>AES Key Registers.</description>
+   <baseAddress>0x40007800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>KEY0</name>
+     <description>AES Key 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY1</name>
+     <description>AES Key 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY2</name>
+     <description>AES Key 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY3</name>
+     <description>AES Key 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY4</name>
+     <description>AES Key 4.</description>
+     <addressOffset>0x10</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY5</name>
+     <description>AES Key 5.</description>
+     <addressOffset>0x14</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY6</name>
+     <description>AES Key 6.</description>
+     <addressOffset>0x18</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY7</name>
+     <description>AES Key 7.</description>
+     <addressOffset>0x1C</addressOffset>
+     <size>32</size>
+    </register>
+   </registers>
+  </peripheral>
+<!--AESKEYS AES Key Registers.-->
+  <peripheral>
+   <name>AES</name>
+   <description>AES Keys.</description>
+   <baseAddress>0x40007400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>AES Control Register</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>AES Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>DMA Request To Read Data Output FIFO</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>DMA Request To Write Data Input FIFO</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start AES Calculation</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FLUSH</name>
+       <description>Flush the data input FIFO</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FLUSH</name>
+       <description>Flush the data output FIFO</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_SIZE</name>
+       <description>Encryption Key Size</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AES128</name>
+         <description>128 Bits.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES192</name>
+         <description>192 Bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES256</name>
+         <description>256 Bits.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TYPE</name>
+       <description>Encryption Type Selection</description>
+       <bitRange>[9:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>AES Status Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>AES Busy Status</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_EM</name>
+       <description>Data input FIFO empty status</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FULL</name>
+       <description>Data input FIFO full status</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_EM</name>
+       <description>Data output FIFO empty status</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FULL</name>
+       <description>Data output FIFO full status</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>AES Interrupt Flag Register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>AES Interrupt Enable Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>AES Data Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>AES FIFO</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--AES AES Keys.-->
+  <peripheral>
+   <name>CRC</name>
+   <description>CRC Registers.</description>
+   <baseAddress>0x4000F000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>CRC Control</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>CRC Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_EN</name>
+       <description>DMA Request Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB</name>
+       <description>MSB Select</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BYTE_SWAP_IN</name>
+       <description>Byte Swap CRC Data Input</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BYTE_SWAP_OUT</name>
+       <description>Byte Swap CRC Value Output</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>CRC Busy</description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN32</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN16</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN8</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>POLY</name>
+     <description>CRC Polynomial</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>POLY</name>
+       <description>CRC Polynomial</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VAL</name>
+     <description>Current CRC Value</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>VALUE</name>
+       <description>Current CRC Value</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CRC CRC Registers.-->
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0</name>
+    <value>28</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1</name>
+    <value>29</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA2</name>
+    <value>30</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA3</name>
+    <value>31</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>INTEN</name>
+     <description>DMA Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel 0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <description>Channel 1 Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <description>Channel 2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <description>Channel 3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>DMA Interrupt Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel Interrupt. To clear an interrupt, all active interrupt bits of the DMA_ST must be cleared. The interrupt bits are set only if their corresponding interrupt enable bits are set in DMA_CN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>4</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CTRL</name>
+      <description>DMA Channel Control Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>EN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQUEST</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1RX</name>
+          <description>SPI1 RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0RX</name>
+          <description>UART0 RX</description>
+          <value>0x04</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1RX</name>
+          <description>UART1 RX</description>
+          <value>0x05</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0RX</name>
+          <description>I2C0 RX</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1RX</name>
+          <description>I2C1 RX</description>
+          <value>0x08</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>ADC</name>
+          <description>ADC</description>
+          <value>0x09</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2RX</name>
+          <description>I2C2 RX</description>
+          <value>0x0A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2RX</name>
+          <description>UART2 RX</description>
+          <value>0x0E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0RX</name>
+          <description>SPI0 RX</description>
+          <value>0x0F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESRX</name>
+          <description>AES RX</description>
+          <value>0x10</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3RX</name>
+          <description>UART3 RX</description>
+          <value>0x1C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2SRX</name>
+          <description>I2S RX</description>
+          <value>0x1E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1TX</name>
+          <description>SPI1 TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0TX</name>
+          <description>UART0 TX</description>
+          <value>0x24</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1TX</name>
+          <description>UART1 TX</description>
+          <value>0x25</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0TX</name>
+          <description>I2C0 TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1TX</name>
+          <description>I2C1 TX</description>
+          <value>0x28</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2TX</name>
+          <description>I2C2 TX</description>
+          <value>0x2A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>CRCTX</name>
+          <description>CRC TX</description>
+          <value>0x2C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2TX</name>
+          <description>UART2 TX</description>
+          <value>0x2E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0TX</name>
+          <description>SPI0 TX</description>
+          <value>0x2F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESTX</name>
+          <description>AES TX</description>
+          <value>0x30</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3TX</name>
+          <description>UART3 TX</description>
+          <value>0x3C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2STX</name>
+          <description>I2S TX</description>
+          <value>0x3E</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_WAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_PER</name>
+        <description>Timeout Period Select.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_CLKDIV</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BURST_SIZE</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>DIS_IE</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IE</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>STATUS</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>STATUS</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IF</name>
+        <description>Count-to-Zero (CTZ) Interrupt Flag</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>RLD_IF</name>
+        <description>Reload Event Interrupt Flag.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>TO_IF</name>
+        <description>Time-Out Event Interrupt Flag.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRCRLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DSTRLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNTRLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>EN</name>
+        <description>Reload Enable. This bit should be set after the address reload registers have been programmed. This bit is automatically cleared to 0 when reload occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+<!--DMA DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral>
+   <name>DVS</name>
+   <description>Dynamic Voltage Scaling</description>
+   <prependToName>DVS_</prependToName>
+   <baseAddress>0x40003C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0030</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DVS</name>
+    <description>Dynamic Voltage Scaling Interrupt</description>
+    <value>83</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTL</name>
+     <description>Control Register</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>MON_ENA</name>
+       <description>Enable the DVS monitoring circuit</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ENA</name>
+       <description>Enable the power supply adjustment based on measurements</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PS_FB_DIS</name>
+       <description>Power Supply Feedback Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTRL_TAP_ENA</name>
+       <description>Use the TAP Select for automatic adjustment or monitoring</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PROP_DLY</name>
+       <description>Additional delay to monitor lines</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>MON_ONESHOT</name>
+       <description>Measure delay once</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GO_DIRECT</name>
+       <description>Operate in automatic mode or move directly</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DIRECT_REG</name>
+       <description>Step incrementally to target voltage</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PRIME_ENA</name>
+       <description>Include a delay line priming signal before monitoring</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LIMIT_IE</name>
+       <description>Enable Limit Error Interrupt</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RANGE_IE</name>
+       <description>Enable Range Error Interrupt</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_IE</name>
+       <description>Enable Adjustment Error Interrupt</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>REF_SEL</name>
+       <description>Select TAP used for voltage adjustment</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>INC_VAL</name>
+       <description>Step size to increment voltage when in automatic mode</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>DVS_PS_APB_DIS</name>
+       <description>Prevent the application code from adjusting Vcore</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DVS_HI_RANGE_ANY</name>
+       <description>Any high range signal from a delay line will cause a voltage adjustment</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FB_TO_IE</name>
+       <description>Enable Voltage Adjustment Timeout Interrupt</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FC_LV_IE</name>
+       <description>Enable Low Voltage Interrupt</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PD_ACK_ENA</name>
+       <description>Prevent DVS from ack'ing a request to enter a low power mode until in the idle state</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ABORT</name>
+       <description>Causes the DVS to enter the idle state immediately on a request to enter a low power mode</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>Status Fields</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000000</resetValue>
+     <fields>
+      <field>
+       <name>DVS_STATE</name>
+       <description>State machine state</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_UP_ENA</name>
+       <description>DVS Raising voltage</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_DWN_ENA</name>
+       <description>DVS Lowering voltage</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ACTIVE</name>
+       <description>Adjustment to a Direct Voltage</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTR_TAP_OK</name>
+       <description>Tap Enabled and the Tap is withing Hi/Low limits</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTR_TAP_SEL</name>
+       <description>Status of selected center tap delay line detect output</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SLOW_TRIP_DET</name>
+       <description>Provides the current combined status of all selected Low Range delay lines</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FAST_TRIP_DET</name>
+       <description>Provides the current combined status of all selected High Range delay lines</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PS_IN_RANGE</name>
+       <description>Indicates if the power supply is in range</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PS_VCNTR</name>
+       <description>Voltage Count value sent to the power supply</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>MON_DLY_OK</name>
+       <description>Indicates the monitor delay count is at 0</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_DLY_OK</name>
+       <description>Indicates the adjustment delay count is at 0</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LO_LIMIT_DET</name>
+       <description>Power supply voltage counter is at low limit</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HI_LIMIT_DET</name>
+       <description>Power supply voltage counter is at high limit</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VALID_TAP</name>
+       <description>At least one delay line has been enabled</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LIMIT_ERR</name>
+       <description>Interrupt flag that indicates a voltage count is at/beyond manufacturer limits</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RANGE_ERR</name>
+       <description>Interrupt flag that indicates a tap has an invalid value</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ERR</name>
+       <description>Interrupt flag that indicates up and down adjustment requested simultaneously</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>REF_SEL_ERR</name>
+       <description>Indicates the ref select register  bit is out of range</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FB_TO_ERR</name>
+       <description>Interrupt flag that indicates a timeout while adjusting the voltage</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FB_TO_ERR_S</name>
+       <description>Interrupt flag that mirror FB_TO_ERR and is write one clear</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FC_LV_DET_INT</name>
+       <description>Interrupt flag that indicates the power supply voltage requested is below the low threshold</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FC_LV_DET_S</name>
+       <description>Interrupt flag that mirrors FC_LV_DET_INT</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DIRECT</name>
+     <description>Direct control of target voltage</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>VOLTAGE</name>
+       <description>Sets the target power supply value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MON</name>
+     <description>Monitor Delay</description>
+     <addressOffset>0x00C</addressOffset>
+     <fields>
+      <field>
+       <name>DLY</name>
+       <description>Number of prescaled clocks between delay line samples</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+      <field>
+       <name>PRE</name>
+       <description>Number of clocks before DVS_MON_DLY is decremented</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADJ_UP</name>
+     <description>Up Delay Register</description>
+     <addressOffset>0x010</addressOffset>
+     <fields>
+      <field>
+       <name>DLY</name>
+       <description>Number of prescaled clocks between updates of the adjustment delay counter</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PRE</name>
+       <description>Number of clocks before DVS_ADJ_UP_DLY is decremented</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADJ_DWN</name>
+     <description>Down Delay Register</description>
+     <addressOffset>0x014</addressOffset>
+     <fields>
+      <field>
+       <name>DLY</name>
+       <description>Number of prescaled clocks between updates of the adjustment delay counter</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PRE</name>
+       <description>Number of clocks before DVS_ADJ_DWN_DLY is decremented</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>THRES_CMP</name>
+     <description>Up Delay Register</description>
+     <addressOffset>0x018</addressOffset>
+     <fields>
+      <field>
+       <name>VCNTR_THRES_CNT</name>
+       <description>Value used to determine 'low voltage' range</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VCNTR_THRES_MASK</name>
+       <description>Mask applied to threshold and vcount to determine if the device is in a low voltage range</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>5</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>TAP_SEL[%s]</name>
+     <description>DVS Tap Select Register</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Select delay line tap for lower bound of auto adjustment</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>LO_TAP_STAT</name>
+       <description>Returns last delay line tap value</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTR_TAP_STAT</name>
+       <description>Returns last delay line tap value</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HI_TAP_STAT</name>
+       <description>Returns last delay line tap value</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Selects delay line tap for high point of auto adjustment</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>CTR</name>
+       <description>Selects delay line tap for center point of auto adjustment</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>COARSE</name>
+       <description>Selects delay line tap for coarse or fixed delay portion of the line</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>DET_DLY</name>
+       <description>Number of HCLK between delay line launch and sampling</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>DELAY_ACT</name>
+       <description>Set if the delay is active</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--DVS Dynamic Voltage Scaling-->
+  <peripheral>
+   <name>FCR</name>
+   <description>Function Control Register.</description>
+   <baseAddress>0x40000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>FCTRL0</name>
+     <description>Function Control 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>I2C0DGEN0</name>
+       <description>I2C0 SDA Pad Deglitcher enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0DGEN1</name>
+       <description>I2C0 SCL Pad Deglitcher enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN0</name>
+       <description>I2C1 SDA Pad Deglitcher enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN1</name>
+       <description>I2C1 SCL Pad Deglitcher enable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2DGEN0</name>
+       <description>I2C2 SDA Pad Deglitcher enable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2DGEN1</name>
+       <description>I2C2 SCL Pad Deglitcher enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL0</name>
+     <description>Automatic Calibration 0.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ACEN</name>
+       <description>Auto-calibration Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACRUN</name>
+       <description>Autocalibration Run.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDTRM</name>
+       <description>Load Trim.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GAININV</name>
+       <description>Invert Gain.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ATOMIC</name>
+       <description>Atomic mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MU</name>
+       <description>MU value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>HIRC96MACTMROUT</name>
+       <description>HIRC96M Trim Value.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL1</name>
+     <description>Automatic Calibration 1.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INITTRM</name>
+       <description>Initial Trim Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL2</name>
+     <description>Automatic Calibration 2</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONECNT</name>
+       <description>Auto-callibration Done Counter Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>ACDIV</name>
+       <description>Auto-callibration Div Setting.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>URVBOOTADDR</name>
+     <description>RISC-V Boot Address.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>URVCTRL</name>
+     <description>RISC-V Control Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MEMSEL</name>
+       <description>RAM2, RAM3 exclusive ownership.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IFLUSHEN</name>
+       <description>URV instruction flush enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ERFOKS</name>
+     <description>ERFO Kick Start Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>KSERFO_CNT</name>
+       <description>Kick Start ERFO Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>KSERFO_EN</name>
+       <description>Kick Start ERFO Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KSERFODRIVER</name>
+       <description>Kick Start ERFO Driver.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>KSERFO2X</name>
+       <description>Kick Start ERFO 2X Pulse.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KSCLKSEL</name>
+       <description>Kick Start Clock Select for ERFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ISO</name>
+         <description>ISO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>IPO.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FCR Function Control Register.-->
+  <peripheral>
+   <name>FLC</name>
+   <description>Flash Memory Control.</description>
+   <prependToName>FLSH_</prependToName>
+   <baseAddress>0x40029000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Flash_Controller</name>
+    <description>Flash Controller interrupt.</description>
+    <value>23</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ADDR</name>
+     <description>Flash Write Address.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address for next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Flash Clock Divide. The clock (PLL0) is divided by this value to generate a 1 MHz clock for Flash controller.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000064</resetValue>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Flash Clock Divide. The clock is divided by this value to generate a 1MHz clock for flash controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Flash Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WR</name>
+       <description>Write.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="WR">
+       <name>ME</name>
+       <description>Mass Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="WR">
+       <name>PGE</name>
+       <description>Page Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERASE_CODE</name>
+       <description>Erase Code.  The ERASE_CODE must be set up property before erase operation can be initiated. These bits are automatically cleared after the operation is complete.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>erasePage</name>
+         <description>Enable Page Erase.</description>
+         <value>0x55</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>eraseAll</name>
+         <description>Enable Mass Erase. The debug port must be enabled.</description>
+         <value>0xAA</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PEND</name>
+       <description>Flash Pending.  When Flash operation is in progress (busy), Flash reads and writes will fail. When PEND is set, write to all Flash registers, with exception of the Flash interrupt register, are ignored.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LVE</name>
+       <description>Low Voltage enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNLOCK</name>
+       <description>Flash Unlock.  The correct unlock code must be written to these four bits before any Flash write or erase operation is allowed.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Flash Unlocked.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Flash Locked.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Flash Interrupt Register.</description>
+     <addressOffset>0x024</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Flash Done Interrupt.  This bit is set to 1 upon Flash write or erase completion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AF</name>
+       <description>Flash Access Fail.  This bit is set when an attempt is made to write the flash while the flash is busy or the flash is locked. This bit can only be set to 1 by hardware.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONEIE</name>
+       <description>Flash Done Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DONEIE">
+       <name>AFIE</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCDATA</name>
+     <description>ECC Data Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>EVEN</name>
+       <description>Error Correction Code Odd Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>ODD</name>
+       <description>Error Correction Code Even Data.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA[%s]</name>
+     <description>Flash Write Data.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACTRL</name>
+     <description>Access Control Register. Writing the ACTRL register with the following values in the order shown, allows read and write access to the system and user Information block:
+    pflc-actrl = 0x3a7f5ca3;
+    pflc-actrl = 0xa1e34f20;
+    pflc-actrl = 0x9608b2c1. When unlocked, a write of any word will disable access to system and user information block. Readback of this register is always zero.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ACTRL</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR0</name>
+     <description>WELR0</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>WELR0</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR1</name>
+     <description>WELR1</description>
+     <addressOffset>0x88</addressOffset>
+     <fields>
+      <field>
+       <name>WELR1</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR0</name>
+     <description>RLR0</description>
+     <addressOffset>0x90</addressOffset>
+     <fields>
+      <field>
+       <name>RLR0</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR1</name>
+     <description>RLR1</description>
+     <addressOffset>0x98</addressOffset>
+     <fields>
+      <field>
+       <name>RLR1</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FLC Flash Memory Control.-->
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x40000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SYSCTRL</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>BSTAPEN</name>
+       <description>Boundary Scan TAP enable. When enabled, the JTAG port is conneted to the Boundary Scan TAP instead of the ARM ICE.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH_PAGE_FLIP</name>
+       <description>Flips the Flash bottom and top halves. (Depending on the total flash size, each half is either 256K or 512K). Initiating a flash page flip will cause a flush of both the data buffer on the DCODE bus and the internal instruction buffer.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Physical layout matches logical layout.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>swapped</name>
+         <description>Bottom half mapped to logical top half and vice versa.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICC0_FLUSH</name>
+       <description>Code Cache Flush. This bit is used to flush the code caches and the instruction buffer of the Cortex-M4. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROMDONE</name>
+       <description>ROM_DONE status. Used to disable SWD interface during system initialization procedure</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CCHK</name>
+       <description>Compute ROM Checksum. This bit is self-cleared when calculation is completed. Once set, software clearing this bit is ignored and the bit will remain set until the operation is completed.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SWD_DIS</name>
+       <description> Serial Wire Debug Disable. This bit is used to disable the serial wire debug interface This bit is only writeable if (FMV lock word is not programmed) or if (ICE lock word is not programmed and the ROM_DONE bit is not set).</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHKRES</name>
+       <description>ROM Checksum Result. This bit is only valid when CHKRD=1.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pass</name>
+         <description>ROM Checksum Correct.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fail</name>
+         <description>ROM Checksum Fail.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OVR</name>
+       <description>Operating Voltage Range.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA">
+       <name>WDT0</name>
+       <description>Watchdog Timer 0 Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO1</name>
+       <description>GPIO1 Reset. Setting this bit to 1 resets GPIO1 pins to their default states.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR0</name>
+       <description>Timer 0 Reset. Setting this bit to 1 resets Timer 0 blocks.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR1</name>
+       <description>Timer 1 Reset. Setting this bit to 1 resets Timer 1 blocks.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR2</name>
+       <description>Timer 2 Reset. Setting this bit to 1 resets Timer 2 blocks.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR3</name>
+       <description>Timer 3 Reset. Setting this bit to 1 resets Timer 3 blocks.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART0</name>
+       <description>UART 0 Reset. Setting this bit to 1 resets all UART 0 blocks.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART1</name>
+       <description>UART 1 Reset. Setting this bit to 1 resets all UART 1 blocks.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI1</name>
+       <description>SPI 1 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>I2C0</name>
+       <description>I2C 0 Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>RTC</name>
+       <description>Real Time Clock Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SMPHR</name>
+       <description>Semaphore Reset.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TRNG</name>
+       <description>TRNG Reset. This reset is only available during the manufacture testing phase.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>CNN</name>
+       <description>CNN Reset.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>ADC</name>
+       <description>ADC Reset.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART2</name>
+       <description>UART2 Reset. Setting this bit to 1 resets all UART 2 blocks.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SOFT</name>
+       <description>Soft Reset. Setting this bit to 1 resets everything except the CPU and the watchdog timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>PERIPH</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SYS</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>SYSCLK_DIV</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the PLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_SEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ISO</name>
+         <description>The internal 60 MHz oscillator is used for the system clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERFO</name>
+         <description>32MHz Crystal is used for the system clock.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INRO</name>
+         <description>8 kHz LIRC is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>The internal 96 MHz oscillator is used for the system clock.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBRO</name>
+         <description>The internal 7.3725 MHz oscillator is used for the system clock.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERTCO</name>
+         <description> 32 kHz is used for the system clock.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EXTCLK</name>
+         <description> External clock on GPIO0.30.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_RDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_EN</name>
+       <description>32MHz Crystal Oscillator Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>32 kHz Crystal Oscillator Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>ISO_EN</name>
+       <description>60 MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>IPO_EN</name>
+       <description>100 MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>IBRO_EN</name>
+       <description>7.3725 MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_VS</name>
+       <description>7.3725 MHz High Frequency Internal Reference Clock Voltage Select. This register bit is used to select the power supply to the IBRO.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Vcor</name>
+         <description>VCore Supply</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1V</name>
+         <description>Dedicated 1V regulated supply.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_RDY</name>
+       <description>32MHz Crystal Oscillator Ready</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERTCO_RDY</name>
+       <description>32 kHz Crystal Oscillator Ready</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>ISO_RDY</name>
+       <description>60 MHz HIRC Ready.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>IPO_RDY</name>
+       <description>100 MHz HIRC Ready.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>IBRO_RDY</name>
+       <description>7.3725 MHz HIRC Ready.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>INRO_RDY</name>
+       <description>8 kHz Low Frequency Reference Clock Ready.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PM</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This two bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sleep</name>
+         <description>Cortex-M4 Active, RISC-V Sleep Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>standby</name>
+         <description>Standby Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>backup</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>lpm</name>
+         <description>LPM or CM4 Deep Sleep Mode.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>upm</name>
+         <description>UPM.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>powerdown</name>
+         <description>Power Down Mode.</description>
+         <value>10</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO_WE</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wake Up Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wake Up Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>RTC_WE</name>
+       <description>RTC Alarm Wake Up Enable. This bit enables RTC alarm as wakeup source. If enabled, the desired RTC alarm must be configured via the RTC control registers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>WUT_WE</name>
+       <description>WUT Wake Up Enable. This bit enables the Wake-Up Timer as wakeup source. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>AINCOMP_WE</name>
+       <description>AIN COMP Wake Up Enable. This bit enables AIN COMP as wakeup source. </description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ISO_PD</name>
+       <description>60 MHz power down. This bit selects the 60 MHz clock power state in DEEPSLEEP mode.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ISO_PD">
+       <name>IPO_PD</name>
+       <description>100 MHz power down. This bit selects 100 MHz clock power state in DEEPSLEEP mode. </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ISO_PD">
+       <name>IBRO_PD</name>
+       <description>7.3725 MHz power down. This bit selects 7.3725 MHz clock power state in DEEPSLEEP mode. </description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_BP</name>
+       <description>32MHz Oscillator Bypass</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIV</name>
+     <description>Peripheral Clock Divider.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>ADCFRQ</name>
+       <description>ADC clock Frequency. These bits define the ADC clock frequency. fADC = fPCLK / (ADCFRQ)</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CNNCLKDIV</name>
+       <description>CNN Clock Divider.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div2</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div1</name>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CNNCLKSEL</name>
+       <description>CNN Clock Select.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>system</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBRO60</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0</name>
+       <description>GPIO0 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>GPIO1</name>
+       <description>GPIO1 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>DMA</name>
+       <description>DMA Clock Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI1</name>
+       <description>SPI 1 Clock Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART0</name>
+       <description>UART 0 Clock Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART1</name>
+       <description>UART 1 Clock Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C0</name>
+       <description>I2C 0 Clock Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR0</name>
+       <description>Timer 0 Clock Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR1</name>
+       <description>Timer 1 Clock Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR2</name>
+       <description>Timer 2 Clock Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR3</name>
+       <description>Timer 3 Clock Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>ADC</name>
+       <description>ADC Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>CNN</name>
+       <description>CNN Clock Disable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C1</name>
+       <description>I2C 1 Clock Disable.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>PT</name>
+       <description>Pluse Train Clock Disable.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCTRL</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 2.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM0ECC</name>
+       <description>SYSRAM0 ECC Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMZ</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM Block 0 Zeroization.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM1</name>
+       <description>System RAM Block 1 Zeroization.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM2</name>
+       <description>System RAM Block 2 Zeroization.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM3</name>
+       <description>System RAM Block 3 Zeroization.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>SYSRAM0ECC</name>
+       <description>System RAM 0 ECC Zeroization.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICC0</name>
+       <description>Instruction Cachei 0 Zeroization.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICC1</name>
+       <description>Instruction Cachei 1 Zeroization.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSST</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICELOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>I2C1</name>
+       <description>I2C1 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>PT</name>
+       <description>PT Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>OWM</name>
+       <description>OWM Reset.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>CRC</name>
+       <description>CRC Reset.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AES</name>
+       <description>AES Reset.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPI0</name>
+       <description>SPI 0 Reset.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SMPHR</name>
+       <description>SMPHR Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2S</name>
+       <description>I2S Reset.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2C2</name>
+       <description>I2C2 Reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>DVS</name>
+       <description>DVS Reset.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SIMO</name>
+       <description>SIMO Reset.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>CPU1</name>
+       <description>CPU1 Reset.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>BTLE</name>
+       <description>Bluetooth Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART2</name>
+       <description>UART2 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="UART2">
+       <name>TRNG</name>
+       <description>TRNG Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SMPHR</name>
+       <description>SMPHR Clock Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>OWM</name>
+       <description>One-Wire Clock Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>CRC</name>
+       <description>CRC Clock Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>AES</name>
+       <description>AES Clock Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SPI0</name>
+       <description>SPI 0 Clock Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>PCIF</name>
+       <description>Parallel Camera Interface Clock Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>I2S</name>
+       <description>I2S Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>I2C2</name>
+       <description>I2C2 Clock Disable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>WDT0</name>
+       <description>Watch Dog Timer 0 Clock Disable.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>CPU1</name>
+       <description>CPU1 Clock Disable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVENTEN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Enable RXEV pin event. When this bit is set, a logic high of GPIO1.8 will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO1.9.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REVISION</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSIE</name>
+     <description>System Status Interrupt Enable Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEUNLOCK</name>
+       <description>ARM ICE Unlock Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCERR</name>
+     <description>ECC Error Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCCED</name>
+     <description>ECC Not Double Error Detect Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCIE</name>
+     <description>ECC IRQ Enable Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Interrup Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCADDR</name>
+     <description>ECC Error Address Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ECCERRAD</name>
+       <description>ECC Error Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLELDOCTRL</name>
+     <description>BTLE LDO Control Register</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>LDOBBEN</name>
+       <description>LDOBB Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBPULLD</name>
+       <description>LDOBB Pull Down.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBVSEL</name>
+       <description>LDOBB Voltage Setting.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_85</name>
+         <description>0.85V</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>0_9</name>
+         <description>0.9V</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0</name>
+         <description>1.0V</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1</name>
+         <description>1.1V</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDORFEN</name>
+       <description>LDORF Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORFPULLD</name>
+       <description>LDORF Pull Down.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORFVSEL</name>
+       <description>LDORF Voltage Setting.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_85</name>
+         <description>0.85V</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>0_9</name>
+         <description>0.9V</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0</name>
+         <description>1.0V</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1</name>
+         <description>1.1V</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDORFBYP</name>
+       <description>LDORF Bypass Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORFDISCH</name>
+       <description>LDORF Discharge.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBBYP</name>
+       <description>LDOBB Bypass Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBDISCH</name>
+       <description>LDOBB Discharge.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBENDLY</name>
+       <description>LDOBB Enable Delay.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORFENDLY</name>
+       <description>LDORF Enable Delay.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORFBYPENENDLY</name>
+       <description>LDORF Bypass Enable Delay.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBBYPENENDLY</name>
+       <description>LDOBB Bypass Enable Delay.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLELDODLY</name>
+     <description>BTLE LDO Delay Register</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>BYPDLYCNT</name>
+       <description>Bypass Delay Count.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBDLYCNT</name>
+       <description>LDOBB Delay Count.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>LDORFDLYCNT</name>
+       <description>LDOBB Delay Count.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPR</name>
+     <description>General Purpose Register.</description>
+     <addressOffset>0x80</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCR Global Control Registers.-->
+  <peripheral>
+   <name>GCFR</name>
+   <description>Global Control Function Register.</description>
+   <baseAddress>0x40005800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>REG0</name>
+     <description>Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ISO_WUP</name>
+       <description>ISO Warm Up Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>IPO_WUP</name>
+       <description>IPO Warm Up Value.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REG1</name>
+     <description>Register 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ERFO_WUP</name>
+       <description>ERFO Warm Up Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_WUP</name>
+       <description>IBRO Warm Up Value.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCFR Global Control Function Register.-->
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x40008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN0</name>
+     <description>GPIO Function Enable Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_SET</name>
+     <description>GPIO Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_OUT bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_IN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTMODE</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTMODE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTPOL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTPOL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INEN</name>
+     <description>GPIO Input Enable</description>
+     <addressOffset>0x30</addressOffset>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_INTFL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WKEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DUALEDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DUALEDGE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL0</name>
+     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL0</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL1</name>
+     <description>GPIO Input Mode Config 2. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL1</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_SET</name>
+     <description>GPIO Alternate Function Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN2</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_SET</name>
+     <description>GPIO Alternate Function 2 Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN2 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_CLR</name>
+     <description>GPIO Wake Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN2 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x7C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HYSEN</name>
+     <description>GPIO Input Hysteresis Enable.</description>
+     <addressOffset>0xA8</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_HYSEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SRSEL</name>
+     <description>GPIO Slew Rate Enable Register.</description>
+     <addressOffset>0xAC</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_SRSEL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>FAST</name>
+         <description>Fast Slew Rate selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SLOW</name>
+         <description>Slow Slew Rate selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS0</name>
+     <description>GPIO Drive Strength  Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS0</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ld</name>
+         <description>GPIO port pin is in low-drive mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hd</name>
+         <description>GPIO port pin is in high-drive mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PS</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VSSEL</name>
+     <description>GPIO Voltage Select.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GPIO0 Individual I/O for each GPIO-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO1</name>
+   <description>Individual I/O for each GPIO 1</description>
+   <baseAddress>0x40009000</baseAddress>
+   <interrupt>
+    <name>GPIO1</name>
+    <description>GPIO1 IRQ</description>
+    <value>25</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO1 Individual I/O for each GPIO 1-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO2</name>
+   <description>Individual I/O for each GPIO 2</description>
+   <baseAddress>0x40080400</baseAddress>
+   <interrupt>
+    <name>GPIO2</name>
+    <description>GPIO2 IRQ</description>
+    <value>26</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO2 Individual I/O for each GPIO 2-->
+  <peripheral>
+   <name>I2C0</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>I2C</groupName>
+   <baseAddress>0x4001D000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2C0</name>
+    <description>I2C0 IRQ</description>
+    <value>13</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>I2C Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable I2C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable I2C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave_mode</name>
+         <description>Slave Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master_mode</name>
+         <description>Master Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_EN</name>
+       <description>General Call Address Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Ignore Gneral Call Address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Acknowledge general call address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_EN</name>
+       <description>Interactive Receive Mode.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interactive Receive Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interactive Receive Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_ACK</name>
+       <description>Data Acknowledge. This bit defines the acknowledge bit returned by the I2C receiver while IRXM = 1 HW forces ACK to 0 when IRXM = 0.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ack</name>
+         <description>return ACK (pulling SDA LOW).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>return NACK (leaving SDA HIGH).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_OUT</name>
+       <description>SCL Output. This bits control SCL output when SWOE =1.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_scl_low</name>
+         <description>Drive SCL low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_scl</name>
+         <description>Release SCL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDA_OUT</name>
+       <description>SDA Output. This bits control SDA output when SWOE = 1. </description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_sda_low</name>
+         <description>Drive SDA low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_sda</name>
+         <description>Release SDA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL</name>
+       <description>SCL status. This bit reflects the logic gate of SCL signal. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDA</name>
+       <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BB_MODE</name>
+       <description>Software Output Enable.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>outputs_disable</name>
+         <description>I2C Outputs SCLO and SDAO disabled. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputs_enable</name>
+         <description>I2C Outputs SCLO and SDAO enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read. This bit reflects the R/W bit of an address match (AMI = 1) or general call match (GCI = 1). This bit is valid 3 cycles after the relevant interrupt bit is set.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKSTR_DIS</name>
+       <description>This bit will disable slave clock stretching when set.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Slave clock stretching enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Slave clock stretching disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ONE_MST_MODE</name>
+       <description>SCL Push-Pull Mode. This bit controls whether SCL is operated in a the I2C standard open-drain mode, or in a non-standard push-pull mode where the Hi-Z output isreplaced with Drive-1. The non-standard mode should only be used when operating as a master and communicating with slaves that are guaranteed to never drive SCL low. </description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Standard open-drain operation:
+					drive low for 0, Hi-Z for 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Non-standard push-pull operation:
+					drive low for 0, drive high for 1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HS_EN</name>
+       <description>High speed mode enable</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>Bus Status.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>I2C Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>I2C Bus Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>RX empty.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX Full.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX Empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>TX Full.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_BUSY</name>
+       <description>Clock Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_actively_driving_scl_clock</name>
+         <description>Device not actively driving SCL clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>actively_driving_scl_clock</name>
+         <description>Device operating as master and actively driving SCL clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL0</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <name>INT_FL0_Done</name>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Interactive Receive Interrupt.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave General Call Address Match Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave Address Match Interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Receive Threshold Interrupt. This bit is automaticcaly cleared when RX_FIFO is below the threshold level.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. RX_FIFO equal or more bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>Transmit Threshold Interrupt. This bit is automaticcaly cleared when TX_FIFO is above the threshold level.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP Interrupt.</description>
+       <bitRange>[6:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Address Acknowledge Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Arbritation error Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>timeout Error Interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Address NACK Error Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Data NACK Error Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Do Not Respond Error Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Start Error Interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Stop Error Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>Transmit Lock Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN0</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when DONE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Description not available.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when RX_MODE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave mode general call address match received input enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when GEN_CTRL_ADDR = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave mode incoming address match interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when ADDR_MATCH = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Above Treshold Level Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Below Treshold Level Interrupt Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Stop Interrupt Enable</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when STOP = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Received Address ACK from Slave Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Master Mode Arbitration Lost Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>Timeout Error Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Master Mode Address NACK Received Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Master Mode Data NACK Received Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Slave Mode Do Not Respond Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Out of Sequence START condition detected interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Out of Sequence STOP condition detected interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>TX FIFO Locked Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL1</name>
+     <description>Interrupt Status Register 1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt. When operating as a slave receiver, this bit is set when you reach the first data bit and the RX FIFO and shift register are both full.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt. When operating as a slave transmitter, this bit is set when you reach the first data bit and the TX FIFO is empty and the master is still asking for more data (i.e the master hasn't sent a NACK yet).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Status Flag.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN1</name>
+     <description>Interrupt Staus Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOLEN</name>
+     <description>FIFO Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RX_DEPTH</name>
+       <description>Receive FIFO Length.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DEPTH</name>
+       <description>Transmit FIFO Length.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL0</name>
+     <description>Receive Control Register 0.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>DNR</name>
+       <description>Do Not Respond.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Always respond to address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>not_respond_rx_fifo_empty</name>
+         <description>Do not respond to address match when RX_FIFO is not empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Receive FIFO Flush. This bit is automatically cleared to 0 after the operation. Setting this bit to 1 will affect RX_FIFO status.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush RX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_LVL</name>
+       <description>Receive FIFO Threshold. These bits define the RX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL1</name>
+     <description>Receive Control Register 1.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Receive Count Bits. These bits define the number of bytes to be received in a transaction, except for the case RXCNT = 0. RXCNT = 0 means 256 bytes to be received in a transaction.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Receive FIFO Count. These bits reflect the number of byte in the RX_FIFO. These bits are flushed when I2CEN = 0.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL0</name>
+     <description>Transmit Control Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_MODE</name>
+       <description>Transmit FIFO Preaload Mode. Setting this bit will allow for high speed application to preload the transmit FIFO prior to Slave Address Match.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TX_READY_MODE</name>
+       <description>Transmit FIFO Ready Manual Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW control of I2CTXRDY enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW control of I2CTXRDY disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO General Call Address Match Auto Flush Disable.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Write Auto Flush Disable.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Read Auto Flush Disable.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NACK_FLUSH_DIS</name>
+       <description>TX FIFO received NACK Auto Flush Disable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Transmit FIFO Flush. This bit is automatically cleared to 0 after the operation.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush TX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_VAL</name>
+       <description>Transmit FIFO Threshold. These bits define the TX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL1</name>
+     <description>Transmit Control Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_RDY</name>
+       <description>Transmit FIFO Preload Ready.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Transmit FIFO Count. These bits reflect the number of bytes in the TX_FIFO.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MSTCTRL</name>
+     <description>Master Control Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Setting this bit to 1 will start a master transfer.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>RESTART</name>
+       <description>Setting this bit to 1 will generate a repeated START.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Setting this bit to 1 will generate a STOP condition.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>EX_ADDR_EN</name>
+       <description>Slave Extend Address Select.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKLO</name>
+     <description>Clock Low Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock low. In master mode, these bits define the SCL low period. In slave mode, these bits define the time SCL will be held low after data is outputted.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKHI</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>HI</name>
+       <description>Clock High. In master mode, these bits define the SCL high period.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HSCLK</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock Low. This field sets the Hs-Mode clock low count. In Slave mode, this is the time SCL is held low after data is output on SDA.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Clock High. This field sets the Hs-Mode clock high count. In Slave mode, this is the time SCL is held high after data is output on SDA</description>
+       <bitRange>[15:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TIMEOUT</name>
+     <description>Timeout Register</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_TO_VAL</name>
+       <description>Timeout</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>SLAVE_MULTI[%s]</name>
+     <description>Slave Address Register.</description>
+     <alternateRegister>SLAVE0</alternateRegister>
+     <addressOffset>0x4C</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Slave Address.</description>
+       <bitRange>[9:0]</bitRange>
+      </field>
+      <field>
+       <name>DIS</name>
+       <description>Slave Disable.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>EXT_ADDR_EN</name>
+       <description>Extended Address Select.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLAVE0</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE1</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x50</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE2</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x54</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE3</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x58</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2C0 Inter-Integrated Circuit.-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C1</name>
+   <description>Inter-Integrated Circuit. 1</description>
+   <baseAddress>0x4001E000</baseAddress>
+   <interrupt>
+    <name>I2C1</name>
+    <description>I2C1 IRQ</description>
+    <value>36</value>
+   </interrupt>
+  </peripheral>
+<!--I2C1 Inter-Integrated Circuit. 1-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C2</name>
+   <description>Inter-Integrated Circuit. 2</description>
+   <baseAddress>0x4001F000</baseAddress>
+   <interrupt>
+    <name>I2C2</name>
+    <description>I2C2 IRQ</description>
+    <value>62</value>
+   </interrupt>
+  </peripheral>
+<!--I2C2 Inter-Integrated Circuit. 2-->
+  <peripheral>
+   <name>I2S</name>
+   <description>Inter-IC Sound Interface.</description>
+   <groupName>I2S</groupName>
+   <baseAddress>0x40060000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2S</name>
+    <description>I2S IRQ</description>
+    <value>99</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0CH0</name>
+     <description>Global mode channel.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>LSB_FIRST</name>
+       <description>LSB Transmit Receive First.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_FILT</name>
+       <description>PDM Filter.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_EN</name>
+       <description>PDM Enable.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>USEDDR</name>
+       <description>DDR.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_INV</name>
+       <description>Invert PDM.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_MODE</name>
+       <description>SCK Select.</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>WS_POL</name>
+       <description>WS polarity select. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB_LOC</name>
+       <description>MSB location. </description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ALIGN</name>
+       <description>Align to MSB or LSB.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EXT_SEL</name>
+       <description>External SCK/WS selection.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>STEREO</name>
+       <description>Stereo mode of I2S.</description>
+       <bitRange>[13:12]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WSIZE</name>
+       <description>Data size when write to FIFO.</description>
+       <bitRange>[15:14]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable. </description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable. </description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Flushes the TX/RX FIFO buffer. </description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RST</name>
+       <description>Write 1 to reset channel. </description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_LSB</name>
+       <description>Bit Field Control. </description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>depth of receive FIFO for threshold interrupt generation. </description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1CH0</name>
+     <description>Local channel Setup.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>BITS_WORD</name>
+       <description>I2S word length.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>I2S clock enable.</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SMP_SIZE</name>
+       <description>I2S sample size length.</description>
+       <bitRange>[13:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ADJUST</name>
+       <description>LSB/MSB Justify.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>I2S clock frequency divisor.</description>
+       <bitRange>[31:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FILTCH0</name>
+     <description>Filter.</description>
+     <addressOffset>0x20</addressOffset>
+    </register>
+    <register>
+     <name>DMACH0</name>
+     <description>DMA Control.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DMA_TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger.</description>
+       <bitRange>[6:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA channel enable.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_THD_VAL</name>
+       <description>RX FIFO Level DMA Trigger.</description>
+       <bitRange>[14:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA channel enable.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Number of data word in the TX FIFO.</description>
+       <bitRange>[23:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Number of data word in the RX FIFO.</description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOCH0</name>
+     <description>I2S Fifo.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>ISR Status.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Status for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Status for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Status for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Status for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Enable for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Enable for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Enable for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Enable for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EXTSETUP</name>
+     <description>Ext Control.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>EXT_BITS_WORD</name>
+       <description>Word Length for ch_mode.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wakeup Enable.</description>
+     <addressOffset>0x5C</addressOffset>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wakeup Flags.</description>
+     <addressOffset>0x60</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2S Inter-IC Sound Interface.-->
+  <peripheral>
+   <name>ICC0</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x4002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x800</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>INFO</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SZ</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCH</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEM</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ICC0 Instruction Cache Controller Registers-->
+  <peripheral>
+   <name>LPCMP</name>
+   <description>Low Power Comparator</description>
+   <baseAddress>0x40088000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>LPCMP</name>
+    <description>Low Power Comparato</description>
+    <value>103</value>
+   </interrupt>
+   <registers>
+    <register>
+     <dim>3</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CTRL[%s]</name>
+     <description>Comparator Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Comparator Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>POL</name>
+       <description>Polarity Select</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTEN</name>
+       <description>IRQ Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUT</name>
+       <description>Raw Compartor Input.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTFL</name>
+       <description>IRQ Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--LPCMP Low Power Comparator-->
+  <peripheral>
+   <name>LPGCR</name>
+   <description>Low Power Global Control.</description>
+   <baseAddress>0x40080000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RST</name>
+     <description>Low Power Reset Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO2</name>
+       <description>Low Power GPIO 2 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>WDT1</name>
+       <description>Low Power Watchdog Timer 1 Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR4</name>
+       <description>Low Power Timer 4 Reset.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR5</name>
+       <description>Low Power Timer 5 Reset.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>UART3</name>
+       <description>Low Power UART 3 Reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>LPCOMP</name>
+       <description>Low Power Comparator Reset.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS</name>
+     <description>Low Power Peripheral Clock Disable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO2</name>
+       <description>Low Power GPIO 2 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>WDT1</name>
+       <description>Low Power Watchdog 1 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR4</name>
+       <description>Low Power Timer 4 Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR5</name>
+       <description>Low Power Timer 5 Clock Disable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>UART3</name>
+       <description>Low Power UART 3 Clock Disable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>LPCOMP</name>
+       <description>Low Power Comparator Clock Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--LPGCR Low Power Global Control.-->
+  <peripheral>
+   <name>MCR</name>
+   <description>Misc Control.</description>
+   <baseAddress>0x40006C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>ECCEN</name>
+     <description>ECC Enable Register</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>ECC System RAM0 Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPO_MTRIM</name>
+     <description>IPO Manual Register</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>MTRIM</name>
+       <description>Manual Trim Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>TRIM_RANGE</name>
+       <description>Trim Range Select.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>Output Enable Register</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>SQWOUT_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PDOWN_OUT_EN</name>
+       <description>Power Down Output Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP_CTRL</name>
+     <description>Comparator Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Comparator Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>POL</name>
+       <description>Polarity Select</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INT_EN</name>
+       <description>IRQ Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUT</name>
+       <description>Comparator Output State.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INT_FL</name>
+       <description>IRQ Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Miscellaneous Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>INRO_EN</name>
+       <description>INRO Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>ERTCO Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SIMO_CLKSCL_EN</name>
+       <description>SIMO Clock Scaling Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SIMO_RSTD</name>
+       <description>SIMO System Reset Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO3_CTRL</name>
+     <description>GPIO3 Pin Control Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>P30_DO</name>
+       <description>GPIO3 Pin 0 Data Output.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P30_OE</name>
+       <description>GPIO3 Pin 0 Output Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P30_PE</name>
+       <description>GPIO3 Pin 0 Pull-up Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P30_IN</name>
+       <description>GPIO3 Pin 0 Input Status.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_DO</name>
+       <description>GPIO3 Pin 1 Data Output.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_OE</name>
+       <description>GPIO3 Pin 1 Output Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_PE</name>
+       <description>GPIO3 Pin 1 Pull-up Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_IN</name>
+       <description>GPIO3 Pin 1 Input Status.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--MCR Misc Control.-->
+  <peripheral>
+   <name>OWM</name>
+   <description>1-Wire Master Interface.</description>
+   <baseAddress>0x4003D000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>OneWire</name>
+    <value>67</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CFG</name>
+     <description>1-Wire Master Configuration.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>long_line_mode</name>
+       <description>Long Line Mode.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>force_pres_det</name>
+       <description>Force Line During Presence Detect.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_en</name>
+       <description>Bit Bang Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_mode</name>
+       <description>Provide an extra output control to control an external pullup.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_enable</name>
+       <description>Enable External Pullup.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>single_bit_mode</name>
+       <description>Enable Single Bit TX/RX Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>overdrive</name>
+       <description>Enables overdrive speed for 1-Wire operations.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>int_pullup_enable</name>
+       <description>Enable intenral pullup.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_DIV_1US</name>
+     <description>1-Wire Master Clock Divisor.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>divisor</name>
+       <description>Clock Divisor for 1Mhz.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL_STAT</name>
+     <description>1-Wire Master Control/Status.</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>start_ow_reset</name>
+       <description>Start OW Reset.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>sra_mode</name>
+       <description>SRA Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_oe</name>
+       <description>Bit Bang Output Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ow_input</name>
+       <description>OW Input State.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>od_spec_mode</name>
+       <description>Overdrive Spec Mode.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>presence_detect</name>
+       <description>Presence Pulse Detected.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>1-Wire Master Data Buffer.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>tx_rx</name>
+       <description>TX/RX Buffer.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>1-Wire Master Interrupt Flags.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>TX Data Empty Interrupt Flag.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>RX Data Ready Interrupt Flag</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Flag.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Flag.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>1-Wire Master Interrupt Enables.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>Tx Data Empty Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>Rx Data Ready Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Enable.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--OWM 1-Wire Master Interface.-->
+  <peripheral>
+   <name>PT</name>
+   <description>Pulse Train</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C020</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0010</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RATE_LENGTH</name>
+     <description>Pulse Train Configuration</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>rate_control</name>
+       <description>Pulse Train Enable and Rate Control. Set to 0 to disable the Pulse Train.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>27</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>mode</name>
+       <description>Pulse Train Output Mode/Train Length</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>32_BIT</name>
+         <description>Pulse train, 32 bit pattern.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SQUARE_WAVE</name>
+         <description>Square wave mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_BIT</name>
+         <description>Pulse train, 2 bit pattern.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_BIT</name>
+         <description>Pulse train, 3 bit pattern.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_BIT</name>
+         <description>Pulse train, 4 bit pattern.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5_BIT</name>
+         <description>Pulse train, 5 bit pattern.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_BIT</name>
+         <description>Pulse train, 6 bit pattern.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7_BIT</name>
+         <description>Pulse train, 7 bit pattern.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_BIT</name>
+         <description>Pulse train, 8 bit pattern.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9_BIT</name>
+         <description>Pulse train, 9 bit pattern.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_BIT</name>
+         <description>Pulse train, 10 bit pattern.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11_BIT</name>
+         <description>Pulse train, 11 bit pattern.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_BIT</name>
+         <description>Pulse train, 12 bit pattern.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13_BIT</name>
+         <description>Pulse train, 13 bit pattern.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14_BIT</name>
+         <description>Pulse train, 14 bit pattern.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15_BIT</name>
+         <description>Pulse train, 15 bit pattern.</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_BIT</name>
+         <description>Pulse train, 16 bit pattern.</description>
+         <value>16</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>17_BIT</name>
+         <description>Pulse train, 17 bit pattern.</description>
+         <value>17</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>18_BIT</name>
+         <description>Pulse train, 18 bit pattern.</description>
+         <value>18</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>19_BIT</name>
+         <description>Pulse train, 19 bit pattern.</description>
+         <value>19</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>20_BIT</name>
+         <description>Pulse train, 20 bit pattern.</description>
+         <value>20</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>21_BIT</name>
+         <description>Pulse train, 21 bit pattern.</description>
+         <value>21</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>22_BIT</name>
+         <description>Pulse train, 22 bit pattern.</description>
+         <value>22</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>23_BIT</name>
+         <description>Pulse train, 23 bit pattern.</description>
+         <value>23</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>24_BIT</name>
+         <description>Pulse train, 24 bit pattern.</description>
+         <value>24</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>25_BIT</name>
+         <description>Pulse train, 25 bit pattern.</description>
+         <value>25</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>26_BIT</name>
+         <description>Pulse train, 26 bit pattern.</description>
+         <value>26</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>27_BIT</name>
+         <description>Pulse train, 27 bit pattern.</description>
+         <value>27</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>28_BIT</name>
+         <description>Pulse train, 28 bit pattern.</description>
+         <value>28</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>29_BIT</name>
+         <description>Pulse train, 29 bit pattern.</description>
+         <value>29</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30_BIT</name>
+         <description>Pulse train, 30 bit pattern.</description>
+         <value>30</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>31_BIT</name>
+         <description>Pulse train, 31 bit pattern.</description>
+         <value>31</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRAIN</name>
+     <description>Write the repeating bit pattern that is shifted out, LSB first, when configured in Pulse Train mode. See PT_RATE_LENGTH.mode for setting the length.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>LOOP</name>
+     <description>Pulse Train Loop Count</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>count</name>
+       <description>Number of loops for this pulse train to repeat.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>delay</name>
+       <description>Delay between loops of the Pulse Train in PT Peripheral Clock cycles</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>12</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESTART</name>
+     <description> Pulse Train Auto-Restart Configuration.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt_x_select</name>
+       <description>Auto-Restart PT X Select</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_x_loop_exit</name>
+       <description>Enable Auto-Restart on PT X Loop Exit</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt_y_select</name>
+       <description>Auto-Restart PT Y Select</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_y_loop_exit</name>
+       <description>Enable Auto-Restart on PT Y Loop Exit</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PT Pulse Train-->
+  <peripheral derivedFrom="PT">
+   <name>PT1</name>
+   <description>Pulse Train 1</description>
+   <baseAddress>0x4003C030</baseAddress>
+  </peripheral>
+<!--PT1 Pulse Train 1-->
+  <peripheral derivedFrom="PT">
+   <name>PT2</name>
+   <description>Pulse Train 2</description>
+   <baseAddress>0x4003C040</baseAddress>
+  </peripheral>
+<!--PT2 Pulse Train 2-->
+  <peripheral derivedFrom="PT">
+   <name>PT3</name>
+   <description>Pulse Train 3</description>
+   <baseAddress>0x4003C050</baseAddress>
+  </peripheral>
+<!--PT3 Pulse Train 3-->
+  <peripheral>
+   <name>PTG</name>
+   <description>Pulse Train Generation</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0020</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>PT</name>
+    <description>Pulse Train IRQ</description>
+    <value>59</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ENABLE</name>
+     <description>Global Enable/Disable Controls for All Pulse Trains</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Enable/Disable control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Enable/Disable control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Enable/Disable control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Enable/Disable control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESYNC</name>
+     <description>Global Resync (All Pulse Trains) Control</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Resync control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Resync control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Resync control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Resync control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Pulse Train Interrupt Flags</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Pulse Train Interrupt Enable/Disable</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_EN</name>
+     <description>Pulse Train Global Safe Enable.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_DIS</name>
+     <description>Pulse Train Global Safe Disable.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PTG Pulse Train Generation-->
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x40006800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>LPCN</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAMRET0</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 0 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET1</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 1 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET2</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 2 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET3</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPMCLKSEL</name>
+       <description>Low Power Mode APB Clock Select.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPMFAST</name>
+       <description>Low Power Mode Clock Select.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BG_DIS</name>
+       <description>Bandgap OFF. This controls the System Bandgap in DeepSleep mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>Bandgap is always ON.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>Bandgap is OFF in DeepSleep mode (default).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPWKST_CLR</name>
+       <description>Low Power Wakeup Status Register Clear</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST0</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO0.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN0</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register derivedFrom="LPWKST0">
+     <name>LPWKST1</name>
+     <description>Low Power I/O Wakeup Status Register 1. This register indicates the low power wakeup status for GPIO1.</description>
+     <addressOffset>0x0C</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN1</name>
+     <description>Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup functionality for GPIO1.</description>
+     <addressOffset>0x10</addressOffset>
+    </register>
+    <register derivedFrom="LPWKST0">
+     <name>LPWKST2</name>
+     <description>Low Power I/O Wakeup Status Register 2. This register indicates the low power wakeup status for GPIO2.</description>
+     <addressOffset>0x14</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN2</name>
+     <description>Low Power I/O Wakeup Enable Register 2. This register enables low power wakeup functionality for GPIO2.</description>
+     <addressOffset>0x18</addressOffset>
+    </register>
+    <register derivedFrom="LPWKST0">
+     <name>LPWKST3</name>
+     <description>Low Power I/O Wakeup Status Register 3. This register indicates the low power wakeup status for GPIO3.</description>
+     <addressOffset>0x1C</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN3</name>
+     <description>Low Power I/O Wakeup Enable Register 3. This register enables low power wakeup functionality for GPIO3.</description>
+     <addressOffset>0x20</addressOffset>
+    </register>
+    <register>
+     <name>LPPWST</name>
+     <description>Low Power Peripheral Wakeup Status Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>AINCOMP0</name>
+       <description>Analog Input Comparator Wakeup Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BACKUP</name>
+       <description>Backup Mode Wakeup Flag.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESET</name>
+       <description>Reset Detected Wakeup Flag.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWEN</name>
+     <description>Low Power Peripheral Wakeup Enable Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>AINCOMP0</name>
+       <description> AINCOMP0 Wakeup Enable. This bit allows wakeup from the AINCOMP0.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WDT0</name>
+       <description> WDT0 Wakeup Enable. This bit allows wakeup from the WDT0.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WDT1</name>
+       <description> WDT1 Wakeup Enable. This bit allows wakeup from the WDT1.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CPU1</name>
+       <description> CPU1 Wakeup Enable. This bit allows wakeup from the CPU1.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR0</name>
+       <description> TMR0 Wakeup Enable. This bit allows wakeup from the TMR0.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR1</name>
+       <description> TMR1 Wakeup Enable. This bit allows wakeup from the TMR1.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR2</name>
+       <description> TMR2 Wakeup Enable. This bit allows wakeup from the TMR2.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR3</name>
+       <description> TMR3 Wakeup Enable. This bit allows wakeup from the TMR3.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR4</name>
+       <description> TMR4 Wakeup Enable. This bit allows wakeup from the TMR4.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR5</name>
+       <description> TMR5 Wakeup Enable. This bit allows wakeup from the TMR5.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART0</name>
+       <description> UART0 Wakeup Enable. This bit allows wakeup from the UART0.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART1</name>
+       <description> UART1 Wakeup Enable. This bit allows wakeup from the UART1.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART2</name>
+       <description> UART2 Wakeup Enable. This bit allows wakeup from the UART2.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART3</name>
+       <description> UART3 Wakeup Enable. This bit allows wakeup from the UART3.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C0</name>
+       <description> I2C0 Wakeup Enable. This bit allows wakeup from the I2C0.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C1</name>
+       <description> I2C1 Wakeup Enable. This bit allows wakeup from the I2C1.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C2</name>
+       <description> I2C2 Wakeup Enable. This bit allows wakeup from the I2C2.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2S</name>
+       <description> I2S Wakeup Enable. This bit allows wakeup from the I2S.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SPI1</name>
+       <description> SPI1 Wakeup Enable. This bit allows wakeup from the SPI1.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPCMP</name>
+       <description> LPCMP Wakeup Enable. This bit allows wakeup from the LPCMP.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VBTLEPD</name>
+     <description>Low-Power VBTLE Power Down Register.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>BTLE</name>
+       <description>Power Down SIMO VREGO_D.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GP0</name>
+     <description>General Purpose Register 0</description>
+     <addressOffset>0x48</addressOffset>
+    </register>
+    <register>
+     <name>GP1</name>
+     <description>General Purpose Register 1</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--PWRSEQ Power Sequencer / Low Power Control Register.-->
+  <peripheral>
+   <name>RTC</name>
+   <description>Real Time Clock and Alarm.</description>
+   <baseAddress>0x40006000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>RTC</name>
+    <description>RTC interrupt.</description>
+    <value>3</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC</name>
+       <description>Sub-Seconds Counter (12-bit).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TODA</name>
+     <description>Time-of-day Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-day Alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSECA</name>
+     <description>RTC sub-second alarm.  This register contains the reload value for the sub-second alarm.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>This register contains the reload value for the sub-second alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>RTC Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Real Time Clock Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM_IE</name>
+       <description>Alarm Time-of-Day Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM_IE</name>
+       <description>Alarm Sub-second Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>RTC Busy. This bit is set to 1 by hardware when changes to RTC registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>RTC Ready. This bit is set to 1 by hardware when the RTC count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the RTC count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY_IE</name>
+       <description>RTC Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-Day Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>Sub-second Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_SEL</name>
+       <description>Frequency Output Selection. When SQE=1, these bits specify the output frequency on the SQW pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq1Hz</name>
+         <description>1 Hz (Compensated).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq512Hz</name>
+         <description>512 Hz (Compensated).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq4KHz</name>
+         <description>4 KHz.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clkDiv8</name>
+         <description>RTC Input Clock / 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_EN</name>
+       <description>Asynchronous Counter Read Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_EN</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical RTC bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIM</name>
+     <description>RTC Trim Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>RTC Trim. This register contains the 2's complement value that specifies the trim resolution. Each increment or decrement of the bit adds or subtracts 1ppm at each 4KHz clock value, with a maximum correction of +/- 127ppm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VRTC_TMR</name>
+       <description>VBAT Timer Value. When RTC is running off of VBAT, this field is incremented every 32 seconds.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>RTC Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>FILTER_EN</name>
+       <description>Enables analog deglitch filter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_SEL</name>
+       <description>If IBIAS_EN is 1, selects 4x,2x mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HYST_EN</name>
+       <description>Enables high current hysteresis buffer.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_EN</name>
+       <description>Enables higher 4x,2x current modes.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYPASS</name>
+       <description>RTC Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SQW_32K</name>
+       <description>RTC 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--RTC Real Time Clock and Alarm.-->
+  <peripheral>
+   <name>SEMA</name>
+   <description>The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.</description>
+   <baseAddress>0x4003E000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>SEMAPHORES[%s]</name>
+     <description>Read to test and set, returns prior value. Write 0 to clear semaphore.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>sema</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>irq0</name>
+     <description>Semaphore IRQ0 register.</description>
+     <addressOffset>0x40</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>en</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cm4_irq</name>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>mail0</name>
+     <description>Semaphore Mailbox 0 register.</description>
+     <addressOffset>0x44</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>data</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>irq1</name>
+     <description>Semaphore IRQ1 register.</description>
+     <addressOffset>0x48</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>en</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>rv32_irq</name>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>mail1</name>
+     <description>Semaphore Mailbox 1 register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>data</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>status</name>
+     <description>Semaphore status bits. 0 indicates the semaphore is free, 1 indicates taken.</description>
+     <addressOffset>0x100</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>status0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SEMA The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.-->
+  <peripheral>
+   <name>SIMO</name>
+   <description>Single Inductor Multiple Output Switching Converter</description>
+   <baseAddress>0x40004400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>VREGO_A</name>
+     <description>Buck Voltage Regulator A Control Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETA</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGEA</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGO_B</name>
+     <description>Buck Voltage Regulator B Control Register</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETB</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGEB</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGO_C</name>
+     <description>Buck Voltage Regulator C Control Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETC</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGEC</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGO_D</name>
+     <description>Buck Voltage Regulator D Control Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETD</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGED</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPKA</name>
+     <description>High Side FET Peak Current VREGO_A/VREGO_B Register</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IPKSETA</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IPKSETB</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPKB</name>
+     <description>High Side FET Peak Current VREGO_C/VREGO_D Register</description>
+     <addressOffset>0x0018</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IPKSETC</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IPKSETD</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAXTON</name>
+     <description>Maximum High Side FET Time On Register</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TONSET</name>
+       <description>Sets the maximum on time for the high side FET, each increment represents 500ns</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_A</name>
+     <description>Buck Cycle Count VREGO_A Register</description>
+     <addressOffset>0x0020</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADA</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_B</name>
+     <description>Buck Cycle Count VREGO_B Register</description>
+     <addressOffset>0x0024</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADB</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_C</name>
+     <description>Buck Cycle Count VREGO_C Register</description>
+     <addressOffset>0x0028</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADC</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_D</name>
+     <description>Buck Cycle Count VREGO_D Register</description>
+     <addressOffset>0x002C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADD</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_A</name>
+     <description>Buck Cycle Count Alert VERGO_A Register</description>
+     <addressOffset>0x0030</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRA</name>
+       <description>Threshold for ILOADA to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_B</name>
+     <description>Buck Cycle Count Alert VERGO_B Register</description>
+     <addressOffset>0x0034</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRB</name>
+       <description>Threshold for ILOADB to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_C</name>
+     <description>Buck Cycle Count Alert VERGO_C Register</description>
+     <addressOffset>0x0038</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRC</name>
+       <description>Threshold for ILOADC to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_D</name>
+     <description>Buck Cycle Count Alert VERGO_D Register</description>
+     <addressOffset>0x003C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRD</name>
+       <description>Threshold for ILOADD to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_OUT_READY</name>
+     <description>Buck Regulator Output Ready Register</description>
+     <addressOffset>0x0040</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUCKOUTRDYA</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notrdy</name>
+         <description>Output voltage not in range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rdy</name>
+         <description>Output voltage in range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="BUCKOUTRDYA">
+       <name>BUCKOUTRDYB</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BUCKOUTRDYA">
+       <name>BUCKOUTRDYC</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BUCKOUTRDYA">
+       <name>BUCKOUTRDYD</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_A</name>
+     <description>Zero Cross Calibration VERGO_A Register</description>
+     <addressOffset>0x0044</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALA</name>
+       <description>Zero Cross Calibrartion Value VREGO_A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_B</name>
+     <description>Zero Cross Calibration VERGO_B Register</description>
+     <addressOffset>0x0048</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALB</name>
+       <description>Zero Cross Calibrartion Value VREGO_B</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_C</name>
+     <description>Zero Cross Calibration VERGO_C Register</description>
+     <addressOffset>0x004C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALC</name>
+       <description>Zero Cross Calibrartion Value VREGO_C</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_D</name>
+     <description>Zero Cross Calibration VERGO_D Register</description>
+     <addressOffset>0x0050</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALD</name>
+       <description>Zero Cross Calibrartion Value VREGO_D</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIMO Single Inductor Multiple Output Switching Converter-->
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x40000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SISTAT</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>MAGIC</name>
+       <description>Magic Word Validation.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>magicNotSet</name>
+         <description>Magic word was not set (OTP has not been initialized properly).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>magicSet</name>
+         <description>Magic word was set (OTP contains valid settings).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRCERR</name>
+       <description>CRC Error Status.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No CRC errors occurred during the read of the OTP memory block.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>A CRC error occurred while reading the OTP. The address of the failure location in the OTP memory is stored in the ERRADDR register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADDR</name>
+     <description>Read-only field set by the SIB block if a CRC error occurs during the read of the OTP memory. Contains the failing address in OTP memory (when CRCERR equals 1).</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ERRADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLE_LDO_TRIM</name>
+     <description>BTLE LDO Trim register.</description>
+     <addressOffset>0x48</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RF</name>
+       <description>RF LDO trim value.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BB</name>
+       <description>BB LDO trim value.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FSTAT</name>
+     <description>funcstat register.</description>
+     <addressOffset>0x100</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>FPU</name>
+       <description>FPU Function.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADC</name>
+       <description>10-bit Sigma Delta ADC.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SMPHR</name>
+       <description>SMPHR function.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFSTAT</name>
+     <description>Security function status register.</description>
+     <addressOffset>0x104</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SECBOOT</name>
+       <description>Security Boot.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRNG</name>
+       <description> TRNG Function.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AES</name>
+       <description>AES Block.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIR System Initialization Registers.-->
+  <peripheral>
+   <name>SPI0</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x400BE000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>56</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FIFO32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>FIFO16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>FIFO8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Start Select Control. Used in Master mode to control the behavior of the Slave Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DEASSERT</name>
+         <description>SPI De-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ASSERT</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_ACTIVE</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3</name>
+         <description>SS3 is selected.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Rising_Edge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Falling_Edge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1</name>
+         <description>1 bits per character.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2</name>
+         <description>2 bits per character.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3</name>
+         <description>3 bits per character.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4</name>
+         <description>4 bits per character.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5</name>
+         <description>5 bits per character.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6</name>
+         <description>6 bits per character.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7</name>
+         <description>7 bits per character.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8</name>
+         <description>8 bits per character.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9</name>
+         <description>9 bits per character.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10</name>
+         <description>10 bits per character.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11</name>
+         <description>11 bits per character.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12</name>
+         <description>12 bits per character.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13</name>
+         <description>13 bits per character.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14</name>
+         <description>14 bits per character.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15</name>
+         <description>15 bits per character.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin (s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_POL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3_high</name>
+         <description>SS3 active high.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSTIME</name>
+     <description>Register for controlling SPI peripheral/Slave Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PRE</name>
+       <description>Slave Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POST</name>
+       <description>Slave Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPI0 SPI peripheral.-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI1</name>
+   <description>SPI peripheral. 1</description>
+   <baseAddress>0x40046000</baseAddress>
+   <interrupt>
+    <name>SPI1</name>
+    <description>SPI1 IRQ</description>
+    <value>32</value>
+   </interrupt>
+  </peripheral>
+<!--SPI1 SPI peripheral. 1-->
+  <peripheral>
+   <name>TMR</name>
+   <description>Low-Power Configurable Timer</description>
+   <baseAddress>0x40010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR</name>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Timer Counter Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>The current count value for the timer. This field increments as the timer counts.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Timer Compare Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>Timer PWM Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PWM</name>
+       <description>Timer PWM Match:
+                In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
+                In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Timer Interrupt Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ_A</name>
+       <description>Interrupt Flag for Timer A.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_A</name>
+       <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_A</name>
+       <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IRQ_B</name>
+       <description>Interrupt Flag for Timer B.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_B</name>
+       <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_B</name>
+       <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MODE_A</name>
+       <description>Mode Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_A</name>
+       <description>Clock Divider Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_A</name>
+       <description>Timer Polarity for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_A</name>
+       <description>PWM Synchronization Mode for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_A</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_A</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_A</name>
+       <description>PWM Phase A-Prime Output Disable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_A</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Write 1 to Enable CLK_TMR for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_A</name>
+       <description>Enable for Timer A</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MODE_B</name>
+       <description>Mode Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_B</name>
+       <description>Clock Divider Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_B</name>
+       <description>Timer Polarity for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_B</name>
+       <description>PWM Synchronization Mode for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_B</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_B</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_B</name>
+       <description>PWM Phase A-Prime Output Disable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_B</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Write 1 to Enable CLK_TMR for Timer B</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_B</name>
+       <description>Enable for Timer B</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO_A</name>
+       <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_A</name>
+       <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>LO_B</name>
+       <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_B</name>
+       <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Timer Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKSEL_A</name>
+       <description>Timer Clock Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Timer A Enable Status</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_A</name>
+       <description>CLK_TMR Ready Flag for Timer A</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_A</name>
+       <description>Event Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_A</name>
+       <description>Negative Edge Trigger for Event for Timer A</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_A</name>
+       <description>Interrupt Enable for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_A</name>
+       <description>Capture Event Select for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_A</name>
+       <description>Software Capture Event for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_A</name>
+       <description>Wake-Up Enable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTEN_A</name>
+       <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTBEN_A</name>
+       <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKSEL_B</name>
+       <description>Timer Clock Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Timer B Enable Status</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_B</name>
+       <description>CLK_TMR Ready Flag for Timer B</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_B</name>
+       <description>Event Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_B</name>
+       <description>Negative Edge Trigger for Event for Timer B</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_B</name>
+       <description>Interrupt Enable for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_B</name>
+       <description>Capture Event Select for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_B</name>
+       <description>Software Capture Event for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_B</name>
+       <description>Wake-Up Enable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CASCADE</name>
+       <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Timer Wakeup Status Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>A</name>
+       <description>Wake-Up Flag for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>B</name>
+       <description>Wake-Up Flag for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TMR Low-Power Configurable Timer-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR1</name>
+   <description>Low-Power Configurable Timer 1</description>
+   <baseAddress>0x40011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+<!--TMR1 Low-Power Configurable Timer 1-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR2</name>
+   <description>Low-Power Configurable Timer 2</description>
+   <baseAddress>0x40012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+<!--TMR2 Low-Power Configurable Timer 2-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR3</name>
+   <description>Low-Power Configurable Timer 3</description>
+   <baseAddress>0x40013000</baseAddress>
+   <interrupt>
+    <name>TMR3</name>
+    <description>TMR3 IRQ</description>
+    <value>8</value>
+   </interrupt>
+  </peripheral>
+<!--TMR3 Low-Power Configurable Timer 3-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR4</name>
+   <description>Low-Power Configurable Timer 4</description>
+   <baseAddress>0x40080C00</baseAddress>
+   <interrupt>
+    <name>TMR4</name>
+    <description>TMR4 IRQ</description>
+    <value>9</value>
+   </interrupt>
+  </peripheral>
+<!--TMR4 Low-Power Configurable Timer 4-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR5</name>
+   <description>Low-Power Configurable Timer 5</description>
+   <baseAddress>0x40081000</baseAddress>
+   <interrupt>
+    <name>TMR5</name>
+    <description>TMR5 IRQ</description>
+    <value>10</value>
+   </interrupt>
+  </peripheral>
+<!--TMR5 Low-Power Configurable Timer 5-->
+  <peripheral>
+   <name>TRIMSIR</name>
+   <description>Trim System Initilazation Registers</description>
+   <baseAddress>0x40005400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RTC</name>
+     <description>RTC Trim System Initialization Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>X1TRIM</name>
+       <description>RTC X1 Trim.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>X2TRIM</name>
+       <description>RTC X2 Trim.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SIMO</name>
+     <description>SIMO Trim System Initialization Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>SIMO Clock Divide.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV16</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV32</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV64</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV128</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPOLO</name>
+     <description>IPO Low Trim System Initialization Register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>IPO_LIMITLO</name>
+       <description>IPO Low Limit Trim.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Control Trim System Initialization Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>VDDA_LIMITLO</name>
+       <description>VDDA Low Trim Limit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VDDA_LIMITHI</name>
+       <description>VDDA High Trim Limit.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>IPO_LIMITHI</name>
+       <description>IPO High Trim Limit.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>INRO_SEL</name>
+       <description>INRO Clock Select.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>8KHZ</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16KHZ</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30KHZ</name>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INRO_TRIM</name>
+       <description>INRO Clock Trim.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INRO</name>
+     <description>RTC Trim System Initialization Register.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>TRIM16K</name>
+       <description>INRO 16KHz Trim.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>TRIM30K</name>
+       <description>INRO 30KHz Trim.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>LPCLKSEL</name>
+       <description>INRO Low Power Mode Clock Select.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>8KHZ</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16KHZ</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30KHZ</name>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRIMSIR Trim System Initilazation Registers-->
+  <peripheral>
+   <name>TRNG</name>
+   <description>Random Number Generator.</description>
+   <baseAddress>0x4004D000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TRNG</name>
+    <description>TRNG interrupt.</description>
+    <value>4</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>TRNG Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000003</resetValue>
+     <fields>
+      <field>
+       <name>RND_IE</name>
+       <description>To enable IRQ generation when a new 32-bit Random number is ready.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEYGEN</name>
+       <description>AES Key Generate. When enabled, the key for securing NVSRAM is generated and transferred to the secure key register automatically without user visibility or intervention. This bit is cleared by hardware once the key has been transferred to the secure key register.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>To wipe the Battery Backed key.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>RDY</name>
+       <description>32-bit random data is ready to read from TRNG_DATA register. Reading TRNG_DATA when RND_RDY=0 will return all 0's. IRQ is generated when RND_RDY=1 if TRNG_CN.RND_IRQ_EN=1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Busy</name>
+         <description>TRNG Busy</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Ready</name>
+         <description>32 bit random data is ready</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data. The content of this register is valid only when RNG_IS =1. When TNRG is disabled, read returns 0x0000 0000.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRNG Random Number Generator.-->
+  <peripheral>
+   <name>UART</name>
+   <description>UART Low Power Registers</description>
+   <baseAddress>0x40042000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control register</description>
+     <addressOffset>0x0000</addressOffset>
+     <fields>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>This field specifies the depth of receive FIFO for interrupt generation (value 0 and &gt; 16 are ignored) </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EN</name>
+       <description>Parity Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EO</name>
+       <description>when PAREN=1 selects odd or even parity odd is 1 even is 0</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_MD</name>
+       <description>Selects parity based on 1s or 0s count (when PAREN=1) </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_DIS</name>
+       <description>CTS Sampling Disable </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Flushes the TX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Flushes the RX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHAR_SIZE</name>
+       <description>Selects UART character size</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5bits</name>
+         <description>5 bits</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6bits</name>
+         <description>6 bits</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7bits</name>
+         <description>7 bits</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8bits</name>
+         <description>8 bits</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPBITS</name>
+       <description>Selects the number of stop bits that will be generated</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HFC_EN</name>
+       <description>Enables/disables hardware flow control</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RTSDC</name>
+       <description>Hardware Flow Control RTS Mode</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKEN</name>
+       <description>Baud clock enable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKSRC</name>
+       <description>To select the UART clock source for the UART engine (except APB registers). Secondary clock (used for baud rate generator) can be asynchronous from APB clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Peripheral_Clock</name>
+         <description>apb clock</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>External_Clock</name>
+         <description>Clock 1</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK2</name>
+         <description>Clock 2</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK3</name>
+         <description>Clock 3</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPFE_EN</name>
+       <description>Data/Parity bit frame error detection enable</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKRDY</name>
+       <description>Baud clock Ready read only bit</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UCAGM</name>
+       <description>UART Clock Auto Gating mode</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FDM</name>
+       <description>Fractional Division Mode</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DESM</name>
+       <description>RX Dual Edge Sampling Mode</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TX_BUSY</name>
+       <description>Read-only flag indicating the UART transmit status</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_BUSY</name>
+       <description>Read-only flag indicating the UART receiver status</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Indicates the number of bytes currently in the RX FIFO (0-RX FIFO_ELTS) </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Indicates the number of bytes currently in the TX FIFO (0-TX FIFO_ELTS) </description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interrupt Enable control register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Enable Interrupt For RX Frame Error</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Enable Interrupt For RX Parity Error</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Enable Interrupt For CTS signal change Error</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Enable Interrupt For RX FIFO Overrun Error</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Enable Interrupt For RX FIFO reaches the number of bytes configured by RXTHD</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Enable Interrupt For TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Enable Interrupt For TX FIFO has half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Interrupt status flags Control register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Flag for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Flag for RX Parity Error interrupt</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Flag for CTS signal change interrupt (hardware flow control disabled) </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Flag for RX FIFO Overrun interrupt</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Flag for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Flag for interrupt when TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Flag for interrupt when TX FIFO is half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Clock Divider register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Baud rate divisor value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSR</name>
+     <description>Over Sampling Rate register</description>
+     <addressOffset>0x0014</addressOffset>
+     <fields>
+      <field>
+       <name>OSR</name>
+       <description>OSR</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXPEEK</name>
+     <description>TX FIFO Output Peek register</description>
+     <addressOffset>0x0018</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read TX FIFO next data. Reading from this field does not affect the contents of TX FIFO. Note that the parity bit is available from this field.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PNR</name>
+     <description> Pin register</description>
+     <addressOffset>0x001C</addressOffset>
+     <fields>
+      <field>
+       <name>CTS</name>
+       <description>Current sampled value of CTS IO</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RTS</name>
+       <description>This bit controls the value to apply on the RTS IO. If set to 1, the RTS IO is set to high level. If set to 0, the RTS IO is set to low level.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Read/Write register</description>
+     <addressOffset>0x0020</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Parity error flag for next byte to be read from FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration register</description>
+     <addressOffset>0x0030</addressOffset>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger If the TX FIFO level is less than this value, then the TX FIFO DMA interface will send a signal to system DMA to notify that TX FIFO is ready to receive data from memory.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX DMA channel enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Rx FIFO Level DMA Trigger If the RX FIFO level is greater than this value, then the RX FIFO DMA interface will send a signal to the system DMA to notify that RX FIFO has characters to transfer to memory.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX DMA channel enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wake up enable Control register</description>
+     <addressOffset>0x0034</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Enable for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Enable for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Enable for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wake up Flags register</description>
+     <addressOffset>0x0038</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Flag for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Flag for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Flag for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--UART UART Low Power Registers-->
+  <peripheral derivedFrom="UART">
+   <name>UART1</name>
+   <description>UART Low Power Registers 1</description>
+   <baseAddress>0x40043000</baseAddress>
+  </peripheral>
+<!--UART1 UART Low Power Registers 1-->
+  <peripheral derivedFrom="UART">
+   <name>UART2</name>
+   <description>UART Low Power Registers 2</description>
+   <baseAddress>0x40044000</baseAddress>
+  </peripheral>
+<!--UART2 UART Low Power Registers 2-->
+  <peripheral derivedFrom="UART">
+   <name>UART3</name>
+   <description>UART Low Power Registers 3</description>
+   <baseAddress>0x40081400</baseAddress>
+  </peripheral>
+<!--UART3 UART Low Power Registers 3-->
+  <peripheral>
+   <name>WDT</name>
+   <description>Windowed Watchdog Timer</description>
+   <baseAddress>0x40003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WWDT</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INT_LATE_VAL</name>
+       <description>Windowed Watchdog Interrupt Upper Limit. Sets the number of WDTCLK cycles until a windowed watchdog timer interrupt is generated (if enabled) if the CPU does not write the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE_VAL</name>
+       <description>Windowed Watchdog Reset Upper Limit. Sets the number of WDTCLK cycles until a system reset occurs (if enabled) if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Windowed Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_LATE</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Late.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_INT_EN</name>
+       <description>Windowed Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_RST_EN</name>
+       <description>Windowed Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Soon.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY_VAL</name>
+       <description>Windowed Watchdog Interrupt Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A windowed watchdog timer interrupt is generated (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY_VAL</name>
+       <description>Windowed Watchdog Reset Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A system reset occurs (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKRDY_IE</name>
+       <description>Switch Ready Interrupt Enable. Fires an interrupt when it is safe to swithc the clock.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY</name>
+       <description>Clock Status.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WIN_EN</name>
+       <description>Enables the Windowed Watchdog Function.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Windowed Mode Disabled (i.e. Compatibility Mode).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Windowed Mode Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Soon.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Late.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Windowed Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>RESET</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD_UPPER_LIMIT then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD_UPPER_LIMIT then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKSEL</name>
+     <description>Windowed Watchdog Timer Clock Select Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SOURCE</name>
+       <description>WWDT Clock Selection Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CNT</name>
+     <description>Windowed Watchdog Timer Count Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Current Value of the Windowed Watchdog Timer Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WDT Windowed Watchdog Timer-->
+  <peripheral derivedFrom="WDT">
+   <name>WDT1</name>
+   <description>Windowed Watchdog Timer 1</description>
+   <baseAddress>0x40080800</baseAddress>
+   <interrupt>
+    <name>WDT1</name>
+    <description>WDT1 IRQ</description>
+    <value>57</value>
+   </interrupt>
+  </peripheral>
+<!--WDT1 Windowed Watchdog Timer 1-->
+  <peripheral>
+   <name>WUT</name>
+   <description>32-bit reloadable timer that can be used for timing and wakeup.</description>
+   <baseAddress>0x40006400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Wakeup_Timer</name>
+    <description>WUT IRQ</description>
+    <value>53</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Count.  This register stores the current timer count.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Timer Count Value. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Compare.  This register stores the compare value, which is used to set the maximum count value to initiate a reload of the timer to 0x0001.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x0000FFFF</resetValue>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>Timer Compare Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Clear Interrupt. Writing a value (0 or 1) to a bit in this register clears the associated interrupt.</description>
+     <addressOffset>0x0C</addressOffset>
+     <modifiedWriteValues>oneToClear</modifiedWriteValues>
+     <fields>
+      <field>
+       <name>IRQ_CLR</name>
+       <description>Clear Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>TMODE</name>
+       <description>Timer Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>oneShot</name>
+         <description>One Shot Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Continuous Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>counter</name>
+         <description>Counter Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>capture</name>
+         <description>Capture Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>compare</name>
+         <description>Compare Mode.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>gated</name>
+         <description>Gated Mode.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>captureCompare</name>
+         <description>Capture/Compare Mode.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES</name>
+       <description>Prescaler.  Set the Timer's prescaler value. The prescaler divides the PCLK input to the timer and sets the Timer's Count Clock, F_CNT_CLK = PCLK(HZ)/prescaler. The Timer's prescaler setting is a 4-bit value with pres3:pres[2:0].</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TPOL</name>
+       <description>Timer input/output polarity bit.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TEN</name>
+       <description>Timer Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES3</name>
+       <description>MSB of prescaler value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>NOLLCMP</name>
+       <description>Non-overlapping Low Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A and next rising edge of PWM output 0A'.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>NOLHCMP</name>
+       <description>Non-overlapping High Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A' and next rising edge of PWM output 0A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET</name>
+     <description>Preset register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>PRESET</name>
+       <description>Preset Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RELOAD</name>
+     <description>Reload register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>RELOAD</name>
+       <description>Rerload Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SNAPSHOT</name>
+     <description>Snapshot register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>SNAPSHOT</name>
+       <description>Snapshot Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WUT 32-bit reloadable timer that can be used for timing and wakeup.-->
+ </peripherals>
+</device>

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.svd
@@ -1,0 +1,23059 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max32690</name>
+ <series>ARMCM4</series>
+ <version>1.0</version>
+ <description>MAX32655 32-bit ARM Cortex-M4 microcontroller, 1024KB of flash, 760KB of system RAM, 128KB of Boot ROM.</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>ADC</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>ADC</groupName>
+   <baseAddress>0x40034000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>ADC</name>
+    <description>ADC IRQ</description>
+    <value>20</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0</name>
+     <description>Control Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADC_EN</name>
+       <description>ADC Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable ADC.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable ADC.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BIAS_EN</name>
+       <description>Bias Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Bias.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Bias.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SKIP_CAL</name>
+       <description>Skip Calibration Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no_skip</name>
+         <description>Do not skip calibration.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>skip</name>
+         <description>Skip calibration.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CHOP_FORCE</name>
+       <description>Chop Force Control.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Do not force chop mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Force chop Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RESETB</name>
+       <description>Reset ADC.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>reset ADC.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activate</name>
+         <description>activate ADC.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Control Register 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Start conversion control.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>stop</name>
+         <description>Stop conversions.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start conversions.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TRIG_MODE</name>
+       <description>Trigger mode control.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>software</name>
+         <description>software trigger mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hardware</name>
+         <description>hardware trigger mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CNV_MODE</name>
+       <description>Conversion mode control.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>atomic</name>
+         <description>Do one conversion sequence.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Do continuous conversion sequences.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SAMP_CK_OFF</name>
+       <description>Sample clock off control.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>always</name>
+         <description>Sample clock always generated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cnv_only</name>
+         <description>Sample clock generated only when converting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TRIG_SEL</name>
+       <description>Hardware trigger source select.</description>
+       <bitRange>[6:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TS_SEL</name>
+       <description>Temp sensor select.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Temp sensor is not one of the slots in the sequence.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Temp sensor is one of the slots in the sequence.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AVG</name>
+       <description>Number of samples to average for each output data code.</description>
+       <bitRange>[10:8]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>avg1</name>
+         <description>1 Sample per output code.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg2</name>
+         <description>2 Samples per output code.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg4</name>
+         <description>4 Samples per output code.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg8</name>
+         <description>8 Samples per output code.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg16</name>
+         <description>16 Samples per output code.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg32</name>
+         <description>32 Samples per output code.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUM_SLOTS</name>
+       <description>Number of slots enabled for the conversion sequence</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>CLKSEL</name>
+       <description>Clock source select.</description>
+       <bitRange>[1:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>HCLK</name>
+         <description>Select HCLK.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK_ADC0</name>
+         <description>Select CLK_ADC0.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK_ADC1</name>
+         <description>Select CLK_ADC1.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK_ADC2</name>
+         <description>Select CLK_ADC2.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>Clock divider control.</description>
+       <bitRange>[6:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <description>Divide by 2.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <description>Divide by 4.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV8</name>
+         <description>Divide by 8.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV16</name>
+         <description>Divide by 16.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <description>Divide by 1.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAMPCLKCTRL</name>
+     <description>Sample Clock Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TRACK_CNT</name>
+       <description>Number of cycles for SAMPLE_CLK high time.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>IDLE_CNT</name>
+       <description>Number of cycles for SAMPLE_CLK low time.</description>
+       <bitRange>[31:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL0</name>
+     <description>Channel Select Register 0.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>slot0_id</name>
+       <description>channel assignment for slot 0.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot1_id</name>
+       <description>channel assignment for slot 1.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot2_id</name>
+       <description>channel assignment for slot 2.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot3_id</name>
+       <description>channel assignment for slot 3.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL1</name>
+     <description>Channel Select Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>slot4_id</name>
+       <description>channel assignment for slot 4.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot5_id</name>
+       <description>channel assignment for slot 5.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot6_id</name>
+       <description>channel assignment for slot 6.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot7_id</name>
+       <description>channel assignment for slot 7.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL2</name>
+     <description>Channel Select Register 2.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>slot8_id</name>
+       <description>channel assignment for slot 8.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot9_id</name>
+       <description>channel assignment for slot 9.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot10_id</name>
+       <description>channel assignment for slot 10.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot11_id</name>
+       <description>channel assignment for slot 11.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL3</name>
+     <description>Channel Select Register 3.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>slot12_id</name>
+       <description>channel assignment for slot 12.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot13_id</name>
+       <description>channel assignment for slot 13.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot14_id</name>
+       <description>channel assignment for slot 14.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot15_id</name>
+       <description>channel assignment for slot 15.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESTART</name>
+     <description>Restart Count Control Register</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Number of sample periods to skip before restarting a continuous mode sequence</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAFMT</name>
+     <description>Channel Data Format Register</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Data format control</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFODMACTRL</name>
+     <description>FIFO and DMA control</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>DMA_EN</name>
+       <description>DMA Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable DMA.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable DMA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>FIFO Flush.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal FIFO operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_FORMAT</name>
+       <description>DATA format control.</description>
+       <bitRange>[3:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>data_status</name>
+         <description>Data and Status in FIFO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>data_only</name>
+         <description>Only Data in FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>raw_data_only</name>
+         <description>Only Raw Data in FIFO.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THRESH</name>
+       <description>FIFO Threshold. These bits define the FIFO interrupt threshold.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data Register (FIFO).</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Conversion data.</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CHAN</name>
+       <description>Channel for the data.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>INVALID</name>
+       <description>Invalid status for the data.</description>
+       <bitRange>[24:24]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLIPPED</name>
+       <description>Clipped status for the data.</description>
+       <bitRange>[31:31]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>READY</name>
+       <description>Indication that the ADC is in ON power state</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EMPTY</name>
+       <description>FIFO Empty</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>FULL</name>
+       <description>FIFO full</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>FIFO_LEVEL</name>
+       <description>Number of entries in FIFO available to read</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSTATUS</name>
+     <description>Channel Status</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>CLIPPED</name>
+       <description />
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>READY</name>
+       <description>ADC is ready.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Conversion start is aborted.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>START_DET</name>
+       <description>Conversion start is detected.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SEQ_STARTED</name>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SEQ_DONE</name>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CONV_DONE</name>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLIPPED</name>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_LVL</name>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_UFL</name>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_OFL</name>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Interrupt Flags Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>READY</name>
+       <description>ADC is ready.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Conversion start is aborted.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>START_DET</name>
+       <description>Conversion start is detected.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>SEQ_STARTED</name>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>SEQ_DONE</name>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>CONV_DONE</name>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>CLIPPED</name>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>FIFO_LVL</name>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>FIFO_UFL</name>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>FIFO_OFL</name>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRADDROFFSET</name>
+     <description>SFR Address Offset Register</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>OFFSET</name>
+       <description>Address Offset for SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRADDR</name>
+     <description>SFR Address Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address to SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRWRDATA</name>
+     <description>SFR Write Data Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>DATA to SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRRDDATA</name>
+     <description>SFR Read Data Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>DATA from SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRSTATUS</name>
+     <description>SFR Status Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>NACK</name>
+       <description>NACK status for SAR Digital SFR communication</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ADC Inter-Integrated Circuit.-->
+  <peripheral>
+   <name>AESKEYS</name>
+   <description>AES Key Registers.</description>
+   <baseAddress>0x40005000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>KEY0</name>
+     <description>AES Key 0.</description>
+     <addressOffset>0x000</addressOffset>
+     <size>128</size>
+    </register>
+    <register>
+     <name>KEY1</name>
+     <description>AES Key 1.</description>
+     <addressOffset>0x010</addressOffset>
+     <size>128</size>
+    </register>
+   </registers>
+  </peripheral>
+<!--AESKEYS AES Key Registers.-->
+  <peripheral>
+   <name>CAN0</name>
+   <description>Controller Area Network Registers</description>
+   <baseAddress>0x40064000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>MODE</name>
+     <description>Mode Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>AFM</name>
+       <description>Hardware acceptance filter scheme.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LOM</name>
+       <description>Listen Only Mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST</name>
+       <description>Reset Mode.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXTRIG</name>
+       <description>Receive FIFO trigger in 32bit word.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>1W</name>
+         <description>1 word</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4W</name>
+         <description>4 word</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8W</name>
+         <description>8 word</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16W</name>
+         <description>16 word</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>32W</name>
+         <description>32 word</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>64W</name>
+         <description>64 word</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>Enable DMA mode.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SLP</name>
+       <description>Sleep mode.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>enter</name>
+         <description>Enter sleep mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>leave</name>
+         <description>Leave sleep mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMD</name>
+     <description>Command Register.</description>
+     <addressOffset>0x0001</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ABORT</name>
+       <description>Abort Transmission</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXREQ</name>
+       <description>Transmit Request.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>Status Register.</description>
+     <addressOffset>0x0002</addressOffset>
+     <size>8</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUS_OFF</name>
+       <description>Bus off Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERR</name>
+       <description>Error Status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Transmit Status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Receive Status.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXBUF</name>
+       <description>Transmit Buffer Status.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DOR</name>
+       <description>Data Overrun Status.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXBUF</name>
+       <description>Receive Buffer Status.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x0003</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DOR</name>
+       <description>Data Overrun Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BERR</name>
+       <description>Bus Error Interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Transmission Interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Receive Interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERPSV</name>
+       <description>Error Passive Interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERWARN</name>
+       <description>Error Warning Interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AL</name>
+       <description>Arbitration Lost Interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WU</name>
+       <description>Wake-up Interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DOR</name>
+       <description>Data Overrun Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BERR</name>
+       <description>Bus Error Interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Transmit Interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Receive Interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERPSV</name>
+       <description>Error Passive Interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERWARN</name>
+       <description>Error Warning Interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AL</name>
+       <description>Arbitration Lost Interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WU</name>
+       <description>Wakeup interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RMC</name>
+     <description>Receive Message Counter Register.</description>
+     <addressOffset>0x0005</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>NUM_MSGS</name>
+       <description>Number of stored message frames.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUSTIM0</name>
+     <description>Bus Timing Register 0.</description>
+     <addressOffset>0x0006</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BR_CLKDIV</name>
+       <description>Baud Rate Prescaler.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>SJW</name>
+       <description>Synchronization Jump Width.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUSTIM1</name>
+     <description>Bus Timing Register 1.</description>
+     <addressOffset>0x0007</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TSEG1</name>
+       <description>Number of clock cycles per Time Segment 1</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TSEG2</name>
+       <description>Number of clock cycles per Time Segment 2</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>SAM</name>
+       <description>Number of bus level samples.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXFIFO32</name>
+     <description>Transmit FIFO Register.</description>
+     <addressOffset>0x0008</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>TXFIFO16[%s]</name>
+     <description>Transmit FIFO Register.</description>
+     <addressOffset>0x0008</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>TXFIFO8[%s]</name>
+     <description>Transmit FIFO Register.</description>
+     <addressOffset>0x0008</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXFIFO32</name>
+     <description>Receive FIFO Register.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read from RX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>RXFIFO16[%s]</name>
+     <description>Receive FIFO Register.</description>
+     <addressOffset>0x000C</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read from RX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>RXFIFO8[%s]</name>
+     <description>Receive FIFO Register.</description>
+     <addressOffset>0x000C</addressOffset>
+     <size>8</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read from RX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACR32</name>
+     <description>Acceptance Code Register.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ACR</name>
+       <description>Acceptance Code.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>ACR16[%s]</name>
+     <description>Acceptance Code Register.</description>
+     <addressOffset>0x0010</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ACR</name>
+       <description>Acceptance Code.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>ACR8[%s]</name>
+     <description>Acceptance Code Register.</description>
+     <addressOffset>0x0010</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ACR</name>
+       <description>Acceptance Code.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AMR32</name>
+     <description>Acceptance Mask Register.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>AMR</name>
+       <description>Acceptance Mask.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>AMR16[%s]</name>
+     <description>Acceptance Mask Register.</description>
+     <addressOffset>0x0014</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>AMR</name>
+       <description>Acceptance Mask.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>AMR8[%s]</name>
+     <description>Acceptance Mask Register.</description>
+     <addressOffset>0x0014</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>AMR</name>
+       <description>Acceptance Mask.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECC</name>
+     <description>Error Code Capture Register.</description>
+     <addressOffset>0x0018</addressOffset>
+     <size>8</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BER</name>
+       <description>Bit Error Occurred.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>STFER</name>
+       <description>Stuff Error Occurred.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRCER</name>
+       <description>CRC Error Occurred.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FRMER</name>
+       <description>Form Error Occurred.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ACKER</name>
+       <description>ACK Error Occurred.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EDIR</name>
+       <description>Direction of transfer while error occurred.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>TX</name>
+         <description>Transmission</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RX</name>
+         <description>Reception</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TXWRN</name>
+       <description>Set when TXERR counter is greater than or equal to 96.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXWRN</name>
+       <description>Set when RXERR counter is greater than or equal to 96.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXERR</name>
+     <description>Receive Error Counter.</description>
+     <addressOffset>0x0019</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RXERR</name>
+       <description>Receive Error Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXERR</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x001A</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TXERR</name>
+       <description>Transmit Error Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ALC</name>
+     <description>Arbitration Lost Code Capture Register.</description>
+     <addressOffset>0x001B</addressOffset>
+     <size>8</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ALC</name>
+       <description>Arbitration Lost Capture.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NBT</name>
+     <description>Nominal Bit Timing Register.</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>NBRP</name>
+       <description>Baudrate Prescaler Used in Arbitration Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+      <field>
+       <name>NSEG1</name>
+       <description>The time segment before the sample point in Abritration Phase.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>NSEG2</name>
+       <description>The time segment after the sample point in Abritration Phase.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>NSJW</name>
+       <description>Synchronization Jump Width in Arbitration Phase.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DBT_SSPP</name>
+     <description>Data Bit Timing Register.</description>
+     <addressOffset>0x0020</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DBRP</name>
+       <description>Baudrate Prescaler in Data Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+      <field>
+       <name>DSEG1</name>
+       <description>The time segment before the sample point in Data Phase.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>DSEG2</name>
+       <description>The time segment before the sample point in Data Phase.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>DSJW</name>
+       <description>Synchronization Jump Width in Data Phase</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>SSPP</name>
+       <description>Position of the secondary sample point.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FDCTRL</name>
+     <description>FD Control Register.</description>
+     <addressOffset>0x0024</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>FDEN</name>
+       <description>FD Frame format/ Extended data length. This bit indicates CAN FD frame format.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>fd</name>
+         <description>CAN FD Frame Format</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>classic</name>
+         <description>Classic CAN Frame Format.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BRSEN</name>
+       <description>This bit indicates whether the bit rate is switched in Data phase.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>NOSW</name>
+         <description>Bit rate is not switced inside of CAN FD frame.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SW</name>
+         <description>Bit rate is switched from nominal bit rate of the arbitration phase to alternate bit rate of data phase.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTBT</name>
+       <description>This bit configure the Bit Time prescaler in Arbitration phase.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>BT</name>
+         <description>Use contents of BT register to configure bit time in arbitration phase.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>NBT</name>
+         <description>Use contents of NBT register to configure bit time in arbitration phase.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ISO</name>
+       <description>ISO CAN FD Format Selection.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>BOSCH</name>
+         <description>Frame format according to Bosch CAN FD specification.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ISO</name>
+         <description>Frame format according to ISO 11898 1, 2015.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DAR</name>
+       <description>Disable Auto Retransmission</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Automatic retransmission enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Automatic retransmission disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>REOM</name>
+       <description>Restricted Operation Mode.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PED</name>
+       <description>Protocol Exception Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FDSTAT</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0025</addressOffset>
+     <size>8</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BITERR</name>
+       <description>Bit Error Indicator. When this bit is set the inconsistency occurs between the transmitted and the received bit in CAN FD frame.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRCERR</name>
+       <description>Cyclic Redundancy Check Error indicator. This indicates that calculated CRC is different from received in CAN FD frame</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FRMERR</name>
+       <description>Form Error indicator. This bit indicates, that a fixed form bit field contains at least one illegal bit in Data phase of CAN FD frame with the BRS 
+bit set</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>STFERR</name>
+       <description>Stuff Error Indicator. This bit indicates stuff error occurred in Data phase in CAN FD frame with the BRS bit set
+</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PEE</name>
+       <description>Protocol Exception Event indicator. Indicates that core detects recessive state on res position and enter to Bus integration state.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>STATE</name>
+       <description>Operation state.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>INT</name>
+         <description>Waiting for 11 recessive bit after reset or bus off</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IDLE</name>
+         <description>Waiting for Start of Frame.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RX</name>
+         <description>Node operating as Receiver.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>TX</name>
+         <description>Node operating as Transmitter.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DPERR</name>
+     <description>Data Phase Error Counter Register.</description>
+     <addressOffset>0x0026</addressOffset>
+     <size>8</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DPERR</name>
+       <description>Data Phase Error Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>APERR</name>
+     <description>Arbitration Phase Error Counter Register.</description>
+     <addressOffset>0x0027</addressOffset>
+     <size>8</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>APERR</name>
+       <description>Arbitration Error Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TEST</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0028</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LBEN</name>
+       <description>Loopback mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXC</name>
+       <description>Transmitted frame.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WUPCLKDIV</name>
+     <description>Wake-up timer prescaler.</description>
+     <addressOffset>0x0029</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WUPDIV</name>
+       <description>Wake-up timer prescaler.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WUPFT</name>
+     <description>Wake up Filter Time Register.</description>
+     <addressOffset>0x002A</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WUPFT</name>
+       <description>Wake-up pattern filter time.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WUPET</name>
+     <description>Wake-up Expire Time Register.</description>
+     <addressOffset>0x002C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WUPET</name>
+       <description>Wake up patter expire time.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXDCNT</name>
+     <description>RX FIFO Data Counter Register.</description>
+     <addressOffset>0x0030</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RXDCNT</name>
+       <description>RX FIFO data counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXSCNT</name>
+     <description>TX FIFO Space Counter.</description>
+     <addressOffset>0x0032</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TXSCNT</name>
+       <description>TX FIFO Space Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXDECMP</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0033</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TDCO</name>
+       <description>Transceiver Delay Compensation Offset. This bit field contains the offset value added to the measured transceiver loop delay</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>TDCEN</name>
+       <description>Transceiver Delay Compensation Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EINTFL</name>
+     <description>Extended Interrupt Flag Register.</description>
+     <addressOffset>0x0034</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO reach programmed trigger level, it is set when the RX FIFO reaches programmed trigger level (RT[2:0] in MR register). To clear the 
+RXFT interrupt, write this bit 1</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_TO</name>
+       <description>RX FIFO Timeout Indicator. It is set when there is no write or read from/in to RX FIFO for the user defined time (RXFTO register) and there is at 
+least 1 entry in RX FIFO during this time, this bit is clear by write 1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EINTEN</name>
+     <description>Extended Interrupt Enable Register.</description>
+     <addressOffset>0x0035</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO reach programmed trigger level, it is set when the RX FIFO reaches programmed trigger level (RT[2:0] in MR register). To clear the 
+RXFT interrupt, write this bit 1</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_TO</name>
+       <description>RX FIFO Timeout Indicator. It is set when there is no write or read from/in to RX FIFO for the user defined time (RXFTO register) and there is at 
+least 1 entry in RX FIFO during this time, this bit is clear by write 1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXTO</name>
+     <description>RX FIFO Timeout Register.</description>
+     <addressOffset>0x0036</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_TO</name>
+       <description>RX FIFO Timeout</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CAN0 Controller Area Network Registers-->
+  <peripheral derivedFrom="CAN0">
+   <name>CAN1</name>
+   <description>Controller Area Network Registers 1</description>
+   <baseAddress>0x40065000</baseAddress>
+  </peripheral>
+<!--CAN1 Controller Area Network Registers 1-->
+  <peripheral derivedFrom="CAN0">
+   <name>CAN2</name>
+   <description>Controller Area Network Registers 2</description>
+   <baseAddress />
+  </peripheral>
+<!--CAN2 Controller Area Network Registers 2-->
+  <peripheral>
+   <name>CTB</name>
+   <description>The Cryptographic Toolbox is a combination of cryptographic engines and a secure cryptographic accelerator (SCA) used to provide advanced cryptographic security.</description>
+   <baseAddress>0x40001000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Crypto_Engine</name>
+    <description>Crypto Engine interrupt.</description>
+    <value>27</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Crypto Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0xC0000000</resetValue>
+     <fields>
+      <field>
+       <name>RST</name>
+       <description>Reset. This bit is used to reset the crypto accelerator.  All crypto internal states and related registers are reset to their default reset values. Control register such as CRYPTO_CTRL, CIPHER_CTRL, HASH_CTRL, CRC_CTRL, MAA_CTRL (with the exception of the STC bit), HASH_MSG_SZ_[3:0] and MAA_MAWS will retain their values. This bit will automatically clear itself after one cycle.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_write</name>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>Starts reset operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INTR</name>
+       <description>Interrupt Enable. Generates an interrupt when done or error set.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRC</name>
+       <description>Source Select.  This bit selects the hash function and CRC generator input source.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inputFIFO</name>
+         <description>Input FIFO</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputFIFO</name>
+         <description>Output FIFO</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="INTR">
+       <name>BSO</name>
+       <description>Byte Swap Output. Note. No byte swap will occur if there is not a full word.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="INTR">
+       <name>BSI</name>
+       <description>Byte Swap Input. Note. No byte swap will occur if there is not a full word.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="INTR">
+       <name>WAIT_EN</name>
+       <description>Wait Pin Enable. This can be used to hold off the crypto DMA until an external memory is ready. This is useful for transferring pages from NAND flash which may take several microseconds to become ready.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WAIT_POL</name>
+       <description>Wait Pin Polarity. When the wait pin is enabled, this bit selects its active state.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRSRC</name>
+       <description>Write FIFO Source Select. This field determines where data written to the write FIFO comes from. When data is written to the write FIFO, it is always written out the DMA. To decrypt or encrypt data, the write FIFO source should be set to the cipher output. To implement memcpy() or memset() functions, or to fill memory with random data, the write FIFO source should be set to the read FIFO. When calculating a HASH or CMAC, the write FIFO should be disabled.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>none</name>
+         <description>None.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cipherOutput</name>
+         <description>Cipher Output.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>readFIFO</name>
+         <description>Read FIFO.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDSRC</name>
+       <description>Read FIFO Source Select. This field selects the source of the read FIFO. Typically, it is set to use the DMA. To implement a memset() function, the read FIFO DMA should be disabled. To fill memory with random data or to hash random numbers, the read FIFO source should be set to the random number generator.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dmaDisabled</name>
+         <description>DMA Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dmaOrApb</name>
+         <description>DMA Or APB.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rng</name>
+         <description>RNG.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLAG_MODE</name>
+       <description>Done Flag Mode. This bit configures the access behavior of the individual CRYPTO_CTRL Done flags (CRYPTO_CTRL[27:24]). This bit is cleared only on reset to limit upkeep, i.e. once set, it will remain set until a reset occurs.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unres_wr</name>
+         <description>Unrestricted write (0 or 1) of CRYPTO_CTRL[27:24] flags.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>res_wr</name>
+         <description>Access to CRYPTO_CTRL[27:24] are write 1 to clear/write 0 no effect.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMADNEMSK</name>
+       <description>DMA Done Flag Mask. This bit masks the DMA_DONE flag from being used to generate the CRYPTO_CTRL.DONE flag, and this disables a DMA_DONE condition from generating and interrupt. The DMA_DONE flag itself is unaffected and still may be monitored. This allows more optimal interrupt-driven crypto operations using DMA.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_used</name>
+         <description>DMA_DONE not used in setting CRYPTO_CTRL.DONE bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>used</name>
+         <description>DMA_DONE used in setting CRYPTO_CTRL.DONE bit.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DMA_DONE</name>
+       <description>DMA Done. DMA write/read operation is complete. This bit must be cleared before starting a DMA operation.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notDone</name>
+         <description>Not Done.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>done</name>
+         <description>Done.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>GLS_DONE</name>
+       <description>Galois Done. FIFO is full and CRC or Hamming Code Generator is enabled. This bit must be cleared before starting a CRC operation Note that DMA_DONE must be polled instead of this bit to determine the end of DMA operation during the utilization of Hamming Code Generator.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>HSH_DONE</name>
+       <description>Hash Done. SHA operation is complete. This bit must be cleared before starting a HASH operation.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>CPH_DONE</name>
+       <description>Cipher Done. Either AES or DES encryption/decryption operation is complete. This bit must be cleared before starting a cipher operation.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERR</name>
+       <description>AHB Bus Error. This bit is set when the DMA encounters a bus error during a read or write operation. Once this bit is set, the DMA will stop. This bit can only be cleared by resetting the crypto block.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Error.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Ready. Crypto block ready for more data.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA_DONE">
+       <name>DONE</name>
+       <description>Done. One or more cryptographic calculations complete (logical OR of done flags).</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CIPHER_CTRL</name>
+     <description>Cipher Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ENC</name>
+       <description>Encrypt. Select encryption or decryption of input data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ENCRYPT</name>
+         <description>Encrypt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DECRYPT</name>
+         <description>Decrypt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEY</name>
+       <description>Load Key from crypto DMA. This bit is automatically cleared by hardware after the DMA has completed loading the key. When the DMA operation is done, it sets the appropriate crypto DMA Done flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SRC</name>
+       <description>Source of Random key.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>cipherKey</name>
+         <description>User cipher key (0x4000_1060).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>regFile</name>
+         <description>Key from battery-backed register file (0x4000_5000 to 0x4000_501F).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>qspiKey_regFile</name>
+         <description>Key from battery-backed register file (0x4000_5020 to 0x4000_502F).</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CIPHER</name>
+       <description>Cipher Operation Select.  Symmetric Block Cipher algorithm selection or memory operation.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes128</name>
+         <description>AES 128.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes192</name>
+         <description>AES 192.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>aes256</name>
+         <description>AES 256.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>des</name>
+         <description>DES.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>tdes</name>
+         <description>Triple DES.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description>Mode Select. Mode of operation for block cipher or memory operation. DES/TDES cannot be used in CFB, OFB or CTR modes.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ECB</name>
+         <description>ECB Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CBC</name>
+         <description>CBC Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CFB</name>
+         <description>CFB (AES only).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>OFB</name>
+         <description>OFB (AES only).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CTR</name>
+         <description>CTR (AES only).</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GCM</name>
+         <description>GCM.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CCM</name>
+         <description>CCM.</description>
+         <value>6</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HVC</name>
+       <description>H Vector Computation.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DTYPE</name>
+       <description>GCM/CCM data type.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AAD</name>
+         <description>AAD.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PLD</name>
+         <description>PLD.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CCMM</name>
+       <description>CCM M Parameter.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>4</name>
+         <description>4</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6</name>
+         <description>6</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8</name>
+         <description>8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10</name>
+         <description>10</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12</name>
+         <description>12</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14</name>
+         <description>14</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16</name>
+         <description>16</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CCML</name>
+       <description>CCM L Parameter.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>2</name>
+         <description>2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3</name>
+         <description>3</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4</name>
+         <description>4</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5</name>
+         <description>5</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6</name>
+         <description>6</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7</name>
+         <description>7</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8</name>
+         <description>8</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PUFKEYSEL</name>
+       <description>PUF Key Selector.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>KEY0</name>
+         <description>Select PUF KEY0</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>KEY1</name>
+         <description>Select PUF KEY1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HASH_CTRL</name>
+     <description>HASH Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>INIT</name>
+       <description>Initialize. Initializes hash registers with standard constants.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>XOR</name>
+       <description>XOR data with IV from cipher block. Useful when calculating HMAC to XOR the input pad and output pad.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HASH</name>
+       <description>Hash function selection.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha1</name>
+         <description>SHA-1.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha224</name>
+         <description>SHA 224.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha256</name>
+         <description>SHA 256.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha384</name>
+         <description>SHA 384.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sha512</name>
+         <description>SHA 512.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LAST</name>
+       <description>Last Message Bit. This bit shall be set along with the HASH_MSG_SZ register prior to hashing the last 512 or 1024-bit block of the message data. It will allow automatic preprocessing of the last message padding, which includes the trailing bit 1, followed by the respective number of zero bits for the last block size and finally the message length represented in bytes. The bit will be automatically cleared at the same time the HASH DONE is set, designating the completion of the last message hash.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEffect</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>lastMsgData</name>
+         <description>Last Message Data.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_CTRL</name>
+     <description>CRC Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>CRC</name>
+       <description>Cyclic Redundancy Check Enable. The CRC cannot be enabled if the PRNG is enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MSB</name>
+       <description>MSB select. This bit selects the order of calculating CRC on data.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lsbFirst</name>
+         <description>LSB First.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>msbFirst</name>
+         <description>MSB First.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CRC">
+       <name>PRNG</name>
+       <description>Pseudo Random Number Generator Enable. If entropy is disabled, this outputs one byte of pseudo random data per clock cycle. If entropy is enabled, data is output at a rate of one bit per clock cycle.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CRC">
+       <name>ENT</name>
+       <description>Entropy Enable. If the PRNG is enabled, this mixes the high frequency ring oscillator with the LFSR. If the PRNG is disabled, the raw entropy data is output at a rate of 1 bit per clock. This makes it possible to characterize the quality of the entropy source.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CRC">
+       <name>HAM</name>
+       <description>Hamming Code Enable. Enable hamming code calculation.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HRST</name>
+       <description>Hamming Reset. Reset Hamming code ECC generator for next block.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+       <enumeratedValues>
+        <usage>write</usage>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>Starts reset operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_SRC</name>
+     <description>Crypto DMA Source Address.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>DMA Source Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_DEST</name>
+     <description>Crypto DMA Destination Address.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>DMA Destination Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA_CNT</name>
+     <description>Crypto DMA Byte Count.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>DMA Byte Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAA_CTRL</name>
+     <description>MAA Control Register.</description>
+     <addressOffset>0x1C</addressOffset>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DIN[%s]</name>
+     <description>Crypto Data Input. Data input can be written to this register instead of using the DMA. This register writes to the FIFO. This register occupies four successive words to allow the use of multi-store instructions. Words can be written to any location, they will be placed in the FIFO in the order they are written. The endian swap input control bit affects this register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Crypto Data Input. Input can be written to this register instead of using DMA.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DOUT[%s]</name>
+     <description>Crypto Data Output. Resulting data from cipher calculation. Data is placed in the lower words of these four registers depending on the algorithm. For block cipher modes, this register holds the result of most recent encryption or decryption operation. These registers are affected by the endian swap bits.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Crypto Data Output. Resulting data from cipher calculation. Data is placed in the lower words of these four registers depending on algorithm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_POLY</name>
+     <description>CRC Polynomial. The polynomial to be used for Galois Field calculations (CRC or LFSR) should be written to this register. This register is affected by the MSB control bit.</description>
+     <addressOffset>0x40</addressOffset>
+     <resetValue>0xEDB88320</resetValue>
+     <fields>
+      <field>
+       <name>POLY</name>
+       <description>CRC Polynomial. The polynomial to be used for Galois Field calculations (CRC or LFSR) should be written to this register. This register is affected by the MSB control bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_VAL</name>
+     <description>CRC Value. This is the state for the Galois Field. This register holds the result of a CRC calculation or the current state of the LFSR. This register is affected by the MSB control bit.</description>
+     <addressOffset>0x44</addressOffset>
+     <resetValue>0xFFFFFFFF</resetValue>
+     <fields>
+      <field>
+       <name>VAL</name>
+       <description>CRC Value. This is the state for the Galois Field. This register holds the result of a CRC calculation or the current state of LFSR. This register is affected by the MSB control bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CRC_PRNG</name>
+     <description>CRC PRNG Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>PRNG</name>
+       <description>PRNG</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HAM_ECC</name>
+     <description>Hamming ECC Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>ECC</name>
+       <description>Hamming ECC Value. These bits are the even parity of their corresponding bit groups.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PAR</name>
+       <description>Parity. This is the parity of the entire array.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>even</name>
+         <description>Even.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>odd</name>
+         <description>Odd.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CIPHER_INIT[%s]</name>
+     <description>Initial Vector. For block cipher operations that use CBC, CFB, OFB, or CNTR modes, this register holds the initial value. This register is updated with each encryption or decryption operation. This register is affected by the endian swap bits.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>IVEC</name>
+       <description>Initial Vector. For block cipher operations that use CBC, CFB, OFB, or CNTR modes, this register holds the initial value. This register is updated with each encryption or decryption operation. This register is affected by the endian swap bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CIPHER_KEY[%s]</name>
+     <description>Cipher Key.  This register holds the key used for block cipher operations. The lower words are used for block ciphers that use shorter key lengths. This register is affected by the endian swap input control bits.</description>
+     <addressOffset>0x60</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>KEY</name>
+       <description>Cipher Key. This register holds the key used for block cipher operations. The lower words are used for block ciphers that use shorter kye lengths. This register is affected by the endian swap input control bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>16</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>HASH_DIGEST[%s]</name>
+     <description>This register holds the calculated hash value. This register is affected by the endian swap bits.</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>HASH</name>
+       <description>This register holds the calculated hash value. This register is affected by the endian swap bits.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>HASH_MSG_SZ[%s]</name>
+     <description>Message Size. This register holds the lowest 32-bit of message size in bytes.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>MSGSZ</name>
+       <description>Message Size. This register holds the lowest 32-bit of message size in bytes.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAA_MAWS</name>
+     <description>MAA Word Size Register.</description>
+     <addressOffset>0xD0</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>SIZE</name>
+       <description>MAA Word Size.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>AAD_LENGTH[%s]</name>
+     <description>AAD Length Registers.</description>
+     <addressOffset>0xD0</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>LENGTH</name>
+       <description>AAD length in bytes for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>PLD_LENGTH[%s]</name>
+     <description>PLD Length Registers.</description>
+     <addressOffset>0xD8</addressOffset>
+     <resetValue>0x0</resetValue>
+     <fields>
+      <field>
+       <name>LENGTH</name>
+       <description>PLD length in bytes for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>TAGMIC[%s]</name>
+     <description>TAG/MIC Registers.</description>
+     <addressOffset>0xE0</addressOffset>
+     <fields>
+      <field>
+       <name>LENGTH</name>
+       <description>TAG/MIC output for AES GCM and CCM operations.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CTB The Cryptographic Toolbox is a combination of cryptographic engines and a secure cryptographic accelerator (SCA) used to provide advanced cryptographic security.-->
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0</name>
+    <value>28</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1</name>
+    <value>29</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA2</name>
+    <value>30</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA3</name>
+    <value>31</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA4</name>
+    <value>68</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA5</name>
+    <value>69</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA6</name>
+    <value>70</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA7</name>
+    <value>71</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA8</name>
+    <value>72</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA9</name>
+    <value>73</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA10</name>
+    <value>74</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA11</name>
+    <value>75</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA12</name>
+    <value>76</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA13</name>
+    <value>77</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA14</name>
+    <value>78</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA15</name>
+    <value>79</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>INTEN</name>
+     <description>DMA Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel 0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <description>Channel 1 Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <description>Channel 2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <description>Channel 3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH4</name>
+       <description>Channel 4 Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH5</name>
+       <description>Channel 5 Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH6</name>
+       <description>Channel 6 Interrupt Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH7</name>
+       <description>Channel 7 Interrupt Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH8</name>
+       <description>Channel 8 Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH9</name>
+       <description>Channel 9 Interrupt Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH10</name>
+       <description>Channel 10 Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH11</name>
+       <description>Channel 11 Interrupt Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH12</name>
+       <description>Channel 12 Interrupt Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH13</name>
+       <description>Channel 13 Interrupt Enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH14</name>
+       <description>Channel 14 Interrupt Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH15</name>
+       <description>Channel 15 Interrupt Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>DMA Interrupt Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel Interrupt. To clear an interrupt, all active interrupt bits of the DMA_ST must be cleared. The interrupt bits are set only if their corresponding interrupt enable bits are set in DMA_CN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH8</name>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH9</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH10</name>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH11</name>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH12</name>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH13</name>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH14</name>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH15</name>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>16</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CTRL</name>
+      <description>DMA Channel Control Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>EN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQUEST</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0RX</name>
+          <description>SPI0 RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1RX</name>
+          <description>SPI1 RX</description>
+          <value>0x02</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI2RX</name>
+          <description>SPI2 RX</description>
+          <value>0x03</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0RX</name>
+          <description>UART0 RX</description>
+          <value>0x04</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1RX</name>
+          <description>UART1 RX</description>
+          <value>0x05</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>CAN0RX</name>
+          <description>CAN0 RX</description>
+          <value>0x06</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0RX</name>
+          <description>I2C0 RX</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1RX</name>
+          <description>I2C1 RX</description>
+          <value>0x08</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>ADC</name>
+          <description>ADC</description>
+          <value>0x09</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2RX</name>
+          <description>I2C2 RX</description>
+          <value>0x0A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2RX</name>
+          <description>UART2 RX</description>
+          <value>0x0E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI3RX</name>
+          <description>SPI3 RX</description>
+          <value>0x0F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI4RX</name>
+          <description>SPI4 RX</description>
+          <value>0x10</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRX1</name>
+          <description>USB RX1</description>
+          <value>0x11</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRX2</name>
+          <description>USB RX2</description>
+          <value>0x12</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRX3</name>
+          <description>USB RX3</description>
+          <value>0x13</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRX4</name>
+          <description>USB RX4</description>
+          <value>0x14</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRX5</name>
+          <description>USB RX5</description>
+          <value>0x15</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRX6</name>
+          <description>USB RX6</description>
+          <value>0x16</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRX7</name>
+          <description>USB RX7</description>
+          <value>0x17</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRX8</name>
+          <description>USB RX8</description>
+          <value>0x18</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRX9</name>
+          <description>USB RX9</description>
+          <value>0x19</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRX10</name>
+          <description>USB RX10</description>
+          <value>0x1A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBRX11</name>
+          <description>USB RX11</description>
+          <value>0x1B</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3RX</name>
+          <description>UART3 RX</description>
+          <value>0x1C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2SRX</name>
+          <description>I2S RX</description>
+          <value>0x1E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>CAN1RX</name>
+          <description>CAN1 RX</description>
+          <value>0x1F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0TX</name>
+          <description>SPI0 TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1TX</name>
+          <description>SPI1 TX</description>
+          <value>0x22</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI2TX</name>
+          <description>SPI2 TX</description>
+          <value>0x23</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0TX</name>
+          <description>UART0 TX</description>
+          <value>0x24</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1TX</name>
+          <description>UART1 TX</description>
+          <value>0x25</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>CAN0TX</name>
+          <description>CAN0 TX</description>
+          <value>0x26</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0TX</name>
+          <description>I2C0 TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1TX</name>
+          <description>I2C1 TX</description>
+          <value>0x28</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2TX</name>
+          <description>I2C2 TX</description>
+          <value>0x2A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2TX</name>
+          <description>UART2 TX</description>
+          <value>0x2E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI3TX</name>
+          <description>SPI3 TX</description>
+          <value>0x2F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI4TX</name>
+          <description>SPI4 TX</description>
+          <value>0x30</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTX1</name>
+          <description>USB TX1</description>
+          <value>0x31</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTX2</name>
+          <description>USB TX2</description>
+          <value>0x32</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTX3</name>
+          <description>USB TX3</description>
+          <value>0x33</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTX4</name>
+          <description>USB TX4</description>
+          <value>0x34</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTX5</name>
+          <description>USB TX5</description>
+          <value>0x35</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTX6</name>
+          <description>USB TX6</description>
+          <value>0x36</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTX7</name>
+          <description>USB TX7</description>
+          <value>0x37</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTX8</name>
+          <description>USB TX8</description>
+          <value>0x38</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTX9</name>
+          <description>USB TX9</description>
+          <value>0x39</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTX10</name>
+          <description>USB TX10</description>
+          <value>0x3A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>USBTX11</name>
+          <description>USB TX11</description>
+          <value>0x3B</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3TX</name>
+          <description>UART3 TX</description>
+          <value>0x3C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2STX</name>
+          <description>I2S TX</description>
+          <value>0x3E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>CAN1TX</name>
+          <description>CAN1 TX</description>
+          <value>0x3F</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_WAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_PER</name>
+        <description>Timeout Period Select.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_CLKDIV</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BURST_SIZE</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>DIS_IE</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IE</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>STATUS</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>STATUS</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IF</name>
+        <description>Count-to-Zero (CTZ) Interrupt Flag</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>RLD_IF</name>
+        <description>Reload Event Interrupt Flag.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>TO_IF</name>
+        <description>Time-Out Event Interrupt Flag.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRCRLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DSTRLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNTRLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>EN</name>
+        <description>Reload Enable. This bit should be set after the address reload registers have been programmed. This bit is automatically cleared to 0 when reload occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+<!--DMA DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral>
+   <name>EMCC</name>
+   <description>External Memory Cache Controller Registers.</description>
+   <baseAddress>0x40033000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>INFO</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SZ</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCH</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEM</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRITE_ALLOC</name>
+       <description>Write Allocate Enable. This bit only writable while the cache is disabled.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Write-no-allocate.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Write-allocate enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CWFST_DIS</name>
+       <description>Critical word first and streaming disable. This bit only writeable while the cache is disabled.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Critical word first and streaming disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Critical word first and streaming enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Cache Contents. Any time this register location is written (regardless of the data value), the cache controller immediately begins invalidating the entire contents of the cache memory. The cache will be in bypass mode until the invalidate operation is complete. System software can examine the Cache Ready bit (CACHE_CTRL.CACHE_RDY) to determine when the invalidate operation is complete. Note that it is not necessary to disable the cache controller prior to beginning this operation. Reads from this register always return 0.</description>
+     <addressOffset>0x0700</addressOffset>
+     <fields>
+      <field>
+       <name>IA</name>
+       <description>Invalidate all cache contents.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--EMCC External Memory Cache Controller Registers.-->
+  <peripheral>
+   <name>FCR</name>
+   <description>Function Control Register.</description>
+   <baseAddress>0x40000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>FCTRL0</name>
+     <description>Function Control 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RDSGCSEL</name>
+       <description>Hyperbys RDS Gray Code Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RDSGCSET</name>
+       <description>Hyperbus RDS Set.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HYPERCGDLY</name>
+       <description>Hyperbus Clock Generator Delay.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>USBCLKSEL</name>
+       <description>USB Core Clock Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>I2C0DGEN0</name>
+       <description>I2C0 SDA Pad Deglitcher enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0DGEN1</name>
+       <description>I2C0 SCL Pad Deglitcher enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN0</name>
+       <description>I2C1 SDA Pad Deglitcher enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN1</name>
+       <description>I2C1 SCL Pad Deglitcher enable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2DGEN0</name>
+       <description>I2C2 SDA Pad Deglitcher enable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2DGEN1</name>
+       <description>I2C2 SCL Pad Deglitcher enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL0</name>
+     <description>Automatic Calibration 0.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ACEN</name>
+       <description>Auto-calibration Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACRUN</name>
+       <description>Autocalibration Run.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDTRM</name>
+       <description>Load Trim.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GAININV</name>
+       <description>Invert Gain.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ATOMIC</name>
+       <description>Atomic mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MU</name>
+       <description>MU value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>HIRC96MACTMROUT</name>
+       <description>HIRC96M Trim Value.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL1</name>
+     <description>Automatic Calibration 1.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INITTRM</name>
+       <description>Initial Trim Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL2</name>
+     <description>Automatic Calibration 2</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONECNT</name>
+       <description>Auto-callibration Done Counter Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>ACDIV</name>
+       <description>Auto-callibration Div Setting.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>URVBOOTADDR</name>
+     <description>RISC-V Boot Address.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>URVCTRL</name>
+     <description>RISC-V Control Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MEMSEL</name>
+       <description>RAM2, RAM3 exclusive ownership.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IFLUSHEN</name>
+       <description>URV instruction flush enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>XO32MKS</name>
+     <description>RISC-V Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLK</name>
+       <description>Kick Start XO Counter Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Kick Start XO Enable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DRIVER</name>
+       <description>Kick Start XO Driver</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>PULSE</name>
+       <description>Kick Start XO 2X Pulse</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKSEL</name>
+       <description>Kick Start XO Clock Select</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>none</name>
+         <description>No kick start clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>test</name>
+         <description>Test Clock in P1.2 (TMR3[22]=1).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ISO</name>
+         <description>Internal secondary oscilator</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>Internal Primary Oscilator</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SARBUFCN</name>
+     <description>TBD</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>THRU_PAD_SW_EN</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>THRU_EN</name>
+       <description>TBD</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAMP_EN</name>
+       <description>TBD</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>THRU_RRI_EN</name>
+       <description>TBD</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DIVSEL</name>
+       <description>TBD</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TS0</name>
+     <description>Temp Sensor trim0</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>GAIN</name>
+       <description>Unsigned gain for temp sensor normalization Temp degrees C = (ADC result * TS_GAIN) + TS_OFFSET.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TS1</name>
+     <description>Temp Sensor trim1</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>OFFSET</name>
+       <description>Signed gain for temp sensor normalization Temp degrees C = (ADC result * TS_GAIN) + TS_OFFSET.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>TS_OFFSET_SIGN</name>
+       <description>Sign extension of TS_OFFSET[13:0]</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>18</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCREFTRIM0</name>
+     <description>Temp Sensor trim1</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VREFP</name>
+       <description>Trimming code for VREFP output of reference buffer</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VREFM</name>
+       <description>Trimming code for VREFM output of reference buffer</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VCM</name>
+       <description>Trimming code for VCM output of reference buffer</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>VX2_TUNE</name>
+       <description>Controls tuning capacitor in fine DAC (offset binary)</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCREFTRIM1</name>
+     <description>Temp Sensor trim1</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VREFP</name>
+       <description>Trimming code for VREFP output of reference buffer</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VREFM</name>
+       <description>Trimming code for VREFM output of reference buffer</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VCM</name>
+       <description>Trimming code for VCM output of reference buffer</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>VX2_TUNE</name>
+       <description>Controls tuning capacitor in fine DAC (offset binary)</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCREFTRIM2</name>
+     <description>Temp Sensor trim1</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IDRV_1P25</name>
+       <description>Trimming code for reference buffer drive strength. 1.25V</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IBOOST_1P25</name>
+       <description>Trimming value for extra drive current in reference buffer outputs. 2.048V</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IDRV_2P048</name>
+       <description>Trimming code for reference buffer drive strength. 2.048V</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IBOOST_2P048</name>
+       <description>Trimming value for extra drive current in reference buffer outputs. 2.048V</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VCM</name>
+       <description>Trimming code for VCM output of reference buffer</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>VX2_TUNE</name>
+       <description>Controls tuning capacitor in fine DAC (offset binary)</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FCR Function Control Register.-->
+  <peripheral>
+   <name>FLC</name>
+   <description>Flash Memory Control.</description>
+   <prependToName>FLSH_</prependToName>
+   <baseAddress>0x40029000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Flash_Controller</name>
+    <description>Flash Controller interrupt.</description>
+    <value>23</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ADDR</name>
+     <description>Flash Write Address.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address for next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Flash Clock Divide. The clock (PLL0) is divided by this value to generate a 1 MHz clock for Flash controller.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000078</resetValue>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Flash Clock Divide. The clock is divided by this value to generate a 1MHz clock for flash controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Flash Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WR</name>
+       <description>Write.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="WR">
+       <name>ME</name>
+       <description>Mass Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="WR">
+       <name>PGE</name>
+       <description>Page Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WDTH</name>
+       <description>TBD</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERASE_CODE</name>
+       <description>Erase Code.  The ERASE_CODE must be set up property before erase operation can be initiated. These bits are automatically cleared after the operation is complete.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>erasePage</name>
+         <description>Enable Page Erase.</description>
+         <value>0x55</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>eraseAll</name>
+         <description>Enable Mass Erase. The debug port must be enabled.</description>
+         <value>0xAA</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PEND</name>
+       <description>Flash Pending.  When Flash operation is in progress (busy), Flash reads and writes will fail. When PEND is set, write to all Flash registers, with exception of the Flash interrupt register, are ignored.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LVE</name>
+       <description>Low Voltage enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNLOCK</name>
+       <description>Flash Unlock.  The correct unlock code must be written to these four bits before any Flash write or erase operation is allowed.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Flash Unlocked.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Flash Locked.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Flash Interrupt Register.</description>
+     <addressOffset>0x024</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Flash Done Interrupt.  This bit is set to 1 upon Flash write or erase completion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AF</name>
+       <description>Flash Access Fail.  This bit is set when an attempt is made to write the flash while the flash is busy or the flash is locked. This bit can only be set to 1 by hardware.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noerr</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PROG_PROT_ERR</name>
+       <description>Program Protection Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noerr</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MASS_ER_PROT_ERR</name>
+       <description>TBD</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noerr</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PAGE_ER_PROT_ERR</name>
+       <description>TBD</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noerr</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PROT_AREA_PROT_ERR</name>
+       <description>TBD</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noerr</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONEIE</name>
+       <description>Flash Done Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AFIE</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PROTIE</name>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA[%s]</name>
+     <description>Flash Write Data.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACTRL</name>
+     <description>Access Control Register. Writing the ACNTL register with the following values in the order shown, allows read and write access to the system and user Information block: pflc-acntl = 0x3a7f5ca3; pflc-acntl = 0xa1e34f20; pflc-acntl = 0x9608b2c1. When unlocked, a write of any word will disable access to system and user information block. Readback of this register is always zero.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ACTRL</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR0</name>
+     <description>Access control.</description>
+     <addressOffset>0x80</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WELR0</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR0</name>
+     <description>Access control.</description>
+     <addressOffset>0x84</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RLR0</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR1</name>
+     <description>Access control.</description>
+     <addressOffset>0x88</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WELR1</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR1</name>
+     <description>Access control.</description>
+     <addressOffset>0x8C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RLR1</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR2</name>
+     <description>Access control.</description>
+     <addressOffset>0x90</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WELR2</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR2</name>
+     <description>Access control.</description>
+     <addressOffset>0x94</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RLR2</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR3</name>
+     <description>Access control.</description>
+     <addressOffset>0x98</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WELR3</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR3</name>
+     <description>Access control.</description>
+     <addressOffset>0x9C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RLR3</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR4</name>
+     <description>Access control.</description>
+     <addressOffset>0xA0</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WELR4</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR4</name>
+     <description>Access control.</description>
+     <addressOffset>0xA4</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RLR4</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR5</name>
+     <description>Access control.</description>
+     <addressOffset>0xA8</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>WELR5</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR5</name>
+     <description>Access control.</description>
+     <addressOffset>0xAC</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RLR5</name>
+       <description>TBD</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FLC Flash Memory Control.-->
+  <peripheral>
+   <name>HPB</name>
+   <description>HyperBus Memory Controller Registers</description>
+   <baseAddress>0x40039000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>STAT</name>
+     <description>Hyperbus Status Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <fields>
+      <field>
+       <name>RDTXN</name>
+       <description>Read Transaction in Progress</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noread</name>
+         <description>No read transaction currently in progress.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read transaction currently in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDADDRERR</name>
+       <description>Read Address Error</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal_op</name>
+         <description>No error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>err</name>
+         <description>External read address not responding.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDSLVST</name>
+       <description>Read Slave Status.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RDRSTERR</name>
+       <description>Reset During Read Error. If this field is set a reset orrcured during a read.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal_op</name>
+         <description>No error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>err</name>
+         <description>Memory controller was reset during read operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDSTALL</name>
+       <description>Read Data Stall.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal_op</name>
+         <description>Memory Controller operating normally.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>stalled</name>
+         <description>Read transaction is stalled because RDS is low (stalled).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRTXN</name>
+       <description>Write Transaction in Progress</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nowrite</name>
+         <description>No write transaction currently in progress.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write transaction currently in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRADDRERR</name>
+       <description>Write Address Error. If this field is set a write address error orrcured.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal_op</name>
+         <description>No error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>err</name>
+         <description>The write address to external memory is invalid.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRRSTERR</name>
+       <description>Reset During Write Error. If this field is set a reset orrcured during a write.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal_op</name>
+         <description>No error.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>err</name>
+         <description>Memory controller was reset during write operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Hyperbus Interrupt Enable Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>MEM</name>
+       <description>Hyperbus Memory Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERR</name>
+       <description>Enables/disables the HPB error interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable error interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable error interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Hyperbus Interrupt Flag Register.</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>MEM</name>
+       <description>Hyperbus Memory Status Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noint</name>
+         <description>Memory interrupt not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Memory interrupt currently pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERR</name>
+       <description>Error interrupt status flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noint</name>
+         <description>Error interrupt not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>Error interrupt currently pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>MEMBADDR[%s]</name>
+     <description>Hyperbus Memory Base Address Register.</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Memory base address. This sets the base address of the addressable memory region where the port is mapped. Each address space is 512Mbytes. The lower 24 bits are read only and will always read 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>MEMCTRL[%s]</name>
+     <description>Hyperbus Memory Control Register.</description>
+     <addressOffset>0x0020</addressOffset>
+     <fields>
+      <field>
+       <name>WRAPSIZE</name>
+       <description>The wrap burst length of HyperBus memory. This bit is 
+ignored when the asymmetry cache support bit is 0. When 
+the asymmetry cache support is 1, this bit should be set the 
+same as wrap size of configuration register in HyperBus 
+memory.
+</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>64B</name>
+         <description>64 bytes</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16B</name>
+         <description>16 bytes</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>32B</name>
+         <description>32 bytes</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DEVTYPE</name>
+       <description>Select the memory device type.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>hyperFlash</name>
+         <description>HyperFlash</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>xccela_psram</name>
+         <description>Xccela PSRAM</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hyperRAM</name>
+         <description>HyperRAM</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRT</name>
+       <description>Configuration Register Target Select. For HyperRAM and Xccela Bus devices, this field selects between read/write target being the devices memory map or configuration register space. For HyperFlash set this field to 0.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>mem_space</name>
+         <description>Access Memory space.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>config_reg</name>
+         <description>Access Configuration Register space.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDLAT_EN</name>
+       <description>Xccela Fixed Read Latency Enable. Set this bit to enable Xccela bus Fixed Read Latency. Set this field to match the latency Type configuration in the target PSRAM.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>variable</name>
+         <description>Variable read latency.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fixed</name>
+         <description>Fixed read latency.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HSE</name>
+       <description>Xccela Half Sleep Exit. When half sleep exit is enabled, the CS# line is held low for ten clock cycles. This bit is automatically cleared by hardware when a Half Sleep Exit completes.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Half Sleep Exit disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Half Sleep Exit enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MAXLEN</name>
+       <description>Maximum Read/Write. Set this field to the CS# low time in terms of clock cycles.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>MAX_EN</name>
+       <description>Maximum CS# Length Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No configured CS# low time.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>CS# low time is configured.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>MEMTIM[%s]</name>
+     <description>Hyperbus Memory Timing Register.</description>
+     <addressOffset>0x0030</addressOffset>
+     <fields>
+      <field>
+       <name>LAT</name>
+       <description>RAM Latency.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5clk</name>
+         <description>5 Clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6clk</name>
+         <description>6 Clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3clk</name>
+         <description>3 Clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4clk</name>
+         <description>4 Clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WRCSHD</name>
+       <description>Write Chip Select Hold after CK falling edge.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RDCSHD</name>
+       <description>Read Chip Select Hold after CK falling edge.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>WRCSST</name>
+       <description>Write Chip Select Setup Time to Next CK Rising Edge.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RDCSST</name>
+       <description>Read Chip Select Setup Time to Next CK Rising Edge.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>WRCSHI</name>
+       <description>Write Chip Select High Between Operations.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RDCSHI</name>
+       <description>Read Chip Select High Between Operations.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--HPB HyperBus Memory Controller Registers-->
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x40000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SYSCTRL</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>BSTAPEN</name>
+       <description>Boundary Scan TAP enable. When enabled, the JTAG port is conneted to the Boundary Scan TAP instead of the ARM ICE.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH_PAGE_FLIP</name>
+       <description>Flips the Flash bottom and top halves. (Depending on the total flash size, each half is either 256K or 512K). Initiating a flash page flip will cause a flush of both the data buffer on the DCODE bus and the internal instruction buffer.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Physical layout matches logical layout.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>swapped</name>
+         <description>Bottom half mapped to logical top half and vice versa.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICC0_FLUSH</name>
+       <description>Code Cache Flush. This bit is used to flush the code caches and the instruction buffer of the Cortex-M4. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCACHE_DIS</name>
+       <description>System Cache Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ROMDONE</name>
+       <description>ROM_DONE status. Used to disable SWD interface during system initialization procedure</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CCHK</name>
+       <description>Compute ROM Checksum. This bit is self-cleared when calculation is completed. Once set, software clearing this bit is ignored and the bit will remain set until the operation is completed.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SWD_DIS</name>
+       <description> Serial Wire Debug Disable. This bit is used to disable the serial wire debug interface This bit is only writeable if (FMV lock word is not programmed) or if (ICE lock word is not programmed and the ROM_DONE bit is not set).</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHKRES</name>
+       <description>ROM Checksum Result. This bit is only valid when CHKRD=1.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pass</name>
+         <description>ROM Checksum Correct.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fail</name>
+         <description>ROM Checksum Fail.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OVR</name>
+       <description>Operating Voltage Range.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>V0_9</name>
+         <description>0.9V</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>V1_0</name>
+         <description>1.0V</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>V1_1</name>
+         <description>1.1V</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA">
+       <name>WDT0</name>
+       <description>Watchdog Timer 0 Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO1</name>
+       <description>GPIO1 Reset. Setting this bit to 1 resets GPIO1 pins to their default states.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO2</name>
+       <description>GPIO2 Reset. Setting this bit to 1 resets GPIO2 pins to their default states.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR0</name>
+       <description>Timer 0 Reset. Setting this bit to 1 resets Timer 0 blocks.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR1</name>
+       <description>Timer 1 Reset. Setting this bit to 1 resets Timer 1 blocks.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR2</name>
+       <description>Timer 2 Reset. Setting this bit to 1 resets Timer 2 blocks.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR3</name>
+       <description>Timer 3 Reset. Setting this bit to 1 resets Timer 3 blocks.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART0</name>
+       <description>UART 0 Reset. Setting this bit to 1 resets all UART 0 blocks.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART1</name>
+       <description>UART 1 Reset. Setting this bit to 1 resets all UART 1 blocks.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI0</name>
+       <description>SPI 0 Reset. Setting this bit to 1 resets all SPI 0 blocks.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI1</name>
+       <description>SPI 1 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI2</name>
+       <description>SPI 2 Reset. Setting this bit to 1 resets all SPI 2 blocks.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>I2C0</name>
+       <description>I2C 0 Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>RTC</name>
+       <description>Real Time Clock Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>CRYPTO</name>
+       <description>Crypto Reset.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>CAN0</name>
+       <description>CAN0 Reset.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>CAN1</name>
+       <description>CAN1 Reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>HPB</name>
+       <description>Hyperbus Reset.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SMPHR</name>
+       <description>Semaphore Reset.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>USB</name>
+       <description>USB Reset.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TRNG</name>
+       <description>TRNG Reset. This reset is only available during the manufacture testing phase.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>ADC</name>
+       <description>ADC Reset.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART2</name>
+       <description>UART2 Reset. Setting this bit to 1 resets all UART 2 blocks.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SOFT</name>
+       <description>Soft Reset. Setting this bit to 1 resets everything except the CPU and the watchdog timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>PERIPH</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SYS</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>SYSCLK_DIV</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the PLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_SEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ISO</name>
+         <description>The internal 60 MHz oscillator is used for the system clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ITO</name>
+         <description>The internal 120 MHz PLL is used for the system clock.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERFO</name>
+         <description>The external 32 MHz input is used for the system clock.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INRO</name>
+         <description>8 kHz LIRC is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>The internal 100 MHz oscillator is used for the system clock.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBRO</name>
+         <description>The internal 7.3725 MHz oscillator is used for the system clock.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERTCO</name>
+         <description>External 32 kHz input is used for the system clock.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EXTCLK</name>
+         <description>External clock input is used for the system clock.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_RDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_EN</name>
+       <description>32 MHz Crystal Oscillator Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERFO_EN">
+       <name>ERTCO_EN</name>
+       <description>32 kHz Oscillator Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_EN">
+       <name>ISO_EN</name>
+       <description>60 MHz Internal Oscillator Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_EN">
+       <name>IPO_EN</name>
+       <description>100 MHz Clock Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_EN">
+       <name>IBRO_EN</name>
+       <description>7.3725 MHz Clock Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_VS</name>
+       <description>7.3725 MHz High Frequency Internal Reference Clock Voltage Select. This register bit is used to select the power supply to the IBRO.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Vcor</name>
+         <description>VCore Supply</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1V</name>
+         <description>Dedicated 1V regulated supply.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERFO_RDY</name>
+       <description>32 MHz Oscillator Ready</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>ERTCO_RDY</name>
+       <description>32 kHz Crystal Oscillator Ready</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>ISO_RDY</name>
+       <description>60 MHz Oscillator Ready.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>IPO_RDY</name>
+       <description>100 MHz Clock Ready.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>IBRO_RDY</name>
+       <description>7.3725 MHz HIRC Ready.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERFO_RDY">
+       <name>INRO_RDY</name>
+       <description>8 kHz Low Frequency Reference Clock Ready.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PM</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This two bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sleep</name>
+         <description>Cortex-M4 Active, RISC-V Sleep Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>standby</name>
+         <description>Standby Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>backup</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>lpm</name>
+         <description>LPM or CM4 Deep Sleep Mode.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>upm</name>
+         <description>UPM.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>powerdown</name>
+         <description>Power Down Mode.</description>
+         <value>10</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO_WE</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wake Up Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wake Up Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>RTC_WE</name>
+       <description>RTC Alarm Wake Up Enable. This bit enables RTC alarm as wakeup source. If enabled, the desired RTC alarm must be configured via the RTC control registers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>USB_WE</name>
+       <description>USB Wake Up Enable. This bit enables USB IRQ as wakeup source</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>WUT_WE</name>
+       <description>WUT Wake Up Enable. This bit enables the Wake-Up Timer as wakeup source. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>AINCOMP_WE</name>
+       <description>AIN COMP Wake Up Enable. This bit enables AIN COMP as wakeup source. </description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ISO_PD</name>
+       <description>60 MHz power down. This bit selects the 60 MHz clock power state in DEEPSLEEP mode.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ISO_PD">
+       <name>IPO_PD</name>
+       <description>100 MHz power down. This bit selects 100 MHz clock power state in DEEPSLEEP mode. </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ISO_PD">
+       <name>IBRO_PD</name>
+       <description>7.3725 MHz power down. This bit selects 7.3725 MHz clock power state in DEEPSLEEP mode. </description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERFO_BP</name>
+       <description>ERFO Bypass.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PFRST</name>
+     <description>Power Fail Reset Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Power Fail Reset Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PFSTAT</name>
+     <description>Power Fail Reset Status Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RST</name>
+       <description>Power Fail Reset Status</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIV</name>
+     <description>Peripheral Clock Divider.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>SDIOCLKDIV</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>IPO_DIV2</name>
+         <description>48 MHz</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO_DIV4</name>
+         <description>24 MHz</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADCFRQ</name>
+       <description>ADC clock Frequency. These bits define the ADC clock frequency. fADC = fPCLK / (ADCFRQ)</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CNNCLKDIV</name>
+       <description>CNN Clock Divider.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div2</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div1</name>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CNNCLKSEL</name>
+       <description>CNN Clock Select.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>PCLK</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ISO</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ITO</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0</name>
+       <description>GPIO0 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>GPIO1</name>
+       <description>GPIO1 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>GPIO2</name>
+       <description>GPIO2 Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>USB</name>
+       <description>USB Clock Disable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>DMA</name>
+       <description>DMA Clock Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI0</name>
+       <description>SPI 0 Clock Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI1</name>
+       <description>SPI 1 Clock Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI2</name>
+       <description>SPI 2 Clock Disable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART0</name>
+       <description>UART 0 Clock Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART1</name>
+       <description>UART 1 Clock Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C0</name>
+       <description>I2C 0 Clock Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>CRYPTO</name>
+       <description>Crypto Clock Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR0</name>
+       <description>Timer 0 Clock Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR1</name>
+       <description>Timer 1 Clock Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR2</name>
+       <description>Timer 2 Clock Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR3</name>
+       <description>Timer 3 Clock Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>ADC</name>
+       <description>ADC Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C1</name>
+       <description>I2C 1 Clock Disable.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>PT</name>
+       <description>Pluse Train Clock Disable.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPIXIP</name>
+       <description>SPI XIP Clock Disable.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPIXIPC</name>
+       <description>SPI XIPC Clock Disable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCTRL</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 2.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>HYPCLKDS</name>
+       <description>HYP Clock Drive Strength Control.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMZ</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM Block 0 Zeroization.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM1</name>
+       <description>System RAM Block 1 Zeroization.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM2</name>
+       <description>System RAM Block 2 Zeroization.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM3</name>
+       <description>System RAM Block 3 Zeroization.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM4</name>
+       <description>System RAM Block 4 Zeroization.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM5</name>
+       <description>System RAM Block 5 Zeroization.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM6</name>
+       <description>System RAM Block 6 Zeroization.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM7</name>
+       <description>System RAM Block 7 Zeroization.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM8</name>
+       <description>System RAM Block 8 Zeroization.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICC0</name>
+       <description>Instruction Cache 0 Zeroization.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICC1</name>
+       <description>Instruction Cache 1 Zeroization.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICCXIP</name>
+       <description>ICC-XIP Zeroization.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>USBFIFO</name>
+       <description>USB FIFO Zeroization.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>MAARAM</name>
+       <description>MAA RAM Zeroization.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>DCACHE_DATA</name>
+       <description>Data-Cache Controller Data Zeroization.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>DCACHE_TAG</name>
+       <description>Data-Cache Controller Tag Zeroization.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PFBUF</name>
+     <description>Power Fail Reset Buffer Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>PWRGOOD_BUF</name>
+       <description>Power Good Detection.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>PWRGOOD</name>
+       <description>Power Good Detected.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSST</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICELOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CODEINTERR</name>
+       <description>Code Interrupt Error Status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATAINTERR</name>
+       <description>Data Interrupt Error Lock Status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>I2C1</name>
+       <description>I2C1 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>PT</name>
+       <description>PT Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPIXIP</name>
+       <description>SPI XIPF Reset.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPIXIPM</name>
+       <description>SPI XIP Master Reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>OWM</name>
+       <description>OWM Reset.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPI3</name>
+       <description>SPI3 Reset.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPI4</name>
+       <description>SPI4 Reset.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SMPHR</name>
+       <description>SMPHR Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>BTLE</name>
+       <description>BTLE Reset.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2S</name>
+       <description>I2S Reset.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2C2</name>
+       <description>I2C2 Reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>PUF</name>
+       <description>PUF Reset.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>CPU1</name>
+       <description>CPU1 Reset.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>BTLE</name>
+       <description>BTLE Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Clock enabled to the peripheral.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Clock disabled to the peripheral.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>UART2</name>
+       <description>UART2 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>TRNG</name>
+       <description>TRNG Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>PUF</name>
+       <description>PUF Clock Disable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>HPB</name>
+       <description>HyperBus/Xccela Clock Disable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>SYSCACHE</name>
+       <description>System Cache Clock Disable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>SMPHR</name>
+       <description>SMPHR Clock Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>CAN0</name>
+       <description>CAN0 Clock Disable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>OWM</name>
+       <description>One-Wire Clock Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>SPI3</name>
+       <description>SPI3 Clock Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>SPI4</name>
+       <description>SPI4 Clock Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>CAN1</name>
+       <description>CAN1 Clock Disable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>SPIXR</name>
+       <description>SPIXR Clock Disable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>I2S</name>
+       <description>I2S Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>I2C2</name>
+       <description>I2C2 Clock Disable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>WDT0</name>
+       <description>Watch Dog Timer 0 Clock Disable.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BTLE">
+       <name>CPU1</name>
+       <description>CPU1 Clock Disable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVENTEN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Enable RXEV pin event. When this bit is set, RXEV event from the CPU is output to GPIO1.9.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO1.9.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REVISION</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSIE</name>
+     <description>System Status Interrupt Enable Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEUNLOCK</name>
+       <description>ARM ICE Unlock Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCERR</name>
+     <description>ECC Error Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>ECC System RAM1 Error Flag. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>ECC System RAM2 Error Flag. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>ECC System RAM3 Error Flag. Write 1 to clear.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM4</name>
+       <description>ECC System RAM4 Error Flag. Write 1 to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM5</name>
+       <description>ECC System RAM5 Error Flag. Write 1 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM6</name>
+       <description>ECC System RAM6 Error Flag. Write 1 to clear.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICACHE0</name>
+       <description>ECC System ICACHE0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICACHEXIP</name>
+       <description>ECC System ICACHEXIP Error Flag. Write 1 to clear.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCCED</name>
+     <description>ECC Not Double Error Detect Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>ECC System RAM1 Error Flag. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>ECC System RAM2 Error Flag. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>ECC System RAM3 Error Flag. Write 1 to clear.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM4</name>
+       <description>ECC System RAM4 Error Flag. Write 1 to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM5</name>
+       <description>ECC System RAM5 Error Flag. Write 1 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM6</name>
+       <description>ECC System RAM6 Error Flag. Write 1 to clear.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICACHE0</name>
+       <description>ECC System ICACHE0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICACHEXIP</name>
+       <description>ECC System ICACHEXIP Error Flag. Write 1 to clear.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCIE</name>
+     <description>ECC IRQ Enable Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>ECC System RAM1 Error Flag. Write 1 to clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>ECC System RAM2 Error Flag. Write 1 to clear.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>ECC System RAM3 Error Flag. Write 1 to clear.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM4</name>
+       <description>ECC System RAM4 Error Flag. Write 1 to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM5</name>
+       <description>ECC System RAM5 Error Flag. Write 1 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAM6</name>
+       <description>ECC System RAM6 Error Flag. Write 1 to clear.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICACHE0</name>
+       <description>ECC System ICACHE0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ICACHEXIP</name>
+       <description>ECC System ICACHEXIP Error Flag. Write 1 to clear.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCADDR</name>
+     <description>ECC Error Address Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>DADDR</name>
+       <description>Data Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>DB</name>
+       <description>Data Error Bank.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DE</name>
+       <description>DE Error.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TADDR</name>
+       <description>Tag Address.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>TB</name>
+       <description>Tag Error Bank.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TE</name>
+       <description>Tag Error.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLELDOCTRL</name>
+     <description>BTLE LDO Control Register</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>LDOBBEN</name>
+       <description>LDOBB Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBPULLD</name>
+       <description>LDOBB Pull Down.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBVSEL</name>
+       <description>LDOBB Voltage Setting.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_85</name>
+         <description>0.85V</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>0_9</name>
+         <description>0.9V</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0</name>
+         <description>1.0V</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1</name>
+         <description>1.1V</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDORFEN</name>
+       <description>LDORF Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORFPULLD</name>
+       <description>LDORF Pull Down.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORFVSEL</name>
+       <description>LDORF Voltage Setting.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_85</name>
+         <description>0.85V</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>0_9</name>
+         <description>0.9V</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_0</name>
+         <description>1.0V</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1_1</name>
+         <description>1.1V</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDORFBYP</name>
+       <description>LDORF Bypass Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORFDISCH</name>
+       <description>LDORF Discharge.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBBYP</name>
+       <description>LDOBB Bypass Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBDISCH</name>
+       <description>LDOBB Discharge.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBENDLY</name>
+       <description>LDOBB Enable Delay.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORFENDLY</name>
+       <description>LDORF Enable Delay.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDORFBYPENENDLY</name>
+       <description>LDORF Bypass Enable Delay.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBBYPENENDLY</name>
+       <description>LDOBB Bypass Enable Delay.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLELDODLY</name>
+     <description>BTLE LDO Delay Register</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>BYPDLYCNT</name>
+       <description>Bypass Delay Count.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>LDORFDLYCNT</name>
+       <description>LDORF Delay Count.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>LDOBBDLYCNT</name>
+       <description>LDOBB Delay Count.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPR0</name>
+     <description>General Purpose Register 0</description>
+     <addressOffset>0x80</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCR Global Control Registers.-->
+  <peripheral>
+   <name>GCFR</name>
+   <description>Global Control Function Register.</description>
+   <baseAddress>0x40005800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>REG0</name>
+     <description>Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CKPDRV</name>
+       <description>Hyperbus CKP Drive Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CKNDRV</name>
+       <description>Hyperbus CKN Drive Setting.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RDSDLL_EN</name>
+       <description>Hyperbus RDS DLL Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCFR Global Control Function Register.-->
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x40008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN0</name>
+     <description>GPIO Function Enable Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_SET</name>
+     <description>GPIO Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_OUT bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_IN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTMODE</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTMODE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTPOL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTPOL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INEN</name>
+     <description>GPIO Input Enable</description>
+     <addressOffset>0x30</addressOffset>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_INTFL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WKEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DUALEDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DUALEDGE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL0</name>
+     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL0</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL1</name>
+     <description>GPIO Input Mode Config 2. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL1</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_SET</name>
+     <description>GPIO Alternate Function Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN2</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_SET</name>
+     <description>GPIO Alternate Function 2 Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN2 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_CLR</name>
+     <description>GPIO Wake Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN2 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x7C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HYSEN</name>
+     <description>GPIO Input Hysteresis Enable.</description>
+     <addressOffset>0xA8</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_HYSEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SRSEL</name>
+     <description>GPIO Slew Rate Enable Register.</description>
+     <addressOffset>0xAC</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_SRSEL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>FAST</name>
+         <description>Fast Slew Rate selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SLOW</name>
+         <description>Slow Slew Rate selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS0</name>
+     <description>GPIO Drive Strength  Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS0</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ld</name>
+         <description>GPIO port pin is in low-drive mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hd</name>
+         <description>GPIO port pin is in high-drive mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PS</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VSSEL</name>
+     <description>GPIO Voltage Select.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GPIO0 Individual I/O for each GPIO-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO1</name>
+   <description>Individual I/O for each GPIO 1</description>
+   <baseAddress>0x40009000</baseAddress>
+   <interrupt>
+    <name>GPIO1</name>
+    <description>GPIO1 IRQ</description>
+    <value>25</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO1 Individual I/O for each GPIO 1-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO2</name>
+   <description>Individual I/O for each GPIO 2</description>
+   <baseAddress>0x4000A000</baseAddress>
+   <interrupt>
+    <name>GPIO2</name>
+    <description>GPIO2 IRQ</description>
+    <value>26</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO2 Individual I/O for each GPIO 2-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO3</name>
+   <description>Individual I/O for each GPIO 3</description>
+   <baseAddress>0x40080400</baseAddress>
+   <interrupt>
+    <name>GPIO3</name>
+    <description>GPIO3 IRQ</description>
+    <value>58</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO3 Individual I/O for each GPIO 3-->
+  <peripheral>
+   <name>I2C0</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>I2C</groupName>
+   <baseAddress>0x4001D000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2C0</name>
+    <description>I2C0 IRQ</description>
+    <value>13</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>I2C Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable I2C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable I2C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave_mode</name>
+         <description>Slave Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master_mode</name>
+         <description>Master Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_EN</name>
+       <description>General Call Address Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Ignore Gneral Call Address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Acknowledge general call address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_EN</name>
+       <description>Interactive Receive Mode.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interactive Receive Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interactive Receive Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_ACK</name>
+       <description>Data Acknowledge. This bit defines the acknowledge bit returned by the I2C receiver while IRXM = 1 HW forces ACK to 0 when IRXM = 0.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ack</name>
+         <description>return ACK (pulling SDA LOW).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>return NACK (leaving SDA HIGH).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_OUT</name>
+       <description>SCL Output. This bits control SCL output when SWOE =1.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_scl_low</name>
+         <description>Drive SCL low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_scl</name>
+         <description>Release SCL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDA_OUT</name>
+       <description>SDA Output. This bits control SDA output when SWOE = 1. </description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_sda_low</name>
+         <description>Drive SDA low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_sda</name>
+         <description>Release SDA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL</name>
+       <description>SCL status. This bit reflects the logic gate of SCL signal. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDA</name>
+       <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BB_MODE</name>
+       <description>Software Output Enable.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>outputs_disable</name>
+         <description>I2C Outputs SCLO and SDAO disabled. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputs_enable</name>
+         <description>I2C Outputs SCLO and SDAO enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read. This bit reflects the R/W bit of an address match (AMI = 1) or general call match (GCI = 1). This bit is valid 3 cycles after the relevant interrupt bit is set.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKSTR_DIS</name>
+       <description>This bit will disable slave clock stretching when set.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Slave clock stretching enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Slave clock stretching disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ONE_MST_MODE</name>
+       <description>SCL Push-Pull Mode. This bit controls whether SCL is operated in a the I2C standard open-drain mode, or in a non-standard push-pull mode where the Hi-Z output isreplaced with Drive-1. The non-standard mode should only be used when operating as a master and communicating with slaves that are guaranteed to never drive SCL low. </description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Standard open-drain operation:
+					drive low for 0, Hi-Z for 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Non-standard push-pull operation:
+					drive low for 0, drive high for 1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HS_EN</name>
+       <description>High speed mode enable</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>Bus Status.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>I2C Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>I2C Bus Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>RX empty.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX Full.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX Empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>TX Full.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_BUSY</name>
+       <description>Clock Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_actively_driving_scl_clock</name>
+         <description>Device not actively driving SCL clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>actively_driving_scl_clock</name>
+         <description>Device operating as master and actively driving SCL clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL0</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <name>INT_FL0_Done</name>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Interactive Receive Interrupt.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave General Call Address Match Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave Address Match Interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Receive Threshold Interrupt. This bit is automaticcaly cleared when RX_FIFO is below the threshold level.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. RX_FIFO equal or more bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>Transmit Threshold Interrupt. This bit is automaticcaly cleared when TX_FIFO is above the threshold level.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP Interrupt.</description>
+       <bitRange>[6:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Address Acknowledge Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Arbritation error Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>timeout Error Interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Address NACK Error Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Data NACK Error Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Do Not Respond Error Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Start Error Interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Stop Error Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>Transmit Lock Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN0</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when DONE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Description not available.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when RX_MODE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave mode general call address match received input enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when GEN_CTRL_ADDR = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave mode incoming address match interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when ADDR_MATCH = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Above Treshold Level Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Below Treshold Level Interrupt Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Stop Interrupt Enable</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when STOP = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Received Address ACK from Slave Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Master Mode Arbitration Lost Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>Timeout Error Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Master Mode Address NACK Received Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Master Mode Data NACK Received Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Slave Mode Do Not Respond Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Out of Sequence START condition detected interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Out of Sequence STOP condition detected interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>TX FIFO Locked Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL1</name>
+     <description>Interrupt Status Register 1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt. When operating as a slave receiver, this bit is set when you reach the first data bit and the RX FIFO and shift register are both full.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt. When operating as a slave transmitter, this bit is set when you reach the first data bit and the TX FIFO is empty and the master is still asking for more data (i.e the master hasn't sent a NACK yet).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Status Flag.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN1</name>
+     <description>Interrupt Staus Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOLEN</name>
+     <description>FIFO Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RX_DEPTH</name>
+       <description>Receive FIFO Length.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DEPTH</name>
+       <description>Transmit FIFO Length.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL0</name>
+     <description>Receive Control Register 0.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>DNR</name>
+       <description>Do Not Respond.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Always respond to address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>not_respond_rx_fifo_empty</name>
+         <description>Do not respond to address match when RX_FIFO is not empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Receive FIFO Flush. This bit is automatically cleared to 0 after the operation. Setting this bit to 1 will affect RX_FIFO status.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush RX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_LVL</name>
+       <description>Receive FIFO Threshold. These bits define the RX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL1</name>
+     <description>Receive Control Register 1.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Receive Count Bits. These bits define the number of bytes to be received in a transaction, except for the case RXCNT = 0. RXCNT = 0 means 256 bytes to be received in a transaction.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Receive FIFO Count. These bits reflect the number of byte in the RX_FIFO. These bits are flushed when I2CEN = 0.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL0</name>
+     <description>Transmit Control Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_MODE</name>
+       <description>Transmit FIFO Preaload Mode. Setting this bit will allow for high speed application to preload the transmit FIFO prior to Slave Address Match.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TX_READY_MODE</name>
+       <description>Transmit FIFO Ready Manual Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW control of I2CTXRDY enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW control of I2CTXRDY disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO General Call Address Match Auto Flush Disable.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Write Auto Flush Disable.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Read Auto Flush Disable.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NACK_FLUSH_DIS</name>
+       <description>TX FIFO received NACK Auto Flush Disable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Transmit FIFO Flush. This bit is automatically cleared to 0 after the operation.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush TX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_VAL</name>
+       <description>Transmit FIFO Threshold. These bits define the TX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL1</name>
+     <description>Transmit Control Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_RDY</name>
+       <description>Transmit FIFO Preload Ready.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Transmit FIFO Count. These bits reflect the number of bytes in the TX_FIFO.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MSTCTRL</name>
+     <description>Master Control Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Setting this bit to 1 will start a master transfer.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>RESTART</name>
+       <description>Setting this bit to 1 will generate a repeated START.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Setting this bit to 1 will generate a STOP condition.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>EX_ADDR_EN</name>
+       <description>Slave Extend Address Select.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKLO</name>
+     <description>Clock Low Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock low. In master mode, these bits define the SCL low period. In slave mode, these bits define the time SCL will be held low after data is outputted.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKHI</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>HI</name>
+       <description>Clock High. In master mode, these bits define the SCL high period.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HSCLK</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock Low. This field sets the Hs-Mode clock low count. In Slave mode, this is the time SCL is held low after data is output on SDA.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Clock High. This field sets the Hs-Mode clock high count. In Slave mode, this is the time SCL is held high after data is output on SDA</description>
+       <bitRange>[15:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TIMEOUT</name>
+     <description>Timeout Register</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_TO_VAL</name>
+       <description>Timeout</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>SLAVE_MULTI[%s]</name>
+     <description>Slave Address Register.</description>
+     <alternateRegister>SLAVE0</alternateRegister>
+     <addressOffset>0x4C</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Slave Address.</description>
+       <bitRange>[9:0]</bitRange>
+      </field>
+      <field>
+       <name>DIS</name>
+       <description>Slave Disable.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>EXT_ADDR_EN</name>
+       <description>Extended Address Select.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLAVE0</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE1</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x50</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE2</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x54</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE3</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x58</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2C0 Inter-Integrated Circuit.-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C1</name>
+   <description>Inter-Integrated Circuit. 1</description>
+   <baseAddress>0x4001E000</baseAddress>
+   <interrupt>
+    <name>I2C1</name>
+    <description>I2C1 IRQ</description>
+    <value>36</value>
+   </interrupt>
+  </peripheral>
+<!--I2C1 Inter-Integrated Circuit. 1-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C2</name>
+   <description>Inter-Integrated Circuit. 2</description>
+   <baseAddress>0x4001F000</baseAddress>
+   <interrupt>
+    <name>I2C2</name>
+    <description>I2C2 IRQ</description>
+    <value>62</value>
+   </interrupt>
+  </peripheral>
+<!--I2C2 Inter-Integrated Circuit. 2-->
+  <peripheral>
+   <name>I2S</name>
+   <description>Inter-IC Sound Interface.</description>
+   <groupName>I2S</groupName>
+   <baseAddress>0x40060000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2S</name>
+    <description>I2S IRQ</description>
+    <value>99</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0CH0</name>
+     <description>Global mode channel.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>LSB_FIRST</name>
+       <description>LSB Transmit Receive First.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_FILT</name>
+       <description>PDM Filter.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_EN</name>
+       <description>PDM Enable.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>USEDDR</name>
+       <description>DDR.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_INV</name>
+       <description>Invert PDM.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_MODE</name>
+       <description>SCK Select.</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>WS_POL</name>
+       <description>WS polarity select. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB_LOC</name>
+       <description>MSB location. </description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ALIGN</name>
+       <description>Align to MSB or LSB.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EXT_SEL</name>
+       <description>External SCK/WS selection.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>STEREO</name>
+       <description>Stereo mode of I2S.</description>
+       <bitRange>[13:12]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WSIZE</name>
+       <description>Data size when write to FIFO.</description>
+       <bitRange>[15:14]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable. </description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable. </description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Flushes the TX/RX FIFO buffer. </description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RST</name>
+       <description>Write 1 to reset channel. </description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_LSB</name>
+       <description>Bit Field Control. </description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>depth of receive FIFO for threshold interrupt generation. </description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1CH0</name>
+     <description>Local channel Setup.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>BITS_WORD</name>
+       <description>I2S word length.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>I2S clock enable.</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SMP_SIZE</name>
+       <description>I2S sample size length.</description>
+       <bitRange>[13:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLKSEL</name>
+       <description>I2S Clock Select.</description>
+       <bitRange>[14:14]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ADJUST</name>
+       <description>LSB/MSB Justify.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>I2S clock frequency divisor.</description>
+       <bitRange>[31:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FILTCH0</name>
+     <description>Filter.</description>
+     <addressOffset>0x20</addressOffset>
+    </register>
+    <register>
+     <name>DMACH0</name>
+     <description>DMA Control.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DMA_TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger.</description>
+       <bitRange>[6:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA channel enable.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_THD_VAL</name>
+       <description>RX FIFO Level DMA Trigger.</description>
+       <bitRange>[14:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA channel enable.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Number of data word in the TX FIFO.</description>
+       <bitRange>[23:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Number of data word in the RX FIFO.</description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOCH0</name>
+     <description>I2S Fifo.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>ISR Status.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Status for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Status for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Status for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Status for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Enable for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Enable for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Enable for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Enable for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EXTSETUP</name>
+     <description>Ext Control.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>EXT_BITS_WORD</name>
+       <description>Word Length for ch_mode.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wakeup Enable.</description>
+     <addressOffset>0x5C</addressOffset>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wakeup Flags.</description>
+     <addressOffset>0x60</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2S Inter-IC Sound Interface.-->
+  <peripheral>
+   <name>ICC0</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x4002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x800</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>INFO</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SZ</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCH</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEM</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ICC0 Instruction Cache Controller Registers-->
+  <peripheral>
+   <name>LPCMP</name>
+   <description>Low Power Comparator</description>
+   <baseAddress>0x40088000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>LPCMP</name>
+    <description>Low Power Comparato</description>
+    <value>103</value>
+   </interrupt>
+   <registers>
+    <register>
+     <dim>3</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CTRL[%s]</name>
+     <description>Comparator Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Comparator Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>POL</name>
+       <description>Polarity Select</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTEN</name>
+       <description>IRQ Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUT</name>
+       <description>Raw Compartor Input.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTFL</name>
+       <description>IRQ Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--LPCMP Low Power Comparator-->
+  <peripheral>
+   <name>LPGCR</name>
+   <description>Low Power Global Control.</description>
+   <baseAddress>0x40080000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RST</name>
+     <description>Low Power Reset Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO3</name>
+       <description>Low Power GPIO 3 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO3">
+       <name>WDT1</name>
+       <description>Low Power Watchdog Timer 1 Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO3">
+       <name>TMR4</name>
+       <description>Low Power Timer 4 Reset.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO3">
+       <name>TMR5</name>
+       <description>Low Power Timer 5 Reset.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO3">
+       <name>UART3</name>
+       <description>Low Power UART 3 Reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO3">
+       <name>LPCOMP</name>
+       <description>Low Power Comparator Reset.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS</name>
+     <description>Low Power Peripheral Clock Disable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO3</name>
+       <description>Low Power GPIO 3 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO3">
+       <name>WDT1</name>
+       <description>Low Power Watchdog 1 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO3">
+       <name>TMR4</name>
+       <description>Low Power Timer 4 Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO3">
+       <name>TMR5</name>
+       <description>Low Power Timer 5 Clock Disable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO3">
+       <name>UART3</name>
+       <description>Low Power UART 3 Clock Disable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO3">
+       <name>LPCOMP</name>
+       <description>Low Power Comparator Clock Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--LPGCR Low Power Global Control.-->
+  <peripheral>
+   <name>MCR</name>
+   <description>Misc Control.</description>
+   <baseAddress>0x40006C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>ECCEN</name>
+     <description>ECC Enable Register</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>ECC System RAM0 Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM1</name>
+       <description>ECC System RAM1 Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM2</name>
+       <description>ECC System RAM2 Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM3</name>
+       <description>ECC System RAM3 Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM4</name>
+       <description>ECC System RAM4 Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM5</name>
+       <description>ECC System RAM5 Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAM6</name>
+       <description>ECC System RAM6 Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHE0</name>
+       <description>ECC ICACHE0 Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICACHEXIP</name>
+       <description>ECC ICACHE XIP Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPO_MTRIM</name>
+     <description>IPO Manual Register</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>MTRIM</name>
+       <description>Manual Trim Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>TRIM_RANGE</name>
+       <description>Trim Range Select.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>Output Enable Register</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>SQWOUT_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PDOWN_OUT_EN</name>
+       <description>Power Down Output Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP_CTRL</name>
+     <description>Comparator Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Comparator Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>POL</name>
+       <description>Polarity Select</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INT_EN</name>
+       <description>IRQ Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUT</name>
+       <description>Comparator Output State.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INT_FL</name>
+       <description>IRQ Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Miscellaneous Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>CMPHYST</name>
+       <description>Comparator HYST.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>INRO_EN</name>
+       <description>INRO Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>ERTCO Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_EN</name>
+       <description>IBRO Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RSTNP1M</name>
+       <description>RSTNP1M</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RSTNVDDIOHSEL</name>
+       <description>RSTNVFFIOHSEL</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO4_CTRL</name>
+     <description>GPIO4 Pin Control Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>P40_DO</name>
+       <description>GPIO4 Pin 0 Data Output.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P40_OE</name>
+       <description>GPIO4 Pin 0 Output Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P40_PE</name>
+       <description>GPIO4 Pin 0 Pull-up Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P40_IN</name>
+       <description>GPIO4 Pin 0 Input Status.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P41_DO</name>
+       <description>GPIO4 Pin 1 Data Output.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P41_OE</name>
+       <description>GPIO4 Pin 1 Output Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P41_PE</name>
+       <description>GPIO4 Pin 1 Pull-up Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P41_IN</name>
+       <description>GPIO4 Pin 1 Input Status.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CWD0</name>
+     <description>Code Word Data0</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>data</name>
+       <description>Code word Data0 the register retains its value while vregi supply present</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CWD1</name>
+     <description>Code Word Data1</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>data</name>
+       <description>Code word Data0 the register retains its value while vregi supply present</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCCFG0</name>
+     <description>ADC Config 0</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>LP_5K_DIS</name>
+       <description>Disable 5K divider optionin low power modes</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LP_50K_DIS</name>
+       <description>Disable 50K divider optionin low power modes</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EXT_REF</name>
+       <description>External Reference Select Option</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>REF_SEL</name>
+       <description>Internal Reference Select Option</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCCFG1</name>
+     <description>ADC Config 1</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>CHX_PU_DYN</name>
+       <description>ADC PU dynamic control</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCCFG2</name>
+     <description>ADC Config 2</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Divider option for ADC input channel 0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>div1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2_5k</name>
+         <description>5k ohom</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2_50k</name>
+         <description>50k ohom</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <description>Divider option for ADC input channel 1</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <description>Divider option for ADC input channel 2</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <description>Divider option for ADC input channel 3</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH4</name>
+       <description>Divider option for ADC input channel 4</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH5</name>
+       <description>Divider option for ADC input channel 5</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH6</name>
+       <description>Divider option for ADC input channel 6</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH7</name>
+       <description>Divider option for ADC input channel 7</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LDOCTRL</name>
+     <description>LDO Control</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>0P9EN</name>
+       <description>LDO 0.9V Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>2P5EN</name>
+       <description>LDO 2.5V Enable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--MCR Misc Control.-->
+  <peripheral>
+   <name>OWM</name>
+   <description>1-Wire Master Interface.</description>
+   <baseAddress>0x4003D000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>OneWire</name>
+    <value>67</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CFG</name>
+     <description>1-Wire Master Configuration.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>long_line_mode</name>
+       <description>Long Line Mode.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>force_pres_det</name>
+       <description>Force Line During Presence Detect.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_en</name>
+       <description>Bit Bang Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_mode</name>
+       <description>Provide an extra output control to control an external pullup.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_enable</name>
+       <description>Enable External Pullup.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>single_bit_mode</name>
+       <description>Enable Single Bit TX/RX Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>overdrive</name>
+       <description>Enables overdrive speed for 1-Wire operations.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>int_pullup_enable</name>
+       <description>Enable intenral pullup.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_DIV_1US</name>
+     <description>1-Wire Master Clock Divisor.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>divisor</name>
+       <description>Clock Divisor for 1Mhz.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL_STAT</name>
+     <description>1-Wire Master Control/Status.</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>start_ow_reset</name>
+       <description>Start OW Reset.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>sra_mode</name>
+       <description>SRA Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_oe</name>
+       <description>Bit Bang Output Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ow_input</name>
+       <description>OW Input State.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>od_spec_mode</name>
+       <description>Overdrive Spec Mode.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>presence_detect</name>
+       <description>Presence Pulse Detected.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>1-Wire Master Data Buffer.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>tx_rx</name>
+       <description>TX/RX Buffer.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>1-Wire Master Interrupt Flags.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>TX Data Empty Interrupt Flag.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>RX Data Ready Interrupt Flag</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Flag.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Flag.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>1-Wire Master Interrupt Enables.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>Tx Data Empty Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>Rx Data Ready Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Enable.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--OWM 1-Wire Master Interface.-->
+  <peripheral>
+   <name>PT</name>
+   <description>Pulse Train</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C020</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0010</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RATE_LENGTH</name>
+     <description>Pulse Train Configuration</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>rate_control</name>
+       <description>Pulse Train Enable and Rate Control. Set to 0 to disable the Pulse Train.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>27</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>mode</name>
+       <description>Pulse Train Output Mode/Train Length</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>32_BIT</name>
+         <description>Pulse train, 32 bit pattern.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SQUARE_WAVE</name>
+         <description>Square wave mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_BIT</name>
+         <description>Pulse train, 2 bit pattern.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_BIT</name>
+         <description>Pulse train, 3 bit pattern.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_BIT</name>
+         <description>Pulse train, 4 bit pattern.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5_BIT</name>
+         <description>Pulse train, 5 bit pattern.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_BIT</name>
+         <description>Pulse train, 6 bit pattern.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7_BIT</name>
+         <description>Pulse train, 7 bit pattern.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_BIT</name>
+         <description>Pulse train, 8 bit pattern.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9_BIT</name>
+         <description>Pulse train, 9 bit pattern.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_BIT</name>
+         <description>Pulse train, 10 bit pattern.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11_BIT</name>
+         <description>Pulse train, 11 bit pattern.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_BIT</name>
+         <description>Pulse train, 12 bit pattern.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13_BIT</name>
+         <description>Pulse train, 13 bit pattern.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14_BIT</name>
+         <description>Pulse train, 14 bit pattern.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15_BIT</name>
+         <description>Pulse train, 15 bit pattern.</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_BIT</name>
+         <description>Pulse train, 16 bit pattern.</description>
+         <value>16</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>17_BIT</name>
+         <description>Pulse train, 17 bit pattern.</description>
+         <value>17</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>18_BIT</name>
+         <description>Pulse train, 18 bit pattern.</description>
+         <value>18</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>19_BIT</name>
+         <description>Pulse train, 19 bit pattern.</description>
+         <value>19</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>20_BIT</name>
+         <description>Pulse train, 20 bit pattern.</description>
+         <value>20</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>21_BIT</name>
+         <description>Pulse train, 21 bit pattern.</description>
+         <value>21</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>22_BIT</name>
+         <description>Pulse train, 22 bit pattern.</description>
+         <value>22</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>23_BIT</name>
+         <description>Pulse train, 23 bit pattern.</description>
+         <value>23</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>24_BIT</name>
+         <description>Pulse train, 24 bit pattern.</description>
+         <value>24</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>25_BIT</name>
+         <description>Pulse train, 25 bit pattern.</description>
+         <value>25</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>26_BIT</name>
+         <description>Pulse train, 26 bit pattern.</description>
+         <value>26</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>27_BIT</name>
+         <description>Pulse train, 27 bit pattern.</description>
+         <value>27</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>28_BIT</name>
+         <description>Pulse train, 28 bit pattern.</description>
+         <value>28</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>29_BIT</name>
+         <description>Pulse train, 29 bit pattern.</description>
+         <value>29</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30_BIT</name>
+         <description>Pulse train, 30 bit pattern.</description>
+         <value>30</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>31_BIT</name>
+         <description>Pulse train, 31 bit pattern.</description>
+         <value>31</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRAIN</name>
+     <description>Write the repeating bit pattern that is shifted out, LSB first, when configured in Pulse Train mode. See PT_RATE_LENGTH.mode for setting the length.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>LOOP</name>
+     <description>Pulse Train Loop Count</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>count</name>
+       <description>Number of loops for this pulse train to repeat.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>delay</name>
+       <description>Delay between loops of the Pulse Train in PT Peripheral Clock cycles</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>12</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESTART</name>
+     <description> Pulse Train Auto-Restart Configuration.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt_x_select</name>
+       <description>Auto-Restart PT X Select</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_x_loop_exit</name>
+       <description>Enable Auto-Restart on PT X Loop Exit</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt_y_select</name>
+       <description>Auto-Restart PT Y Select</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_y_loop_exit</name>
+       <description>Enable Auto-Restart on PT Y Loop Exit</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PT Pulse Train-->
+  <peripheral derivedFrom="PT">
+   <name>PT1</name>
+   <description>Pulse Train 1</description>
+   <baseAddress>0x4003C030</baseAddress>
+  </peripheral>
+<!--PT1 Pulse Train 1-->
+  <peripheral derivedFrom="PT">
+   <name>PT2</name>
+   <description>Pulse Train 2</description>
+   <baseAddress>0x4003C040</baseAddress>
+  </peripheral>
+<!--PT2 Pulse Train 2-->
+  <peripheral derivedFrom="PT">
+   <name>PT3</name>
+   <description>Pulse Train 3</description>
+   <baseAddress>0x4003C050</baseAddress>
+  </peripheral>
+<!--PT3 Pulse Train 3-->
+  <peripheral derivedFrom="PT">
+   <name>PT4</name>
+   <description>Pulse Train 4</description>
+   <baseAddress>0x4003C060</baseAddress>
+  </peripheral>
+<!--PT4 Pulse Train 4-->
+  <peripheral derivedFrom="PT">
+   <name>PT5</name>
+   <description>Pulse Train 5</description>
+   <baseAddress>0x4003C070</baseAddress>
+  </peripheral>
+<!--PT5 Pulse Train 5-->
+  <peripheral derivedFrom="PT">
+   <name>PT6</name>
+   <description>Pulse Train 6</description>
+   <baseAddress>0x4003C080</baseAddress>
+  </peripheral>
+<!--PT6 Pulse Train 6-->
+  <peripheral derivedFrom="PT">
+   <name>PT7</name>
+   <description>Pulse Train 7</description>
+   <baseAddress>0x4003C090</baseAddress>
+  </peripheral>
+<!--PT7 Pulse Train 7-->
+  <peripheral derivedFrom="PT">
+   <name>PT8</name>
+   <description>Pulse Train 8</description>
+   <baseAddress>0x4003C0A0</baseAddress>
+  </peripheral>
+<!--PT8 Pulse Train 8-->
+  <peripheral derivedFrom="PT">
+   <name>PT9</name>
+   <description>Pulse Train 9</description>
+   <baseAddress>0x4003C0B0</baseAddress>
+  </peripheral>
+<!--PT9 Pulse Train 9-->
+  <peripheral derivedFrom="PT">
+   <name>PT10</name>
+   <description>Pulse Train 10</description>
+   <baseAddress>0x4003C0C0</baseAddress>
+  </peripheral>
+<!--PT10 Pulse Train 10-->
+  <peripheral derivedFrom="PT">
+   <name>PT11</name>
+   <description>Pulse Train 11</description>
+   <baseAddress>0x4003C0D0</baseAddress>
+  </peripheral>
+<!--PT11 Pulse Train 11-->
+  <peripheral derivedFrom="PT">
+   <name>PT12</name>
+   <description>Pulse Train 12</description>
+   <baseAddress>0x4003C0E0</baseAddress>
+  </peripheral>
+<!--PT12 Pulse Train 12-->
+  <peripheral derivedFrom="PT">
+   <name>PT13</name>
+   <description>Pulse Train 13</description>
+   <baseAddress>0x4003C0F0</baseAddress>
+  </peripheral>
+<!--PT13 Pulse Train 13-->
+  <peripheral derivedFrom="PT">
+   <name>PT14</name>
+   <description>Pulse Train 14</description>
+   <baseAddress>0x4003C100</baseAddress>
+  </peripheral>
+<!--PT14 Pulse Train 14-->
+  <peripheral derivedFrom="PT">
+   <name>PT15</name>
+   <description>Pulse Train 15</description>
+   <baseAddress>0x4003C110</baseAddress>
+  </peripheral>
+<!--PT15 Pulse Train 15-->
+  <peripheral>
+   <name>PTG</name>
+   <description>Pulse Train Generation</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0020</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>PT</name>
+    <description>Pulse Train IRQ</description>
+    <value>59</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ENABLE</name>
+     <description>Global Enable/Disable Controls for All Pulse Trains</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Enable/Disable control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Enable/Disable control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Enable/Disable control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Enable/Disable control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Enable/Disable control for PT4</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Enable/Disable control for PT5</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Enable/Disable control for PT6</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Enable/Disable control for PT7</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Enable/Disable control for PT8</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Enable/Disable control for PT9</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Enable/Disable control for PT10</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Enable/Disable control for PT11</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Enable/Disable control for PT12</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Enable/Disable control for PT13</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Enable/Disable control for PT14</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Enable/Disable control for PT15</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESYNC</name>
+     <description>Global Resync (All Pulse Trains) Control</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Resync control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Resync control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Resync control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Resync control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Resync control for PT4</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Resync control for PT5</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Resync control for PT6</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Resync control for PT7</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Resync control for PT8</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Resync control for PT9</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Resync control for PT10</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Resync control for PT11</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Resync control for PT12</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Resync control for PT13</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Resync control for PT14</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Resync control for PT15</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STOP_INTFL</name>
+     <description>Pulse Train Interrupt Flags</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Flag</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Flag</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Flag</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Pulse Train 8 Stopped Interrupt Flag</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Pulse Train 9 Stopped Interrupt Flag</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Pulse Train 10 Stopped Interrupt Flag</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Pulse Train 11 Stopped Interrupt Flag</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Pulse Train 12 Stopped Interrupt Flag</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Pulse Train 13 Stopped Interrupt Flag</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Pulse Train 14 Stopped Interrupt Flag</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Pulse Train 15 Stopped Interrupt Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STOP_INTEN</name>
+     <description>Pulse Train Interrupt Enable/Disable</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Pulse Train 8 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Pulse Train 9 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Pulse Train 10 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Pulse Train 11 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Pulse Train 12 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Pulse Train 13 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Pulse Train 14 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Pulse Train 15 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_EN</name>
+     <description>Pulse Train Global Safe Enable.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT8</name>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT9</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT10</name>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT11</name>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT12</name>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT13</name>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT14</name>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT15</name>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_DIS</name>
+     <description>Pulse Train Global Safe Disable.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT8</name>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT9</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT10</name>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT11</name>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT12</name>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT13</name>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT14</name>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT15</name>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTFL</name>
+     <description>Pulse Train Ready Interrupt Flags</description>
+     <addressOffset>0x0018</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Ready Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Ready Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Ready Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Ready Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Ready Interrupt Flag</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Ready Interrupt Flag</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Ready Interrupt Flag</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Ready Interrupt Flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Pulse Train 8 Ready Interrupt Flag</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Pulse Train 9 Ready Interrupt Flag</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Pulse Train 10 Ready Interrupt Flag</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Pulse Train 11 Ready Interrupt Flag</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Pulse Train 12 Ready Interrupt Flag</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Pulse Train 13 Ready Interrupt Flag</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Pulse Train 14 Ready Interrupt Flag</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Pulse Train 15 Ready Interrupt Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTEN</name>
+     <description>Pulse Train Ready Interrupt Enable/Disable</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Ready Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Ready Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Ready Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Ready Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Ready Interrupt Enable/Disable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Ready Interrupt Enable/Disable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Ready Interrupt Enable/Disable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Ready Interrupt Enable/Disable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Pulse Train 8 Ready Interrupt Enable/Disable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Pulse Train 9 Ready Interrupt Enable/Disable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Pulse Train 10 Ready Interrupt Enable/Disable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Pulse Train 11 Ready Interrupt Enable/Disable</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Pulse Train 12 Ready Interrupt Enable/Disable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Pulse Train 13 Ready Interrupt Enable/Disable</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Pulse Train 14 Ready Interrupt Enable/Disable</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Pulse Train 15 Ready Interrupt Enable/Disable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PTG Pulse Train Generation-->
+  <peripheral>
+   <name>PUF</name>
+   <description>PUF Registers</description>
+   <baseAddress>0x40070000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>PUF Control Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PUF_EN</name>
+       <description>PUF Controller Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY_CLR_EN</name>
+       <description>Key Clear Enable or PUFSEC Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY0_GEN_EN</name>
+       <description>PUF Key0 Generation Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY1_GEN_EN</name>
+       <description>PUF Key1 Generation Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYGEN_ERR_IE</name>
+       <description>Key Generation Error Interrupt Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY0_DN_IE</name>
+       <description>Key0 Done Interrupt Enable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY1_DN_IE</name>
+       <description>Key1 Done Interrupt Enable </description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>PUF Status Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>PUF Controller Busy.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MAGIC_ERR</name>
+       <description>PUF Magic Word Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYGEN_EN_ERR</name>
+       <description>PUF Magic Word Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYGEN_ERR</name>
+       <description>PUF Magic Word Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADC_FREQ_FL</name>
+       <description>ADC Frequency Flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY0_INIT_ERR</name>
+       <description>PUF Key0 Initialization Error.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY0_CNST_ERR</name>
+       <description> PUF Key0 Constant Key Mismatch Error</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY1_INIT_ERR</name>
+       <description>PUF Key1 Initialization Error.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY1_CNST_ERR</name>
+       <description> PUF Key1 Constant Key Mismatch Error</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY0_DN</name>
+       <description>Key0 Done.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEY1_DN</name>
+       <description>Key1 Done.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PUF PUF Registers-->
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x40006800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>LPCN</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAMRET0</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 0 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET1</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 1 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET2</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 2 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET3</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET4</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET5</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET6</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET8</name>
+       <description>System RAM retention in BACKUP mode. RAM7 is retained if any of RAM0 to RAM6 is retained.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ISOCLK_SELECT</name>
+       <description>0 = PCLK 1= ISO CLK use for RISV in Low power mode  </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FAST_ENTRY_DIS</name>
+       <description>Fast Low Power mode entry disable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BGOFF</name>
+       <description>Bandgap OFF. This controls the System Bandgap in DeepSleep mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>Bandgap is always ON.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>Bandgap is OFF in DeepSleep mode (default).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WKRST</name>
+       <description>Reset wakeup status registers</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST0</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO0.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN0</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST1</name>
+     <description>Low Power I/O Wakeup Status Register 1. This register indicates the low power wakeup status for GPIO1.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN1</name>
+     <description>Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup functionality for GPIO1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST2</name>
+     <description>Low Power I/O Wakeup Status Register 2. This register indicates the low power wakeup status for GPIO2.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN2</name>
+     <description>Low Power I/O Wakeup Enable Register 2. This register enables low power wakeup functionality for GPIO2.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST3</name>
+     <description>Low Power I/O Wakeup Status Register 3. This register indicates the low power wakeup status for GPIO3.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN3</name>
+     <description>Low Power I/O Wakeup Enable Register 3. This register enables low power wakeup functionality for GPIO3.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST4</name>
+     <description>Low Power I/O Wakeup Status Register 4. This register indicates the low power wakeup status for GPIO4.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN4</name>
+     <description>Low Power I/O Wakeup Enable Register 4. This register enables low power wakeup functionality for GPIO4.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWST</name>
+     <description>Low Power Peripheral Wakeup Status Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>AINCOMP0</name>
+       <description>Analog Input Comparator Wakeup Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BACKUP</name>
+       <description>Backup Mode Wakeup Flag.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESET</name>
+       <description>Reset Detected Wakeup Flag.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWEN</name>
+     <description>Low Power Peripheral Wakeup Enable Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>USBLS</name>
+       <description> USB UTMI Linestate Detect Wakeup Enable. These bits allow wakeup from the corresponding USB linestate
+signal(s) on transition(s) from low to high or high to low when PM.USBWKEN is set.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>USBVBUS</name>
+       <description> USB VBUS Detect Wakeup Enable. This bit allows wakeup from the USB power supply on or off status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP0</name>
+       <description> AINCOMP0 Wakeup Enable. This bit allows wakeup from the AINCOMP0.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WDT0</name>
+       <description> WDT0 Wakeup Enable. This bit allows wakeup from the WDT0.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WDT1</name>
+       <description> WDT1 Wakeup Enable. This bit allows wakeup from the WDT1.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CPU1</name>
+       <description> CPU1 Wakeup Enable. This bit allows wakeup from the CPU1.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR0</name>
+       <description> TMR0 Wakeup Enable. This bit allows wakeup from the TMR0.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR1</name>
+       <description> TMR1 Wakeup Enable. This bit allows wakeup from the TMR1.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR2</name>
+       <description> TMR2 Wakeup Enable. This bit allows wakeup from the TMR2.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR3</name>
+       <description> TMR3 Wakeup Enable. This bit allows wakeup from the TMR3.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR4</name>
+       <description> TMR4 Wakeup Enable. This bit allows wakeup from the TMR4.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR5</name>
+       <description> TMR5 Wakeup Enable. This bit allows wakeup from the TMR5.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART0</name>
+       <description> UART0 Wakeup Enable. This bit allows wakeup from the UART0.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART1</name>
+       <description> UART1 Wakeup Enable. This bit allows wakeup from the UART1.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART2</name>
+       <description> UART2 Wakeup Enable. This bit allows wakeup from the UART2.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART3</name>
+       <description> UART3 Wakeup Enable. This bit allows wakeup from the UART3.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C0</name>
+       <description> I2C0 Wakeup Enable. This bit allows wakeup from the I2C0.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C1</name>
+       <description> I2C1 Wakeup Enable. This bit allows wakeup from the I2C1.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C2</name>
+       <description> I2C2 Wakeup Enable. This bit allows wakeup from the I2C2.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2S</name>
+       <description> I2S Wakeup Enable. This bit allows wakeup from the I2S.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SPI0</name>
+       <description> SPI0 Wakeup Enable. This bit allows wakeup from the SPI0.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPCMP</name>
+       <description> LPCMP Wakeup Enable. This bit allows wakeup from the LPCMP.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BTLE</name>
+       <description>BTLE Wakeup Enable. This bit allows wakeup from the BTLE.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SPI1</name>
+       <description> SPI1 Wakeup Enable. This bit allows wakeup from the SPI1.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SPI2</name>
+       <description> SPI2 Wakeup Enable. This bit allows wakeup from the SPI2.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAN0</name>
+       <description>CAN0 Wakeup Enable. This bit allows wakeup from the CAN0.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAN1</name>
+       <description>CAN1 Wakeup Enable. This bit allows wakeup from the CAN1.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GP0</name>
+     <description>General Purpose Register 0</description>
+     <addressOffset>0x48</addressOffset>
+    </register>
+    <register>
+     <name>GP1</name>
+     <description>General Purpose Register 1</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--PWRSEQ Power Sequencer / Low Power Control Register.-->
+  <peripheral>
+   <name>RTC</name>
+   <description>Real Time Clock and Alarm.</description>
+   <baseAddress>0x40006000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>RTC</name>
+    <description>RTC interrupt.</description>
+    <value>3</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC</name>
+       <description>Sub-Seconds Counter (12-bit).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TODA</name>
+     <description>Time-of-day Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-day Alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSECA</name>
+     <description>RTC sub-second alarm.  This register contains the reload value for the sub-second alarm.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>This register contains the reload value for the sub-second alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>RTC Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Real Time Clock Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM_IE</name>
+       <description>Alarm Time-of-Day Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM_IE</name>
+       <description>Alarm Sub-second Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>RTC Busy. This bit is set to 1 by hardware when changes to RTC registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>RTC Ready. This bit is set to 1 by hardware when the RTC count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the RTC count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY_IE</name>
+       <description>RTC Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-Day Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>Sub-second Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_SEL</name>
+       <description>Frequency Output Selection. When SQE=1, these bits specify the output frequency on the SQW pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq1Hz</name>
+         <description>1 Hz (Compensated).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq512Hz</name>
+         <description>512 Hz (Compensated).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq4KHz</name>
+         <description>4 KHz.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clkDiv8</name>
+         <description>RTC Input Clock / 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_EN</name>
+       <description>Asynchronous Counter Read Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_EN</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical RTC bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIM</name>
+     <description>RTC Trim Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>RTC Trim. This register contains the 2's complement value that specifies the trim resolution. Each increment or decrement of the bit adds or subtracts 1ppm at each 4KHz clock value, with a maximum correction of +/- 127ppm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VRTC_TMR</name>
+       <description>VBAT Timer Value. When RTC is running off of VBAT, this field is incremented every 32 seconds.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>RTC Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>FILTER_EN</name>
+       <description>Enables analog deglitch filter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_SEL</name>
+       <description>If IBIAS_EN is 1, selects 4x,2x mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HYST_EN</name>
+       <description>Enables high current hysteresis buffer.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_EN</name>
+       <description>Enables higher 4x,2x current modes.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYPASS</name>
+       <description>RTC Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SQW_32K</name>
+       <description>RTC 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--RTC Real Time Clock and Alarm.-->
+  <peripheral>
+   <name>SEMA</name>
+   <description>The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.</description>
+   <baseAddress>0x4003E000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>SEMAPHORES[%s]</name>
+     <description>Read to test and set, returns prior value. Write 0 to clear semaphore.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>sema</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>irq0</name>
+     <description>Semaphore IRQ0 register.</description>
+     <addressOffset>0x40</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>en</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cm4_irq</name>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>mail0</name>
+     <description>Semaphore Mailbox 0 register.</description>
+     <addressOffset>0x44</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>data</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>irq1</name>
+     <description>Semaphore IRQ1 register.</description>
+     <addressOffset>0x48</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>en</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>rv32_irq</name>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>mail1</name>
+     <description>Semaphore Mailbox 1 register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>data</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>status</name>
+     <description>Semaphore status bits. 0 indicates the semaphore is free, 1 indicates taken.</description>
+     <addressOffset>0x100</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>status0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SEMA The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.-->
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x40000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SISTAT</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>MAGIC</name>
+       <description>Magic Word Validation. This bit is set by the system initialization block
+              following power-up.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>magicNotSet</name>
+         <description>Magic word was not set (OTP has not been initialized properly).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>magicSet</name>
+         <description>Magic word was set (OTP contains valid settings).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRCERR</name>
+       <description>CRC Error Status. This bit is set by the system initialization block
+              following power-up.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No CRC errors occurred during the read of the OTP memory block.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>A CRC error occurred while reading the OTP. The address of the failure
+                  location in the OTP memory is stored in the ERRADDR register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SIADDR</name>
+     <description>Read-only field set by the SIB block if a CRC error occurs during the read of
+          the OTP memory. Contains the failing address in OTP memory (when CRCERR equals 1).</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ERRADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BTLE_LDO_TRIM</name>
+     <description>BTLE LDO Trim register.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RF</name>
+       <description>RF LDO trim value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BB</name>
+       <description>BB LDO trim value.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FSTAT</name>
+     <description>funcstat register.</description>
+     <addressOffset>0x100</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>FPU</name>
+       <description>FPU Function.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USB</name>
+       <description>USB Function.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADC</name>
+       <description>ADC Function.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SPIXIP</name>
+       <description>SPIXIP Function.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HBC</name>
+       <description>HBC Function.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SMPHR</name>
+       <description>SMPHR function.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BTLE</name>
+       <description>BTLE function.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFSTAT</name>
+     <description>Security function status register.</description>
+     <addressOffset>0x104</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TRNG</name>
+       <description> TRNG Function.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AES</name>
+       <description>AES Block.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHA</name>
+       <description>SHA Block.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MAA</name>
+       <description>MAA Block.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIR System Initialization Registers.-->
+  <peripheral>
+   <name>SMON</name>
+   <description>The Security Monitor block used to monitor system threat conditions.</description>
+   <baseAddress>0x40004000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>EXTSCN</name>
+     <description>External Sensor Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x3800FFC0</resetMask>
+     <fields>
+      <field>
+       <name>EXTS_EN0</name>
+       <description>External Sensor Enable for input/output pair 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN1</name>
+       <description>External Sensor Enable for input/output pair 1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN2</name>
+       <description>External Sensor Enable for input/output pair 2.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN3</name>
+       <description>External Sensor Enable for input/output pair 3.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN4</name>
+       <description>External Sensor Enable for input/output pair 4.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTS_EN5</name>
+       <description>External Sensor Enable for input/output pair 5.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTCNT</name>
+       <description>External Sensor Error Counter. These bits set the number of external sensor accepted mismatches that have to occur within a single bit period before an external sensor alarm is triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>EXTFRQ</name>
+       <description>External Sensor Frequency. These bits define the frequency at which the external sensors are clocked to/from the EXTS_IN and EXTS_OUT pair.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq2000Hz</name>
+         <description>Div 4 (2000Hz).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq1000Hz</name>
+         <description>Div 8 (1000Hz).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq500Hz</name>
+         <description>Div 16 (500Hz).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq250Hz</name>
+         <description>Div 32 (250Hz).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq125Hz</name>
+         <description>Div 64 (125Hz).</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq63Hz</name>
+         <description>Div 128 (63Hz).</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq31Hz</name>
+         <description>Div 256 (31Hz).</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RFU</name>
+         <description>Reserved. Do not use.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DIVCLK</name>
+       <description>Clock Divide.  These bits are used to divide the 8KHz input clock. The resulting divided clock is used for all logic within the Security Monitor Block. Note:
+                                                             If the input clock is divided with these bits, the error count threshold table and output frequency will be affected accordingly with the same divide factor.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1 (8000 Hz).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2 (4000 Hz).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4 (2000 Hz).</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8 (1000 Hz).</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16 (500 Hz).</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32 (250 Hz).</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64 (125 Hz).</description>
+         <value>6</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>Busy. This bit is set to 1 by hardware after EXTSCN register is written to. This bit is automatically cleared to 0 after this register information has been transferred to the security monitor domain.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Update in Progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock Register. Once locked, the EXTSCN register can no longer be modified.  Only a battery disconnect will clear this bit. VBAT powers this register.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTSCN</name>
+     <description>Internal Sensor Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x7F00FFF7</resetMask>
+     <fields>
+      <field>
+       <name>SHIELD_EN</name>
+       <description>Die Shield Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TEMP_EN</name>
+       <description>Temperature Sensor Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VBAT_EN</name>
+       <description>Battery Monitor Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DFD_EN</name>
+       <description>Digital Fault Dector Enable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DFD_NMI</name>
+       <description>Digital Fault NMI Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DFD_STDBY</name>
+       <description>Digital Fault Dector Stand by Enable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PUF_TRIM_ERASE</name>
+       <description>Erase puf trim Enable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LOTEMP_SEL</name>
+       <description>Low Temperature Detection Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>neg50C</name>
+         <description>-50 degrees C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>neg30C</name>
+         <description>-30 degrees C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORELOEN</name>
+       <description>VCORE Undervoltage Detect Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREHIEN</name>
+       <description>VCORE Overvoltage Detect Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDLOEN</name>
+       <description>VDD Undervoltage Detect Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDHIEN</name>
+       <description>VDD Overvoltage Detect Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VGLEN</name>
+       <description>Voltage Glitch Detection Enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock Register. Once locked, the INTSCN register can no longer be modified.  Only a battery disconnect will clear this bit. VBAT powers this register.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECALM</name>
+     <description>Security Alarm Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000000</resetValue>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>DRS</name>
+       <description>Destructive Reset Trigger. Setting this bit will generate a DRS. This bit is self-cleared by hardware.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>Key Wipe Trigger. Set to 1 to initiate a wipe of the AES key register. It does not reset the part, or log a timestamp. AES and DES registers are not affected by this bit. This bit is automatically cleared to 0 after the keys have been wiped.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHIELDF</name>
+       <description>Die Shield Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOTEMP</name>
+       <description>Low Temperature Detect.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HITEMP</name>
+       <description>High Temperature Detect.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATLO</name>
+       <description>Battery Undervoltage Detect.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATHI</name>
+       <description>Battery Overvoltage Detect.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTF</name>
+       <description>External Sensor Flag.   This bit is set to 1 when any of the EXTSTAT bits are set.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDLO</name>
+       <description>VDD Undervoltage Detect Flag.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCORELO</name>
+       <description>VCORE Undervoltage Detect Flag.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VCOREHI</name>
+       <description>VCORE Overvoltage Detect Flag.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VDDHI</name>
+       <description>VDD Overvoltage Flag.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>VGL</name>
+       <description>Voltage Glitch Detection Flag.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT0</name>
+       <description>External Sensor 0 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT1</name>
+       <description>External Sensor 1 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT2</name>
+       <description>External Sensor 2 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT3</name>
+       <description>External Sensor 3 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT4</name>
+       <description>External Sensor 4 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT5</name>
+       <description>External Sensor 5 Detect. The tamper detect is only active when it is enabled. This bits needs to be cleared in software after a tamper event to re-arm the sensor.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN0</name>
+       <description>External Sensor 0 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN1</name>
+       <description>External Sensor 1 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN2</name>
+       <description>External Sensor 2 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN3</name>
+       <description>External Sensor 3 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN4</name>
+       <description>External Sensor 4 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSWARN5</name>
+       <description>External Sensor 5 Warning Ready flag. The tamper detect warning flags are set, regardless of whether the external sensors are enabled.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECDIAG</name>
+     <description>Security Diagnostic Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00000001</resetValue>
+     <resetMask>0xFFC0FE02</resetMask>
+     <fields>
+      <field>
+       <name>BORF</name>
+       <description>Battery-On-Reset Flag. This bit is set once the back up battery is conneted.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SHIELDF</name>
+       <description>Die Shield Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOTEMP</name>
+       <description>Low Temperature Detect.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HITEMP</name>
+       <description>High Temperature Detect.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATLO</name>
+       <description>Battery Undervoltage Detect.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BATHI</name>
+       <description>Battery Overvoltage Detect.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DYNF</name>
+       <description>Dynamic Sensor Flag.  This bit is set to 1 when any of the EXTSTAT bits are set.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AESKT</name>
+       <description>AES Key Transfer.  This bit is set to 1 when AES Key has been transferred from the TRNG to the battery backed AES key register. This bit can only be reset by a BOR.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>incomplete</name>
+         <description>Key has not been transferred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>Key has been transferred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT0</name>
+       <description>External Sensor 0 Detect.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT1</name>
+       <description>External Sensor 1 Detect.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT2</name>
+       <description>External Sensor 2 Detect.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT3</name>
+       <description>External Sensor 3 Detect.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT4</name>
+       <description>External Sensor 4 Detect.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXTSTAT5</name>
+       <description>External Sensor 5 Detect.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DLRTC</name>
+     <description>DRS Log RTC Value. This register contains the 32 bit value in the RTC second register when the last DRS event occurred.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-only</access>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>DLRTC</name>
+       <description>DRS Log RTC Value. This register contains the 32 bit value in the RTC second register when the last DRS event occured.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEUCFG</name>
+     <description>MEU Configuration</description>
+     <addressOffset>0x24</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>MEUCFG</name>
+       <description>Configuration plain/encrypted area of the backed NVSRAM.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SECST</name>
+     <description>Security Monitor Status Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>EXTSRS</name>
+       <description>External Sensor Control Register Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INTSRS</name>
+       <description>Internal Sensor Control Register Status.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SECALRS</name>
+       <description>Security Alarm Register Status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>allowed</name>
+         <description>Access authorized.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>notAllowed</name>
+         <description>Access not authorized.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SDBE</name>
+     <description>Security Monitor Self Destruct Byte.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>DBYTE</name>
+       <description>Self Destruct Byte</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>SBDEN</name>
+       <description>Self-Destruct Byte ENable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SMON The Security Monitor block used to monitor system threat conditions.-->
+  <peripheral>
+   <name>SPI0</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x40046000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>16</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FIFO32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>FIFO16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>FIFO32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>FIFO8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>FIFO32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Start Select Control. Used in Master mode to control the behavior of the Slave Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DEASSERT</name>
+         <description>SPI De-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ASSERT</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_ACTIVE</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3</name>
+         <description>SS3 is selected.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Rising_Edge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Falling_Edge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLK_FB_INV</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1</name>
+         <description>1 bits per character.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2</name>
+         <description>2 bits per character.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3</name>
+         <description>3 bits per character.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4</name>
+         <description>4 bits per character.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5</name>
+         <description>5 bits per character.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6</name>
+         <description>6 bits per character.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7</name>
+         <description>7 bits per character.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8</name>
+         <description>8 bits per character.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9</name>
+         <description>9 bits per character.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10</name>
+         <description>10 bits per character.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11</name>
+         <description>11 bits per character.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12</name>
+         <description>12 bits per character.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13</name>
+         <description>13 bits per character.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14</name>
+         <description>14 bits per character.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15</name>
+         <description>15 bits per character.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin (s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_POL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3_high</name>
+         <description>SS3 active high.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSTIME</name>
+     <description>Register for controlling SPI peripheral/Slave Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PRE</name>
+       <description>Slave Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POST</name>
+       <description>Slave Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>AFP_FCD</name>
+       <description>AFP FCD.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPI0 SPI peripheral.-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI1</name>
+   <description>SPI peripheral. 1</description>
+   <baseAddress>0x40047000</baseAddress>
+   <interrupt>
+    <name>SPI1</name>
+    <description>SPI1 IRQ</description>
+    <value>17</value>
+   </interrupt>
+  </peripheral>
+<!--SPI1 SPI peripheral. 1-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI2</name>
+   <description>SPI peripheral. 2</description>
+   <baseAddress>0x40048000</baseAddress>
+   <interrupt>
+    <name>SPI2</name>
+    <description>SPI2 IRQ</description>
+    <value>18</value>
+   </interrupt>
+  </peripheral>
+<!--SPI2 SPI peripheral. 2-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI3</name>
+   <description>SPI peripheral. 3</description>
+   <baseAddress>0x400BE000</baseAddress>
+   <interrupt>
+    <name>SPI3</name>
+    <description>SPI3 IRQ</description>
+    <value>56</value>
+   </interrupt>
+  </peripheral>
+<!--SPI3 SPI peripheral. 3-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI4</name>
+   <description>SPI peripheral. 4</description>
+   <baseAddress>0x400BE400</baseAddress>
+   <interrupt>
+    <name>SPI4</name>
+    <description>SPI4 IRQ</description>
+    <value>105</value>
+   </interrupt>
+  </peripheral>
+<!--SPI4 SPI peripheral. 4-->
+  <peripheral>
+   <name>SPIXR</name>
+   <description>SPIXR peripheral.</description>
+   <baseAddress>0x4003A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>DATA32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>DATA16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>DATA32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>DATA8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <alternateRegister>DATA32</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MSTR_EN</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSIO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,
+                                                 Slave Select 0 can be input in Master mode. This bit has no
+                                                 effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is
+                                                             self clearing when transactions are done. If
+                                                             a transaction completes, and the TX FIFO
+                                                             is empty, the Master halts, if a transaction
+                                                                 completes, and the TX FIFO is not empty,
+                                                                            the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Slave Select Control.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>deassert</name>
+         <description>SPI de-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>assert</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are
+                                                                            selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>Slave Select 0</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCLK_FB_INV</name>
+       <description>Invert SCLK Feedback in Master Mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>NON_INV</name>
+         <description>SCLK is not inverted to Line Receiver.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INV</name>
+         <description>SCLK is inverted to Line Receiver.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin (s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSPOL</name>
+       <description>Slave Select Polarity</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL3</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SSACT1</name>
+       <description>Slave Select Action delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSACT2</name>
+       <description>Slave Select Action delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSIACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BRGCTRL</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LOW</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HIGH</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCALE</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_FIFO_LVL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for
+                                                                                                    threshold status. When TX FIFO has fewer than this many bytes, the
+                                                                                                    associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CLEAR</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write
+                                                                                                        pointers. This should be done when FIFO is not being accessed on the SPI side.
+                                                                                                        </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_CNT</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_LVL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for
+                                                                                                            threshold status. When RX FIFO has more than this many bytes, the
+                                                                                                            associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CLR</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write
+                                                                                                                pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFIO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_CNT</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data
+                                                                                                                    to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data
+                                                                                                                    from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EMPTY</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>M_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OVR</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UND</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OVR</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UND</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THRESH</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THRESH</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts,
+                                                                                                                                cleared when last bit of last character is acted upon and Slave Select
+                                                                                                                                de-assertion would occur. In Slave mode, set when Slave Select is
+                                                                                                                                asserted, cleared when Slave Select is de-asserted. Not used in Timer mode.
+                                                                                                                                </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>XMEMCTRL</name>
+     <description>Register to control external memory.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RD_CMD</name>
+       <description>Read command.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>WR_CMD</name>
+       <description>Write command.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>DUMMY_CLK</name>
+       <description>Dummy clocks.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>XMEM_EN</name>
+       <description>XMEM enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXR SPIXR peripheral.-->
+  <peripheral>
+   <name>SPIXFC</name>
+   <description>SPI XiP Flash Configuration Controller</description>
+   <baseAddress>0x40027000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPIXFC</name>
+    <description>SPIXFC IRQ</description>
+    <value>38</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0</name>
+     <description>Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>SSEL</name>
+       <description>Slaves Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Slave_0</name>
+         <description>Slave 0 is selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Slave_1</name>
+         <description>Slave 1 is selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire Mode.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description>Defines SPI Mode, Only valid values are 0 and 3.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SPI_Mode_0</name>
+         <description>SPIX Mode 0. CLK Polarity = 0, CLK Phase = 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SPI_Mode_3</name>
+         <description>SPIX Mode 3. CLK Polarity = 1, CLK Phase = 1.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PGSZ</name>
+       <description>Page Size.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>4_bytes</name>
+         <description>4 bytes.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_bytes</name>
+         <description>8 bytes.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_bytes</name>
+         <description>16 bytes.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>32_bytes</name>
+         <description>32 bytes.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HICLK</name>
+       <description>SCLK High Clocks. Number of system clocks that SCLK will be high when SCLK pulses are generated. 0 Correspond to 16 system clocks and, all other values defines the number of system clock taht SCLK will be held high.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16_SCLK</name>
+         <description>16 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LOCLK</name>
+       <description>SCLK low Clocks. Number of system clocks that SCLK will be low when SCLK pulses are generated. 0 correspond to 16 system clocks and, all other values defines the number of system clock taht SCLK will be held low.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16_SCLK</name>
+         <description>16 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSACT</name>
+       <description>Slaves Select Activate Timing.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0_CLKS</name>
+         <description>0 sytem clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_CLKS</name>
+         <description>2 sytem clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_CLKS</name>
+         <description>4 sytem clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_CLKS</name>
+         <description>8 sytem clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSIACT</name>
+       <description>Slaves Select Inactive Timing.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>4_CLKS</name>
+         <description>4 sytem clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_CLKS</name>
+         <description>6 sytem clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_CLKS</name>
+         <description>8 sytem clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_CLKS</name>
+         <description>12 sytem clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IOSMPL</name>
+       <description>Sample Delay</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSPOL</name>
+     <description>SPIX Controller Slave Select Polarity Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>SS_POL</name>
+       <description>Slave Select Polarity.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lo</name>
+         <description>Active Low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hi</name>
+         <description>Active High.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FC_POL</name>
+       <description>FC Polarity.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>lo</name>
+         <description>Active Low.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hi</name>
+         <description>Active High.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>SPIX Controller General Controller Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Master enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable SPI Master, putting a reset state.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable SPI Master for processing transactions.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transaction FIFO Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis_txfifo</name>
+         <description>Disable Transaction FIFO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en_txfifo</name>
+         <description>Enable Transaction FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Result FIFO Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS_RXFIFO</name>
+         <description>Disable Result FIFO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EN_RXFIFO</name>
+         <description>Enable Result FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BBMODE</name>
+       <description>Bit-Bang Mode.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Bit-Bang Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Bit-Bang Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSDR</name>
+       <description>This bits reflects the state of the currently selected slave select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output0</name>
+         <description>Selected Slave select output = 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>output1</name>
+         <description>Selected Slave select output = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FCDR</name>
+       <description>This bits reflects the state of the selected FC.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCLKDR</name>
+       <description>SCLK Drive and State.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SCLK_0</name>
+         <description>SCLK is 0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SCLK_1</name>
+         <description>SCLK is 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDIO_DATA_IN</name>
+       <description>SDIO Input Data Value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BB_DATA_OUT</name>
+       <description>No description available.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BB_DATA_OUT_EN</name>
+       <description>Bit Bang SDIO Output Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SDIO0</name>
+         <description>SDIO[0]</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO1</name>
+         <description>SDIO[1]</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO2</name>
+         <description>SDIO[2]</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SDIO3</name>
+         <description>SDIO[3]</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SIMPLE</name>
+       <description>Simple Mode Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SIMPLE_RX</name>
+       <description>Simple Receive Enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SIMPLE_SS</name>
+       <description>Simple Mode Slave Select.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SCLK_FB</name>
+       <description>Enable SCLK Feedback Mode.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>En</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLK_FB_INV</name>
+       <description>SCK Invert.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>SPIX Controller FIFO Control and Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>TX_AE_LVL</name>
+       <description>Transaction FIFO Almost Empty Level.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_CNT</name>
+       <description>Transaction FIFO Used.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_AF_LVL</name>
+       <description>Results FIFO Almost Full Level.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_CNT</name>
+       <description>Result FIFO Used.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL3</name>
+     <description>SPIX Controller Special Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>SAMPLE</name>
+       <description>Setting this bit to a 1 enables the ability to drive SDIO outputs prior to the assertion of Slave Select. This bit must
+                                                                         only be set when the SPIXF bus is idle and the transaction FIFO is empty. This bit is automatically cleared by hardware after the
+                                                                         next slave select assertion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MISO_FC_EN</name>
+       <description>MISO FC Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SDIO_OUT</name>
+       <description>SDIO Output Value Sample Mode</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>SDIO_OUT_EN</name>
+       <description>SDIO Output Enable Sample Mode</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>SCLKINH3</name>
+       <description>SCLK Inhibit Mode3. In SPI Mode 3, some SPI flash read timing diagrams show the last SCLK going low prior to de-assertion. The default is to support this additional falling edge of clock. When this bit is set and the device is in SPI Mode 3, the SPI clock is held high while Slave Select is de-asserted. This is to support some SPI flash write timing diagrams.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Allow trailing SCLK low pulse prior to Slave Select de-assertion.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Inhibit trailing SCLK low pulse prior to Slave Select de-assertion.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>SPIX Controller Interrupt Status Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>TX_STALLED</name>
+       <description>Transaction Stalled Interrupt Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Normal FIFO Transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Stalled FIFO Transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_STALLED</name>
+       <description>Results Stalled Interrupt Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Normal FIFO Operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Stalled FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_RDY</name>
+       <description>Transaction Ready Interrupt Status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>FIFO Transaction not ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>FIFO Transaction ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_DONE</name>
+       <description>Results Done Interrupt Status.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Results FIFO ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Results FIFO Not ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_AE</name>
+       <description>Transaction FIFO Almost Empty Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Transaction FIFO not Almost Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Transaction FIFO Almost Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_AF</name>
+       <description>Results FIFO Almost Full Flag.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLR</name>
+         <description>Results FIFO level below the Almost Full level.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SET</name>
+         <description>Results FIFO level at Almost Full level.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>SPIX Controller Interrupt Enable Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>TX_STALLED</name>
+       <description>Transaction Stalled Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable Transaction Stalled Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable Transaction Stalled Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_STALLED</name>
+       <description>Results Stalled Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable Results Stalled Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable Results Stalled Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_RDY</name>
+       <description>Transaction Ready Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable FIFO Transaction Ready Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable FIFO Transaction Ready Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_DONE</name>
+       <description>Results Done Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable Results Done Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable Results Done Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FIFO_AE</name>
+       <description>Transaction FIFO Almost Empty Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable Transaction FIFO Almost Empty Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable Transaction FIFO Almost Empty Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FIFO_AF</name>
+       <description>Results FIFO Almost Full Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Disable Results FIFO Almost Full Interrupt.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Enable Results FIFO Almost Full Interrupt.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SIMPLE_HEADER</name>
+     <description>Simple Header</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>TX_BIDIR</name>
+       <description>TX Bdirectional Header.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>RX_ONLY</name>
+       <description>RX Only Header.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXFC SPI XiP Flash Configuration Controller-->
+  <peripheral>
+   <name>SPIXFC_FIFO</name>
+   <description>SPI XiP Master Controller FIFO.</description>
+   <baseAddress>0x400BC000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>TX_8</name>
+     <description>SPI TX FIFO 8-Bit Write</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <dataType>uint8_t</dataType>
+    </register>
+    <register>
+     <name>TX_16</name>
+     <description>SPI TX FIFO 16-Bit Write</description>
+     <alternateRegister>TX_8</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <dataType>uint16_t</dataType>
+    </register>
+    <register>
+     <name>TX_32</name>
+     <description>SPI TX FIFO 32-Bit Write</description>
+     <alternateRegister>TX_8</alternateRegister>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <dataType>uint32_t</dataType>
+    </register>
+    <register>
+     <name>RX_8</name>
+     <description>SPI RX FIFO 8-Bit Access</description>
+     <addressOffset>0x04</addressOffset>
+     <size>8</size>
+     <dataType>uint8_t</dataType>
+    </register>
+    <register>
+     <name>RX_16</name>
+     <description>SPI RX FIFO 16-Bit Access</description>
+     <alternateRegister>RX_8</alternateRegister>
+     <addressOffset>0x04</addressOffset>
+     <size>16</size>
+     <dataType>uint16_t</dataType>
+    </register>
+    <register>
+     <name>RX_32</name>
+     <description>SPI RX FIFO 32-Bit Access</description>
+     <alternateRegister>RX_8</alternateRegister>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+     <dataType>uint32_t</dataType>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXFC_FIFO SPI XiP Master Controller FIFO.-->
+  <peripheral>
+   <name>SPIXFM</name>
+   <description>SPIXF Master</description>
+   <baseAddress>0x40026000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>SPIX Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Defines SPI Mode, Only valid values are 0 and 3.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SCLK_HI_SAMPLE_RISING</name>
+         <description>Description not available.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SCLK_LO_SAMPLE_FAILLING</name>
+         <description>Description not available.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSPOL</name>
+       <description>Slave Select Polarity.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ACTIVE_HIGH</name>
+         <description>Slave Select is Active High.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ACTIVE_LOW</name>
+         <description>Slave Select is Active Low.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEL</name>
+       <description>Slave Select. Only valid value is zero.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>LOCLK</name>
+       <description>Number of system clocks that SCLK will be low when SCLK pulses are generated.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>HICLK</name>
+       <description>Number of system clocks that SCLK will be high when SCLK pulses are generated.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>SSACT</name>
+       <description>Slave Select Active Timing.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>off</name>
+         <description>0 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_2_mod_clk</name>
+         <description>2 System clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_4_mod_clk</name>
+         <description>4 System clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_8_mod_clk</name>
+         <description>8 System clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSIACT</name>
+       <description>Slave Select Inactive Timing.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>for_1_mod_clk</name>
+         <description>1 system clocks.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_3_mod_clk</name>
+         <description>3 System clocks.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_5_mod_clk</name>
+         <description>5 System clocks.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>for_9_mod_clk</name>
+         <description>9 System clocks.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FETCHCTRL</name>
+     <description>SPIX Fetch Control Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>CMDVAL</name>
+       <description>Command Value sent to target to initiate fetching from SPI flash.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>CMDWTH</name>
+       <description>Command Width. Number of data I/O used to send commands.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Single</name>
+         <description>Single SDIO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual_IO</name>
+         <description>Dual SDIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad_IO</name>
+         <description>Quad SDIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Invalid</name>
+         <description>Invalid.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_WIDTH</name>
+       <description>Address Width. Number of data I/O used to send address, and mode/dummy clocks.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Single</name>
+         <description>Single SDIO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual_IO</name>
+         <description>Dual SDIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad_IO</name>
+         <description>Quad SDIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Invalid</name>
+         <description>Invalid.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>Data Width. Number of data I/O used to receive data.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Single</name>
+         <description>Single SDIO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual_IO</name>
+         <description>Dual SDIO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad_IO</name>
+         <description>Quad SDIO.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Invalid</name>
+         <description>Invalid.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>4BADDR</name>
+       <description>Four Byte Address Mode. Enables 4-byte Flash Address Mode.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>3</name>
+         <description>3 Byte Address Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4</name>
+         <description>4 Byte Address Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MODECTRL</name>
+     <description>SPIX Mode Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>MDCLK</name>
+       <description>Mode Clocks. Number of SPI clocks needed during mode/dummy phase of fetch.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>NOCMD</name>
+       <description>No Command Mode.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>always</name>
+         <description>Send read command every time SPI transaction is initiated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>once</name>
+         <description>Send read command only once. NO read command in subsequent SPI transactions.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EXIT_NOCMD</name>
+       <description>Mode Send.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MODEDATA</name>
+     <description>SPIX Mode Data Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MDDATA</name>
+       <description>Mode Data. Specifies the data to send with the Dummy/Mode clocks.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MDOUT_EN</name>
+       <description>Mode Output Enable. Output enable state for each corresponding data bit in MD_DATA. 0: output enable off, I/O is tristate and 1: Output enable on, I/O is driving MD_DATA.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FBCTRL</name>
+     <description>SPIX Feedback Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>FB_EN</name>
+       <description>Enable SCLK feedback mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable SCLK feedback mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable SCLK feedback mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INVERT</name>
+       <description>Invert SCLK in feedback mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Invert SCLK feedback mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Invert SCLK feedback mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IOCTRL</name>
+     <description>SPIX IO Control Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>SCLK_DS</name>
+       <description>SCLK drive Strength. This bit controls the drive strength on the SCLK pin.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Low</name>
+         <description>Low drive strength.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>High</name>
+         <description>High drive strength.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_DS</name>
+       <description>Slave Select Drive Strength. This bit controls the drive strength on the dedicated slave select pin.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Low</name>
+         <description>Low drive strength.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>High</name>
+         <description>High drive strength.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDIO_DS</name>
+       <description>SDIO Drive Strength. This bit controls the drive strength of all SDIO pins.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Low</name>
+         <description>Low drive strength.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>High</name>
+         <description>High drive strength.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PADCTRL</name>
+       <description>IO Pullup/Pulldown Control. These bits control the pullups and pulldowns associated with all SPI XiP SDIO pins.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>tri_state</name>
+         <description>Tristate.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pull_Up</name>
+         <description>Pull-Up.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pull_down</name>
+         <description>Pull-Down.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMSECCTRL</name>
+     <description>SPIX Memory Security Control Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>DEC_EN</name>
+       <description>Decryption Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable decryption of SPIX data.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable decryption of SPIX data.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTH_DISABLE</name>
+       <description>Integrity Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Integrity checking enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Integrity checking disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CNTOPT_EN</name>
+       <description>Enable counters optimization (when authentication is enabled).</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable counter optimization.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable counter optimization.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INTERL_DIS</name>
+       <description>Disable authenticity interleaving (when authentication is enabled)</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable interleaving of SPIX data.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable interleaving of SPIX data.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTHERR_FL</name>
+       <description>Authentication Error Flag Bit.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUSIDLE</name>
+     <description>Bus Idle</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>BUSIDLE</name>
+       <description>A 16-bit timer will be triggered for each external access. The timer will be
+                                         restarted if another access is performed before the timer expires. When the
+                                             timer expires, slave select will be deactivated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTHOFFSET</name>
+     <description>Auth Offset</description>
+     <addressOffset>0x28</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPIXFM SPIXF Master-->
+  <peripheral>
+   <name>TMR</name>
+   <description>Low-Power Configurable Timer</description>
+   <baseAddress>0x40010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR</name>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Timer Counter Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>The current count value for the timer. This field increments as the timer counts.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Timer Compare Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>Timer PWM Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PWM</name>
+       <description>Timer PWM Match:
+                In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
+                In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Timer Interrupt Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ_A</name>
+       <description>Interrupt Flag for Timer A.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_A</name>
+       <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_A</name>
+       <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IRQ_B</name>
+       <description>Interrupt Flag for Timer B.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_B</name>
+       <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_B</name>
+       <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MODE_A</name>
+       <description>Mode Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_A</name>
+       <description>Clock Divider Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_A</name>
+       <description>Timer Polarity for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_A</name>
+       <description>PWM Synchronization Mode for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_A</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_A</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_A</name>
+       <description>PWM Phase A-Prime Output Disable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_A</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Write 1 to Enable CLK_TMR for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_A</name>
+       <description>Enable for Timer A</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MODE_B</name>
+       <description>Mode Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_B</name>
+       <description>Clock Divider Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_B</name>
+       <description>Timer Polarity for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_B</name>
+       <description>PWM Synchronization Mode for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_B</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_B</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_B</name>
+       <description>PWM Phase A-Prime Output Disable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_B</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Write 1 to Enable CLK_TMR for Timer B</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_B</name>
+       <description>Enable for Timer B</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO_A</name>
+       <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_A</name>
+       <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>LO_B</name>
+       <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_B</name>
+       <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Timer Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKSEL_A</name>
+       <description>Timer Clock Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Timer A Enable Status</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_A</name>
+       <description>CLK_TMR Ready Flag for Timer A</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_A</name>
+       <description>Event Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_A</name>
+       <description>Negative Edge Trigger for Event for Timer A</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_A</name>
+       <description>Interrupt Enable for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_A</name>
+       <description>Capture Event Select for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_A</name>
+       <description>Software Capture Event for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_A</name>
+       <description>Wake-Up Enable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTEN_A</name>
+       <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTBEN_A</name>
+       <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads of the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKSEL_B</name>
+       <description>Timer Clock Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Timer B Enable Status</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_B</name>
+       <description>CLK_TMR Ready Flag for Timer B</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_B</name>
+       <description>Event Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_B</name>
+       <description>Negative Edge Trigger for Event for Timer B</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_B</name>
+       <description>Interrupt Enable for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_B</name>
+       <description>Capture Event Select for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_B</name>
+       <description>Software Capture Event for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_B</name>
+       <description>Wake-Up Enable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CASCADE</name>
+       <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Timer Wakeup Status Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>A</name>
+       <description>Wake-Up Flag for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>B</name>
+       <description>Wake-Up Flag for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TMR Low-Power Configurable Timer-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR1</name>
+   <description>Low-Power Configurable Timer 1</description>
+   <baseAddress>0x40011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+<!--TMR1 Low-Power Configurable Timer 1-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR2</name>
+   <description>Low-Power Configurable Timer 2</description>
+   <baseAddress>0x40012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+<!--TMR2 Low-Power Configurable Timer 2-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR3</name>
+   <description>Low-Power Configurable Timer 3</description>
+   <baseAddress>0x40013000</baseAddress>
+   <interrupt>
+    <name>TMR3</name>
+    <description>TMR3 IRQ</description>
+    <value>8</value>
+   </interrupt>
+  </peripheral>
+<!--TMR3 Low-Power Configurable Timer 3-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR4</name>
+   <description>Low-Power Configurable Timer 4</description>
+   <baseAddress>0x40080C00</baseAddress>
+   <interrupt>
+    <name>TMR4</name>
+    <description>TMR4 IRQ</description>
+    <value>9</value>
+   </interrupt>
+  </peripheral>
+<!--TMR4 Low-Power Configurable Timer 4-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR5</name>
+   <description>Low-Power Configurable Timer 5</description>
+   <baseAddress>0x40081000</baseAddress>
+   <interrupt>
+    <name>TMR5</name>
+    <description>TMR5 IRQ</description>
+    <value>10</value>
+   </interrupt>
+  </peripheral>
+<!--TMR5 Low-Power Configurable Timer 5-->
+  <peripheral>
+   <name>TRIMSIR</name>
+   <description>Trim System Initilazation Registers</description>
+   <baseAddress>0x40005400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RTC</name>
+     <description>RTC Trim System Initialization Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>RTCX1</name>
+       <description>RTC X1 Trim.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RTCX2</name>
+       <description>RTC X2 Trim.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRIMSIR Trim System Initilazation Registers-->
+  <peripheral>
+   <name>TRNG</name>
+   <description>Random Number Generator.</description>
+   <baseAddress>0x4004D000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TRNG</name>
+    <description>TRNG interrupt.</description>
+    <value>4</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>TRNG Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000003</resetValue>
+     <fields>
+      <field>
+       <name>RND_IE</name>
+       <description>To enable IRQ generation when a new 32-bit Random number is ready.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEYGEN</name>
+       <description>AES Key Generate. When enabled, the key for securing NVSRAM is generated and transferred to the secure key register automatically without user visibility or intervention. This bit is cleared by hardware once the key has been transferred to the secure key register.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>To wipe the Battery Backed key.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>RDY</name>
+       <description>32-bit random data is ready to read from TRNG_DATA register. Reading TRNG_DATA when RND_RDY=0 will return all 0's. IRQ is generated when RND_RDY=1 if TRNG_CN.RND_IRQ_EN=1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Busy</name>
+         <description>TRNG Busy</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Ready</name>
+         <description>32 bit random data is ready</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data. The content of this register is valid only when RNG_IS =1. When TNRG is disabled, read returns 0x0000 0000.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRNG Random Number Generator.-->
+  <peripheral>
+   <name>UART</name>
+   <description>UART Low Power Registers</description>
+   <baseAddress>0x40042000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control register</description>
+     <addressOffset>0x0000</addressOffset>
+     <fields>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>This field specifies the depth of receive FIFO for interrupt generation (value 0 and &gt; 16 are ignored) </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EN</name>
+       <description>Parity Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EO</name>
+       <description>when PAREN=1 selects odd or even parity odd is 1 even is 0</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_MD</name>
+       <description>Selects parity based on 1s or 0s count (when PAREN=1) </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_DIS</name>
+       <description>CTS Sampling Disable </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Flushes the TX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Flushes the RX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHAR_SIZE</name>
+       <description>Selects UART character size</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5bits</name>
+         <description>5 bits</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6bits</name>
+         <description>6 bits</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7bits</name>
+         <description>7 bits</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8bits</name>
+         <description>8 bits</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPBITS</name>
+       <description>Selects the number of stop bits that will be generated</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HFC_EN</name>
+       <description>Enables/disables hardware flow control</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RTSDC</name>
+       <description>Hardware Flow Control RTS Mode</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKEN</name>
+       <description>Baud clock enable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKSRC</name>
+       <description>To select the UART clock source for the UART engine (except APB registers). Secondary clock (used for baud rate generator) can be asynchronous from APB clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Peripheral_Clock</name>
+         <description>apb clock</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>External_Clock</name>
+         <description>Clock 1</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK2</name>
+         <description>Clock 2</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK3</name>
+         <description>Clock 3</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPFE_EN</name>
+       <description>Data/Parity bit frame error detection enable</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKRDY</name>
+       <description>Baud clock Ready read only bit</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UCAGM</name>
+       <description>UART Clock Auto Gating mode</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FDM</name>
+       <description>Fractional Division Mode</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DESM</name>
+       <description>RX Dual Edge Sampling Mode</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TX_BUSY</name>
+       <description>Read-only flag indicating the UART transmit status</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_BUSY</name>
+       <description>Read-only flag indicating the UART receiver status</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Indicates the number of bytes currently in the RX FIFO (0-RX FIFO_ELTS) </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Indicates the number of bytes currently in the TX FIFO (0-TX FIFO_ELTS) </description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interrupt Enable control register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Enable Interrupt For RX Frame Error</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Enable Interrupt For RX Parity Error</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Enable Interrupt For CTS signal change Error</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Enable Interrupt For RX FIFO Overrun Error</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Enable Interrupt For RX FIFO reaches the number of bytes configured by RXTHD</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Enable Interrupt For TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Enable Interrupt For TX FIFO has half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Interrupt status flags Control register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Flag for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Flag for RX Parity Error interrupt</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Flag for CTS signal change interrupt (hardware flow control disabled) </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Flag for RX FIFO Overrun interrupt</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Flag for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Flag for interrupt when TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Flag for interrupt when TX FIFO is half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Clock Divider register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Baud rate divisor value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSR</name>
+     <description>Over Sampling Rate register</description>
+     <addressOffset>0x0014</addressOffset>
+     <fields>
+      <field>
+       <name>OSR</name>
+       <description>OSR</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXPEEK</name>
+     <description>TX FIFO Output Peek register</description>
+     <addressOffset>0x0018</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read TX FIFO next data. Reading from this field does not affect the contents of TX FIFO. Note that the parity bit is available from this field.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PNR</name>
+     <description> Pin register</description>
+     <addressOffset>0x001C</addressOffset>
+     <fields>
+      <field>
+       <name>CTS</name>
+       <description>Current sampled value of CTS IO</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RTS</name>
+       <description>This bit controls the value to apply on the RTS IO. If set to 1, the RTS IO is set to high level. If set to 0, the RTS IO is set to low level.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Read/Write register</description>
+     <addressOffset>0x0020</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Parity error flag for next byte to be read from FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration register</description>
+     <addressOffset>0x0030</addressOffset>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger If the TX FIFO level is less than this value, then the TX FIFO DMA interface will send a signal to system DMA to notify that TX FIFO is ready to receive data from memory.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX DMA channel enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Rx FIFO Level DMA Trigger If the RX FIFO level is greater than this value, then the RX FIFO DMA interface will send a signal to the system DMA to notify that RX FIFO has characters to transfer to memory.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX DMA channel enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wake up enable Control register</description>
+     <addressOffset>0x0034</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Enable for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Enable for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Enable for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wake up Flags register</description>
+     <addressOffset>0x0038</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Flag for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Flag for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Flag for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--UART UART Low Power Registers-->
+  <peripheral derivedFrom="UART">
+   <name>UART1</name>
+   <description>UART Low Power Registers 1</description>
+   <baseAddress>0x40043000</baseAddress>
+  </peripheral>
+<!--UART1 UART Low Power Registers 1-->
+  <peripheral derivedFrom="UART">
+   <name>UART2</name>
+   <description>UART Low Power Registers 2</description>
+   <baseAddress>0x40044000</baseAddress>
+  </peripheral>
+<!--UART2 UART Low Power Registers 2-->
+  <peripheral derivedFrom="UART">
+   <name>UART3</name>
+   <description>UART Low Power Registers 3</description>
+   <baseAddress>0x40081400</baseAddress>
+  </peripheral>
+<!--UART3 UART Low Power Registers 3-->
+  <peripheral>
+   <name>USBHS</name>
+   <description>USB 2.0 High-speed Controller.</description>
+   <baseAddress>0x400B1000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>USB</name>
+    <value>2</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FADDR</name>
+     <description>Function address register.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <resetMask>0x00</resetMask>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Function address for this controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>UPDATE</name>
+       <description>Set when ADDR is written, cleared when new address takes effect.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>POWER</name>
+     <description>Power management register.</description>
+     <addressOffset>0x01</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>EN_SUSPENDM</name>
+       <description>Enable SUSPENDM signal.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SUSPEND</name>
+       <description>Suspend mode detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESUME</name>
+       <description>Generate resume signaling.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESET</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS_MODE</name>
+       <description>High-speed mode detected.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS_ENABLE</name>
+       <description>High-speed mode enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SOFTCONN</name>
+       <description>Softconn.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ISO_UPDATE</name>
+       <description>Wait for SOF during Isochronous xfers.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRIN</name>
+     <description>Interrupt register for EP0 and IN EP1-15.</description>
+     <addressOffset>0x02</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_IN_INT</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP14_IN_INT</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP13_IN_INT</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP12_IN_INT</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP11_IN_INT</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP10_IN_INT</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP9_IN_INT</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP8_IN_INT</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP7_IN_INT</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP6_IN_INT</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP5_IN_INT</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP4_IN_INT</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP3_IN_INT</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP2_IN_INT</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP1_IN_INT</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP0_IN_INT</name>
+       <description>Endpoint 0 interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTROUT</name>
+     <description>Interrupt register for OUT EP 1-15.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_OUT_INT</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP14_OUT_INT</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP13_OUT_INT</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP12_OUT_INT</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP11_OUT_INT</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP10_OUT_INT</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP9_OUT_INT</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP8_OUT_INT</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP7_OUT_INT</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP6_OUT_INT</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP5_OUT_INT</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP4_OUT_INT</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP3_OUT_INT</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP2_OUT_INT</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP1_OUT_INT</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRINEN</name>
+     <description>Interrupt enable for EP 0 and IN EP 1-15.</description>
+     <addressOffset>0x06</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_IN_INT_EN</name>
+       <description>Endpoint 15 interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP14_IN_INT_EN</name>
+       <description>Endpoint 14 interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP13_IN_INT_EN</name>
+       <description>Endpoint 13 interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP12_IN_INT_EN</name>
+       <description>Endpoint 12 interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP11_IN_INT_EN</name>
+       <description>Endpoint 11 interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP10_IN_INT_EN</name>
+       <description>Endpoint 10 interrupt enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP9_IN_INT_EN</name>
+       <description>Endpoint 9 interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP8_IN_INT_EN</name>
+       <description>Endpoint 8 interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP7_IN_INT_EN</name>
+       <description>Endpoint 7 interrupt enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP6_IN_INT_EN</name>
+       <description>Endpoint 6 interrupt enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP5_IN_INT_EN</name>
+       <description>Endpoint 5 interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP4_IN_INT_EN</name>
+       <description>Endpoint 4 interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP3_IN_INT_EN</name>
+       <description>Endpoint 3 interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP2_IN_INT_EN</name>
+       <description>Endpoint 2 interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP1_IN_INT_EN</name>
+       <description>Endpoint 1 interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP0_INT_EN</name>
+       <description>Endpoint 0 interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTROUTEN</name>
+     <description>Interrupt enable for OUT EP 1-15.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_OUT_INT_EN</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP14_OUT_INT_EN</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP13_OUT_INT_EN</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP12_OUT_INT_EN</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP11_OUT_INT_EN</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP10_OUT_INT_EN</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP9_OUT_INT_EN</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP8_OUT_INT_EN</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP7_OUT_INT_EN</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP6_OUT_INT_EN</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP5_OUT_INT_EN</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP4_OUT_INT_EN</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP3_OUT_INT_EN</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP2_OUT_INT_EN</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP1_OUT_INT_EN</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRUSB</name>
+     <description>Interrupt register for common USB interrupts.</description>
+     <addressOffset>0x0A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SOF_INT</name>
+       <description>Start of Frame.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESET_INT</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESUME_INT</name>
+       <description>Resume detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SUSPEND_INT</name>
+       <description>Suspend detected.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRUSBEN</name>
+     <description>Interrupt enable for common USB interrupts.</description>
+     <addressOffset>0x0B</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SOF_INT_EN</name>
+       <description>Start of Frame.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESET_INT_EN</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESUME_INT_EN</name>
+       <description>Resume detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SUSPEND_INT_EN</name>
+       <description>Suspend detected.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FRAME</name>
+     <description>Frame number.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>FRAMENUM</name>
+       <description>Read the last received frame number, that is the 11-bit frame number received in the SOF packet.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INDEX</name>
+     <description>Index for banked registers.</description>
+     <addressOffset>0x0E</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>INDEX</name>
+       <description>Index Register Access Selector. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TESTMODE</name>
+     <description>USB 2.0 test mode enable register.</description>
+     <addressOffset>0x0F</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>FORCE_FS</name>
+       <description>Force USB to Full-speed after reset.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FORCE_HS</name>
+       <description>Force USB to High-speed after reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_PKT</name>
+       <description>Transmit fixed test packet.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_K</name>
+       <description>Force USB to continuous K state.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_J</name>
+       <description>Force USB to continuous J state.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_SE0_NAK</name>
+       <description>Respond to any valid IN token with NAK.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INMAXP</name>
+     <description>Maximum packet size for INx endpoint (x == INDEX).</description>
+     <addressOffset>0x10</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>MAXPACKETSIZE</name>
+       <description>Maximum Packet Size in a Single Transaction. That is the maximum packet size in bytes, that is transmitted for each microframe. The maximum value is 1024, subject to the limitations of the endpoint type set in USB 2.0 Specification, Chapter 9</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+      <field>
+       <name>NUMPACKMINUS1</name>
+       <description>Number of Split Packets - 1. Defines the maximum number of packets minus 1 that a USB payload can be split into. THis must be an exact multiple of maxpacketsize. Only applicable for HS High-Bandwidth isochronous endpoints and Bulk endpoints. Ignored in all other cases. </description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CSR0</name>
+     <description>Control status register for EP 0 (when INDEX == 0).</description>
+     <addressOffset>0x12</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SERV_SETUP_END</name>
+       <description>Clear EP0 Setup End Bit. Write a 1 to clear the setupend bit. Automatically cleared after being set </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SERV_OUTPKTRDY</name>
+       <description>Clear EP0 Out Packet Ready Bit. Write a 1 to clear the outpktrdy bit. Automatically cleared after being set.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SEND_STALL</name>
+       <description>Send EP0 STALL Handshake. Write a 1 to this bit to terminate the current control transaction by sneding a STALL handshake. Automatically cleared after being set. </description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SETUP_END</name>
+       <description>Read Setup End Status. Automatically set when a contorl transaction ends before the dataend bit has been set by fimrware. An interrupt is generated when this bit is set. Write 1 to servicedsetupend to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_END</name>
+       <description>Control Transaction Data End. Write a 1 to this bit after firmware completes any of the following three transactions: 1. set inpktrdy = 1 for the last data packet. 2. Set inpktrdy =1 for a zero-length data packet. 3. Clear outpktrdy = 0 after unloading the last data packet. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENT_STALL</name>
+       <description> Read EP0 STALL Handshake Sent Status Automatically set when a STALL handshake is transmitted. Write a 0 to clear. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPKTRDY</name>
+       <description>EP0 IN Packet Ready 1: Write a 1 after writing a data packet to the IN FIFO. Automatically cleared when the data packet is transmitted. An interrupt is generated when this bit is cleared. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPKTRDY</name>
+       <description>EP0 OUT Packet Ready Status Automatically set when a data packet is received in the OUT FIFO. An interrupt is generated when this bit is set. Write a 1 to the servicedoutpktrdy bit (above) to clear after the packet is unloaded from the OUT FIFO. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INCSRL</name>
+     <description>Control status lower register for INx endpoint (x == INDEX).</description>
+     <alternateRegister>CSR0</alternateRegister>
+     <addressOffset>0x12</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>INCOMPTX</name>
+       <description>Read Incomplete Split Transfer Error Status High-bandwidth isochronous transfers: Automatically set when a payload is split into multiple packets but insufficient IN tokens were received to send all packets. The current packets is flushed from the IN FIFO. Write 0 to clear.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLRDATATOG</name>
+       <description>Write 1 to clear IN endpoint data-toggle to 0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENTSTALL</name>
+       <description>Read STALL Handshake Sent Status Automatically set when a STALL handshake is transmitted, at which time the IN FIFO is flushed, and inpktrdy is cleared. Write 0 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENDSTALL</name>
+       <description>Send STALL Handshake.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>terminate</name>
+         <description>Terminate STALL handhsake</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Respond to an IN token with a STALL handshake</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSHFIFO</name>
+       <description>Flush Next Packet from IN FIFO. Write 1 to clear</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>UNDERRUN</name>
+       <description>Read IN FIFO Underrun Error Status Isochronous Mode: Automatically set if the IN FIFO is empty. Write 0 to clear</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFONOTEMPTY</name>
+       <description>Read FIFO Not Empty Status. Automatically set when there is at least one packet in the IN FIFO. Write a 0 to clear. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPKTRDY</name>
+       <description>IN Packet Ready. Write a 1 to clear </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INCSRU</name>
+     <description>Control status upper register for INx endpoint (x == INDEX).</description>
+     <addressOffset>0x13</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>AUTOSET</name>
+       <description>Auto Set inpktrdy. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>set</name>
+         <description>USBHS_INCSRL_inpktrdy must be set by firmware.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>auto</name>
+         <description>USBHS_INCSRL_inpktrdy is automatically set. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ISO</name>
+       <description>Isochronous Transfer Enable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>interrupt</name>
+         <description>Enable IN Bulk and IN interrupt transfers.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>isochronous</name>
+         <description>Enable IN Isochronous transfers. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description> Endpoint Direction Mode.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>out</name>
+         <description>Endpoint direction is OUT.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>in</name>
+         <description>Endpoint direction is IN. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FRCDATATOG</name>
+       <description> Force In Data - Toggle</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>received</name>
+         <description>Toggle data-toglge only when an ACK is received.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dontcare</name>
+         <description>Toggle data-toggle regardless of ACK. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPKTBUFDIS</name>
+       <description> Double Packet Buffering Disable </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Double packet buffering.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Double Packet Buffering.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTMAXP</name>
+     <description>Maximum packet size for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x14</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>NUMPACKMINUS1</name>
+       <description>Number of Split Packets -1. Defines the maximum number of packets - 1 that a usb payload is combined into. The value must be exact multiple of maxpacketsize. </description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>MAXPACKETSIZE</name>
+       <description>Maximum Packet in a Single Transaction. This is the maximum packet size, in bytes, that is transmitted for each microframe. The maximum value is 1024, subject to the limitations for the endpoint type set in USB2.0 spesification, chapter 9.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCSRL</name>
+     <description>Control status lower register for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x16</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>CLRDATATOG</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENTSTALL</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENDSTALL</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FLUSHFIFO</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DATAERROR</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>OVERRUN</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFOFULL</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>OUTPKTRDY</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCSRU</name>
+     <description>Control status upper register for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x17</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>AUTOCLEAR</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ISO</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DISNYET</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DPKTBUFDIS</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INCOMPRX</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>COUNT0</name>
+     <description>Number of received bytes in EP 0 FIFO (INDEX == 0).</description>
+     <addressOffset>0x18</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>COUNT0</name>
+       <description>Read Number of Data Bytes in the Endpoint 0 FIFO. Returns the number of data bytes in the endpoint 0 FIFO. This value changes as contents of the FIFO change. The value is only valued when USBHS_OUTSCRL_outpktrdy = 1 </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCOUNT</name>
+     <description>Number of received bytes in OUT EPx FIFO (x == INDEX).</description>
+     <alternateRegister>COUNT0</alternateRegister>
+     <addressOffset>0x18</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>OUTCOUNT</name>
+       <description>Read Number of Data Bytes in OUT FIFO. Returns the number of data bytes in the packet that are read next in the OUT FIFO. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>13</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO0</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO0</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO1</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO1</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO2</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO2</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO3</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x2c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO3</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO4</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO4</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO5</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO5</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO6</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO6</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO7</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x3c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO7</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO8</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO8</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO9</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO9</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO10</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO10</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO11</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x4c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO11</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO12</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO12</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO13</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO13</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO14</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO14</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO15</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x5c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO15</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HWVERS</name>
+     <description>HWVERS</description>
+     <addressOffset>0x6c</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>USBHS_HWVERS</name>
+       <description>USBHS Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EPINFO</name>
+     <description>Endpoint hardware information.</description>
+     <addressOffset>0x78</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>OUTENDPOINTS</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>INTENDPOINTS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RAMINFO</name>
+     <description>RAM width information.</description>
+     <addressOffset>0x79</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RAMBITS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SOFTRESET</name>
+     <description>Software reset register.</description>
+     <addressOffset>0x7A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RSTXS</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RSTS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTUCH</name>
+     <description>Chirp timeout timer setting.</description>
+     <addressOffset>0x80</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>C_T_UCH</name>
+       <description>HS Chirp Timeout Clock Cycles. This configures the chirp timeout used by this device to negotiate a HS connection with a FS Host. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTHSRTN</name>
+     <description>Sets delay between HS resume to UTM normal operating mode.</description>
+     <addressOffset>0x82</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>C_T_HSTRN</name>
+       <description>High Speed Resume Delay Clock Cycles. This configures the delay from when the RESUME state on the bus ends, the when the USBHS resumes normal operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_USB_REG_00</name>
+     <description>MXM_USB_REG_00</description>
+     <addressOffset>0x400</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_UTMI_RESET</name>
+     <description>M31_PHY_UTMI_RESET</description>
+     <addressOffset>0x404</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_UTMI_VCONTROL</name>
+     <description>M31_PHY_UTMI_VCONTROL</description>
+     <addressOffset>0x408</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CLK_EN</name>
+     <description>M31_PHY_CLK_EN</description>
+     <addressOffset>0x40C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_PONRST</name>
+     <description>M31_PHY_PONRST</description>
+     <addressOffset>0x410</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_NONCRY_RSTB</name>
+     <description>M31_PHY_NONCRY_RSTB</description>
+     <addressOffset>0x414</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_NONCRY_EN</name>
+     <description>M31_PHY_NONCRY_EN</description>
+     <addressOffset>0x418</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_EN</name>
+     <description>M31_PHY_U2_COMPLIANCE_EN</description>
+     <addressOffset>0x420</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_DAC_ADJ</name>
+     <description>M31_PHY_U2_COMPLIANCE_DAC_ADJ</description>
+     <addressOffset>0x424</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_DAC_ADJ_EN</name>
+     <description>M31_PHY_U2_COMPLIANCE_DAC_ADJ_EN</description>
+     <addressOffset>0x428</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CLK_RDY</name>
+     <description>M31_PHY_CLK_RDY</description>
+     <addressOffset>0x42C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_PLL_EN</name>
+     <description>M31_PHY_PLL_EN</description>
+     <addressOffset>0x430</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_BIST_OK</name>
+     <description>M31_PHY_BIST_OK</description>
+     <addressOffset>0x434</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DATA_OE</name>
+     <description>M31_PHY_DATA_OE</description>
+     <addressOffset>0x438</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_OSCOUTEN</name>
+     <description>M31_PHY_OSCOUTEN</description>
+     <addressOffset>0x43C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_LPM_ALIVE</name>
+     <description>M31_PHY_LPM_ALIVE</description>
+     <addressOffset>0x440</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_HS_BIST_MODE</name>
+     <description>M31_PHY_HS_BIST_MODE</description>
+     <addressOffset>0x444</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CORECLKIN</name>
+     <description>M31_PHY_CORECLKIN</description>
+     <addressOffset>0x448</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XTLSEL</name>
+     <description>M31_PHY_XTLSEL</description>
+     <addressOffset>0x44C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_LS_EN</name>
+     <description>M31_PHY_LS_EN</description>
+     <addressOffset>0x450</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DEBUG_SEL</name>
+     <description>M31_PHY_DEBUG_SEL</description>
+     <addressOffset>0x454</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DEBUG_OUT</name>
+     <description>M31_PHY_DEBUG_OUT</description>
+     <addressOffset>0x458</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_OUTCLKSEL</name>
+     <description>M31_PHY_OUTCLKSEL</description>
+     <addressOffset>0x45C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_31_0</name>
+     <description>M31_PHY_XCFGI_31_0</description>
+     <addressOffset>0x460</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_63_32</name>
+     <description>M31_PHY_XCFGI_63_32</description>
+     <addressOffset>0x464</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_95_64</name>
+     <description>M31_PHY_XCFGI_95_64</description>
+     <addressOffset>0x468</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_127_96</name>
+     <description>M31_PHY_XCFGI_127_96</description>
+     <addressOffset>0x46C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_137_128</name>
+     <description>M31_PHY_XCFGI_137_128</description>
+     <addressOffset>0x470</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_HS_COARSE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_HS_COARSE_TUNE_NUM</description>
+     <addressOffset>0x474</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_HS_FINE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_HS_FINE_TUNE_NUM</description>
+     <addressOffset>0x478</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_FS_COARSE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_FS_COARSE_TUNE_NUM</description>
+     <addressOffset>0x47C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_FS_FINE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_FS_FINE_TUNE_NUM</description>
+     <addressOffset>0x480</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_LOCK_RANGE_MAX</name>
+     <description>M31_PHY_XCFG_LOCK_RANGE_MAX</description>
+     <addressOffset>0x484</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_LOCK_RANGE_MIN</name>
+     <description>M31_PHY_XCFGI_LOCK_RANGE_MIN</description>
+     <addressOffset>0x488</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_OB_RSEL</name>
+     <description>M31_PHY_XCFG_OB_RSEL</description>
+     <addressOffset>0x48C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_OC_RSEL</name>
+     <description>M31_PHY_XCFG_OC_RSEL</description>
+     <addressOffset>0x490</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGO</name>
+     <description>M31_PHY_XCFGO</description>
+     <addressOffset>0x494</addressOffset>
+    </register>
+    <register>
+     <name>MXM_INT</name>
+     <description>USB Added Maxim Interrupt Flag Register.</description>
+     <addressOffset>0x498</addressOffset>
+     <fields>
+      <field>
+       <name>VBUS</name>
+       <description>VBUS</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOVBUS</name>
+       <description>NOVBUS</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_INT_EN</name>
+     <description>USB Added Maxim Interrupt Enable Register.</description>
+     <addressOffset>0x49C</addressOffset>
+     <fields>
+      <field>
+       <name>VBUS</name>
+       <description>VBUS</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOVBUS</name>
+       <description>NOVBUS</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_SUSPEND</name>
+     <description>USB Added Maxim Suspend Register.</description>
+     <addressOffset>0x4A0</addressOffset>
+     <fields>
+      <field>
+       <name>SEL</name>
+       <description>Suspend register</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_REG_A4</name>
+     <description>USB Added Maxim Power Status Register</description>
+     <addressOffset>0x4A4</addressOffset>
+     <fields>
+      <field>
+       <name>VRST_VDDB_N_A</name>
+       <description>VRST_VDDB_N_A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--USBHS USB 2.0 High-speed Controller.-->
+  <peripheral>
+   <name>WDT</name>
+   <description>Windowed Watchdog Timer</description>
+   <baseAddress>0x40003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WWDT</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INT_LATE_VAL</name>
+       <description>Windowed Watchdog Interrupt Upper Limit. Sets the number of WDTCLK cycles until a windowed watchdog timer interrupt is generated (if enabled) if the CPU does not write the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE_VAL</name>
+       <description>Windowed Watchdog Reset Upper Limit. Sets the number of WDTCLK cycles until a system reset occurs (if enabled) if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Windowed Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_LATE</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Late.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_INT_EN</name>
+       <description>Windowed Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_RST_EN</name>
+       <description>Windowed Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Soon.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY_VAL</name>
+       <description>Windowed Watchdog Interrupt Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A windowed watchdog timer interrupt is generated (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY_VAL</name>
+       <description>Windowed Watchdog Reset Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A system reset occurs (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKRDY_IE</name>
+       <description>Switch Ready Interrupt Enable. Fires an interrupt when it is safe to swithc the clock.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY</name>
+       <description>Clock Status.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WIN_EN</name>
+       <description>Enables the Windowed Watchdog Function.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Windowed Mode Disabled (i.e. Compatibility Mode).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Windowed Mode Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Soon.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Late.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Windowed Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>RESET</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD_UPPER_LIMIT then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD_UPPER_LIMIT then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKSEL</name>
+     <description>Windowed Watchdog Timer Clock Select Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SOURCE</name>
+       <description>WWDT Clock Selection Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CNT</name>
+     <description>Windowed Watchdog Timer Count Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Current Value of the Windowed Watchdog Timer Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WDT Windowed Watchdog Timer-->
+  <peripheral derivedFrom="WDT">
+   <name>WDT1</name>
+   <description>Windowed Watchdog Timer 1</description>
+   <baseAddress>0x40080800</baseAddress>
+   <interrupt>
+    <name>WDT1</name>
+    <description>WDT1 IRQ</description>
+    <value>57</value>
+   </interrupt>
+  </peripheral>
+<!--WDT1 Windowed Watchdog Timer 1-->
+  <peripheral>
+   <name>WUT</name>
+   <description>Wake Up Timer</description>
+   <baseAddress>0x40006400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WUT</name>
+    <value>53</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Wakeup Timer Count Register</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Timer Count Value. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Wakeup Timer Compare Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>Timer Compare Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Wakeup Timer Interrupt Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ_CLR</name>
+       <description>Timer Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Wakeup Timer Control Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TMODE</name>
+       <description>Timer Mode Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>oneShot</name>
+         <description>One Shot Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Continuous Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>counter</name>
+         <description>Counter Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pwm</name>
+         <description>PWM Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>capture</name>
+         <description>Capture Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>compare</name>
+         <description>Compare Mode.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>gated</name>
+         <description>Gated Mode.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>captureCompare</name>
+         <description>Capture/Compare Mode.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES</name>
+       <description>Timer Prescaler Select.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV8</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV16</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV32</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV64</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV128</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV256</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV512</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV1024</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV2048</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4096</name>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TPOL</name>
+       <description>Timer Polarity.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TEN</name>
+       <description>Timer Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>timer_dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>timer_en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES3</name>
+       <description>Timer Prescaler Select.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pres3_1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_2</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_4</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_8</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_16</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_32</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_64</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_128</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_256</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_512</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_1024</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_2048</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_4096</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Non Overlaping Compare Register</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>NOLLCMP</name>
+       <description>Non Overlaping Low Compare.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>NOLHCMP</name>
+       <description>Non Overlaping High Compare.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET</name>
+     <description>Preset register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>PRESET</name>
+       <description>Preset Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RELOAD</name>
+     <description>Reload register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>RELOAD</name>
+       <description>Reload Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SNAPSHOT</name>
+     <description>Snapshot register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>SNAPSHOT</name>
+       <description>Snapshot Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WUT Wake Up Timer-->
+  <peripheral derivedFrom="WUT">
+   <name>WUT1</name>
+   <description>Wake Up Timer 1</description>
+   <baseAddress>0x40006600</baseAddress>
+   <interrupt>
+    <name>WUT1</name>
+    <description>WUT1 IRQ</description>
+    <value>109</value>
+   </interrupt>
+  </peripheral>
+<!--WUT1 Wake Up Timer 1-->
+ </peripherals>
+</device>

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX78000/Include/max78000.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX78000/Include/max78000.svd
@@ -1,0 +1,12887 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max78000</name>
+ <series>ARMCM4</series>
+ <version>1.0</version>
+ <description>MAX78000 Machine Learning System-on-Chip.</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>ADC</name>
+   <description>10-bit Analog to Digital Converter</description>
+   <baseAddress>0x40034000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>ADC</name>
+    <description>ADC IRQ</description>
+    <value>20</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>ADC Control</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>start</name>
+       <description>Start ADC Conversion</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pwr</name>
+       <description>ADC Power Up</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>refbuf_pwr</name>
+       <description>ADC Reference Buffer Power Up</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ref_sel</name>
+       <description>ADC Reference Select</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ref_scale</name>
+       <description>ADC Reference Scale</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>scale</name>
+       <description>ADC Scale</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>clk_en</name>
+       <description>ADC Clock Enable</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_sel</name>
+       <description>ADC Channel Select</description>
+       <bitRange>[16:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AIN0</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN1</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN2</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN3</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN4</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN5</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN6</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AIN7</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VcoreA</name>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VcoreB</name>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vrxout</name>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vtxout</name>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VddA</name>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VddB</name>
+         <description>VddB/4</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vddio</name>
+         <description>Vddio/4</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Vddioh</name>
+         <description>Vddioh/4</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>VregI</name>
+         <description>VregI/4</description>
+         <value>16</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>adc_divsel</name>
+       <description>Scales the external inputs, all inputs are scaled the same</description>
+       <bitRange>[18:17]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV3</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>data_align</name>
+       <description>ADC Data Alignment Select</description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>ADC Status</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>active</name>
+       <description>ADC Conversion In Progress</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>afe_pwr_up_active</name>
+       <description>AFE Power Up Delay Active</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>overflow</name>
+       <description>ADC Overflow</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>ADC Output Data</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>adc_data</name>
+       <description>ADC Converted Sample Data Output</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>ADC Interrupt Control Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>done_ie</name>
+       <description>ADC Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ref_ready_ie</name>
+       <description>ADC Reference Ready Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>hi_limit_ie</name>
+       <description>ADC Hi Limit Monitor Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>lo_limit_ie</name>
+       <description>ADC Lo Limit Monitor Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>overflow_ie</name>
+       <description>ADC Overflow Interrupt Enable</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>done_if</name>
+       <description>ADC Done Interrupt Flag</description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>ref_ready_if</name>
+       <description>ADC Reference Ready Interrupt Flag</description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>hi_limit_if</name>
+       <description>ADC Hi Limit Monitor Interrupt Flag</description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>lo_limit_if</name>
+       <description>ADC Lo Limit Monitor Interrupt Flag</description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>overflow_if</name>
+       <description>ADC Overflow Interrupt Flag</description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>pending</name>
+       <description>ADC Interrupt Pending Status</description>
+       <bitRange>[22:22]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>LIMIT[%s]</name>
+     <description>ADC Limit</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ch_lo_limit</name>
+       <description>Low Limit Threshold</description>
+       <bitRange>[9:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_hi_limit</name>
+       <description>High Limit Threshold</description>
+       <bitRange>[21:12]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_sel</name>
+       <description>ADC Channel Select</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_lo_limit_en</name>
+       <description>Low Limit Monitoring Enable</description>
+       <bitRange>[29:29]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ch_hi_limit_en</name>
+       <description>High Limit Monitoring Enable</description>
+       <bitRange>[30:30]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ADC 10-bit Analog to Digital Converter-->
+  <peripheral>
+   <name>AES</name>
+   <description>AES Keys.</description>
+   <baseAddress>0x40007400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>AES Control Register</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>AES Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>DMA Request To Read Data Output FIFO</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>DMA Request To Write Data Input FIFO</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start AES Calculation</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FLUSH</name>
+       <description>Flush the data input FIFO</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FLUSH</name>
+       <description>Flush the data output FIFO</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_SIZE</name>
+       <description>Encryption Key Size</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AES128</name>
+         <description>128 Bits.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES192</name>
+         <description>192 Bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES256</name>
+         <description>256 Bits.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TYPE</name>
+       <description>Encryption Type Selection</description>
+       <bitRange>[9:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>AES Status Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>AES Busy Status</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_EM</name>
+       <description>Data input FIFO empty status</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FULL</name>
+       <description>Data input FIFO full status</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_EM</name>
+       <description>Data output FIFO empty status</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FULL</name>
+       <description>Data output FIFO full status</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>AES Interrupt Flag Register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>AES Interrupt Enable Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>AES Data Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>AES FIFO</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--AES AES Keys.-->
+  <peripheral>
+   <name>AESKEYS</name>
+   <description>AES Key Registers.</description>
+   <baseAddress>0x40007800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>KEY0</name>
+     <description>AES Key 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY1</name>
+     <description>AES Key 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY2</name>
+     <description>AES Key 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY3</name>
+     <description>AES Key 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY4</name>
+     <description>AES Key 4.</description>
+     <addressOffset>0x10</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY5</name>
+     <description>AES Key 5.</description>
+     <addressOffset>0x14</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY6</name>
+     <description>AES Key 6.</description>
+     <addressOffset>0x18</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY7</name>
+     <description>AES Key 7.</description>
+     <addressOffset>0x1C</addressOffset>
+     <size>32</size>
+    </register>
+   </registers>
+  </peripheral>
+<!--AESKEYS AES Key Registers.-->
+  <peripheral>
+   <name>CAMERAIF</name>
+   <description>Parallel Camera Interface.</description>
+   <baseAddress>0x4000E000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>CameraIF</name>
+    <value>91</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>VER</name>
+     <description>Hardware Version.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>minor</name>
+       <description>Minor Version Number.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>major</name>
+       <description>Major Version Number.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO_SIZE</name>
+     <description>FIFO Depth.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>fifo_size</name>
+       <description>FIFO size.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register.</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>READ_MODE</name>
+       <description>Read Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Camera Interface Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>single_img</name>
+         <description>Single Image Capture.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Continuous Image Capture.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>Data Width.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>8bit</name>
+         <description>8 bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10bit</name>
+         <description>10 bit.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12bit</name>
+         <description>12 bit.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DS_TIMING_EN</name>
+       <description>DS Timing Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Timing from VSYNC and HSYNC.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Timing embedded in data using SAV and EAV codes.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FIFO_THRSH</name>
+       <description>Data FIFO Threshold.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_DMA</name>
+       <description>DMA Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>DMA disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>DMA enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_DMA_THRSH</name>
+       <description>DMA Threshold.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>THREE_CH_EN</name>
+       <description>Three-channel mode enable.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PCIF_SYS</name>
+       <description>PCIF Control.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PCIF disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PCIF enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interupt Enable Register.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IMG_DONE</name>
+       <description>Image Done.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_FULL</name>
+       <description>FIFO Full.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_THRESH</name>
+       <description>FIFO Threshold Level Met.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_NOT_EMPTY</name>
+       <description>FIFO Not Empty.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Interupt Flag Register.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IMG_DONE</name>
+       <description>Image Done.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_FULL</name>
+       <description>FIFO Full.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_THRESH</name>
+       <description>FIFO Threshold Level Met.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_NOT_EMPTY</name>
+       <description>FIFO Not Empty.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS_TIMING_CODES</name>
+     <description>DS Timing Code Register.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SAV</name>
+       <description>Start Active Video Code.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EAV</name>
+       <description>End Active Video Code.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO_DATA</name>
+     <description>FIFO DATA Register.</description>
+     <addressOffset>0x0030</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data from FIFO to be read by DMA.</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CAMERAIF Parallel Camera Interface.-->
+  <peripheral>
+   <name>CRC</name>
+   <description>CRC Registers.</description>
+   <baseAddress>0x4000F000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>CRC Control</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>CRC Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_EN</name>
+       <description>DMA Request Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB</name>
+       <description>MSB Select</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BYTE_SWAP_IN</name>
+       <description>Byte Swap CRC Data Input</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BYTE_SWAP_OUT</name>
+       <description>Byte Swap CRC Value Output</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>CRC Busy</description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN32</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN16</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN8</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>POLY</name>
+     <description>CRC Polynomial</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>POLY</name>
+       <description>CRC Polynomial</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VAL</name>
+     <description>Current CRC Value</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>VALUE</name>
+       <description>Current CRC Value</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CRC CRC Registers.-->
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0</name>
+    <value>28</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1</name>
+    <value>45</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA2</name>
+    <value>46</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA3</name>
+    <value>47</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>INTEN</name>
+     <description>DMA Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel 0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <description>Channel 1 Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <description>Channel 2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <description>Channel 3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>DMA Interrupt Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel Interrupt. To clear an interrupt, all active interrupt bits of the DMA_ST must be cleared. The interrupt bits are set only if their corresponding interrupt enable bits are set in DMA_CN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>4</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CTRL</name>
+      <description>DMA Channel Control Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>EN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQUEST</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1RX</name>
+          <description>SPI1 RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0RX</name>
+          <description>UART0 RX</description>
+          <value>0x04</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1RX</name>
+          <description>UART1 RX</description>
+          <value>0x05</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0RX</name>
+          <description>I2C0 RX</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1RX</name>
+          <description>I2C1 RX</description>
+          <value>0x08</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>ADC</name>
+          <description>ADC</description>
+          <value>0x09</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2RX</name>
+          <description>I2C2 RX</description>
+          <value>0x0A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2RX</name>
+          <description>UART2 RX</description>
+          <value>0x0E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0RX</name>
+          <description>SPI0 RX</description>
+          <value>0x0F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESRX</name>
+          <description>AES RX</description>
+          <value>0x10</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3RX</name>
+          <description>UART3 RX</description>
+          <value>0x1C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2SRX</name>
+          <description>I2S RX</description>
+          <value>0x1E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1TX</name>
+          <description>SPI1 TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0TX</name>
+          <description>UART0 TX</description>
+          <value>0x24</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1TX</name>
+          <description>UART1 TX</description>
+          <value>0x25</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0TX</name>
+          <description>I2C0 TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1TX</name>
+          <description>I2C1 TX</description>
+          <value>0x28</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2TX</name>
+          <description>I2C2 TX</description>
+          <value>0x2A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>CRCTX</name>
+          <description>CRC TX</description>
+          <value>0x2C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>PCIFTX</name>
+          <description>PCIF TX</description>
+          <value>0x2D</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2TX</name>
+          <description>UART2 TX</description>
+          <value>0x2E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0TX</name>
+          <description>SPI0 TX</description>
+          <value>0x2F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESTX</name>
+          <description>AES TX</description>
+          <value>0x30</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART3TX</name>
+          <description>UART3 TX</description>
+          <value>0x3C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2STX</name>
+          <description>I2S TX</description>
+          <value>0x3E</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_WAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_PER</name>
+        <description>Timeout Period Select.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_CLKDIV</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BURST_SIZE</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>DIS_IE</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IE</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>STATUS</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>STATUS</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IF</name>
+        <description>Count-to-Zero (CTZ) Interrupt Flag</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>RLD_IF</name>
+        <description>Reload Event Interrupt Flag.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>TO_IF</name>
+        <description>Time-Out Event Interrupt Flag.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRCRLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DSTRLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNTRLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>EN</name>
+        <description>Count Reload Enable.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+<!--DMA DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral>
+   <name>DVS</name>
+   <description>Dynamic Voltage Scaling</description>
+   <prependToName>DVS_</prependToName>
+   <baseAddress>0x40003C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0030</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DVS</name>
+    <description>Dynamic Voltage Scaling Interrupt</description>
+    <value>83</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTL</name>
+     <description>Control Register</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>MON_ENA</name>
+       <description>Enable the DVS monitoring circuit</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ENA</name>
+       <description>Enable the power supply adjustment based on measurements</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PS_FB_DIS</name>
+       <description>Power Supply Feedback Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTRL_TAP_ENA</name>
+       <description>Use the TAP Select for automatic adjustment or monitoring</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PROP_DLY</name>
+       <description>Additional delay to monitor lines</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>MON_ONESHOT</name>
+       <description>Measure delay once</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GO_DIRECT</name>
+       <description>Operate in automatic mode or move directly</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DIRECT_REG</name>
+       <description>Step incrementally to target voltage</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PRIME_ENA</name>
+       <description>Include a delay line priming signal before monitoring</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LIMIT_IE</name>
+       <description>Enable Limit Error Interrupt</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RANGE_IE</name>
+       <description>Enable Range Error Interrupt</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_IE</name>
+       <description>Enable Adjustment Error Interrupt</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>REF_SEL</name>
+       <description>Select TAP used for voltage adjustment</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>INC_VAL</name>
+       <description>Step size to increment voltage when in automatic mode</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>DVS_PS_APB_DIS</name>
+       <description>Prevent the application code from adjusting Vcore</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DVS_HI_RANGE_ANY</name>
+       <description>Any high range signal from a delay line will cause a voltage adjustment</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FB_TO_IE</name>
+       <description>Enable Voltage Adjustment Timeout Interrupt</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FC_LV_IE</name>
+       <description>Enable Low Voltage Interrupt</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PD_ACK_ENA</name>
+       <description>Prevent DVS from ack'ing a request to enter a low power mode until in the idle state</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ABORT</name>
+       <description>Causes the DVS to enter the idle state immediately on a request to enter a low power mode</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>Status Fields</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000000</resetValue>
+     <fields>
+      <field>
+       <name>DVS_STATE</name>
+       <description>State machine state</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_UP_ENA</name>
+       <description>DVS Raising voltage</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_DWN_ENA</name>
+       <description>DVS Lowering voltage</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ACTIVE</name>
+       <description>Adjustment to a Direct Voltage</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTR_TAP_OK</name>
+       <description>Tap Enabled and the Tap is withing Hi/Low limits</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTR_TAP_SEL</name>
+       <description>Status of selected center tap delay line detect output</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SLOW_TRIP_DET</name>
+       <description>Provides the current combined status of all selected Low Range delay lines</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FAST_TRIP_DET</name>
+       <description>Provides the current combined status of all selected High Range delay lines</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PS_IN_RANGE</name>
+       <description>Indicates if the power supply is in range</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PS_VCNTR</name>
+       <description>Voltage Count value sent to the power supply</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>MON_DLY_OK</name>
+       <description>Indicates the monitor delay count is at 0</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_DLY_OK</name>
+       <description>Indicates the adjustment delay count is at 0</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LO_LIMIT_DET</name>
+       <description>Power supply voltage counter is at low limit</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HI_LIMIT_DET</name>
+       <description>Power supply voltage counter is at high limit</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VALID_TAP</name>
+       <description>At least one delay line has been enabled</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LIMIT_ERR</name>
+       <description>Interrupt flag that indicates a voltage count is at/beyond manufacturer limits</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RANGE_ERR</name>
+       <description>Interrupt flag that indicates a tap has an invalid value</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ERR</name>
+       <description>Interrupt flag that indicates up and down adjustment requested simultaneously</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>REF_SEL_ERR</name>
+       <description>Indicates the ref select register  bit is out of range</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FB_TO_ERR</name>
+       <description>Interrupt flag that indicates a timeout while adjusting the voltage</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FB_TO_ERR_S</name>
+       <description>Interrupt flag that mirror FB_TO_ERR and is write one clear</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FC_LV_DET_INT</name>
+       <description>Interrupt flag that indicates the power supply voltage requested is below the low threshold</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FC_LV_DET_S</name>
+       <description>Interrupt flag that mirrors FC_LV_DET_INT</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DIRECT</name>
+     <description>Direct control of target voltage</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>VOLTAGE</name>
+       <description>Sets the target power supply value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MON</name>
+     <description>Monitor Delay</description>
+     <addressOffset>0x00C</addressOffset>
+     <fields>
+      <field>
+       <name>DLY</name>
+       <description>Number of prescaled clocks between delay line samples</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+      <field>
+       <name>PRE</name>
+       <description>Number of clocks before DVS_MON_DLY is decremented</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADJ_UP</name>
+     <description>Up Delay Register</description>
+     <addressOffset>0x010</addressOffset>
+     <fields>
+      <field>
+       <name>DLY</name>
+       <description>Number of prescaled clocks between updates of the adjustment delay counter</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PRE</name>
+       <description>Number of clocks before DVS_ADJ_UP_DLY is decremented</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADJ_DWN</name>
+     <description>Down Delay Register</description>
+     <addressOffset>0x014</addressOffset>
+     <fields>
+      <field>
+       <name>DLY</name>
+       <description>Number of prescaled clocks between updates of the adjustment delay counter</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PRE</name>
+       <description>Number of clocks before DVS_ADJ_DWN_DLY is decremented</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>THRES_CMP</name>
+     <description>Up Delay Register</description>
+     <addressOffset>0x018</addressOffset>
+     <fields>
+      <field>
+       <name>VCNTR_THRES_CNT</name>
+       <description>Value used to determine 'low voltage' range</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VCNTR_THRES_MASK</name>
+       <description>Mask applied to threshold and vcount to determine if the device is in a low voltage range</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>5</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>TAP_SEL[%s]</name>
+     <description>DVS Tap Select Register</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Select delay line tap for lower bound of auto adjustment</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>LO_TAP_STAT</name>
+       <description>Returns last delay line tap value</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTR_TAP_STAT</name>
+       <description>Returns last delay line tap value</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HI_TAP_STAT</name>
+       <description>Returns last delay line tap value</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Selects delay line tap for high point of auto adjustment</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>CTR</name>
+       <description>Selects delay line tap for center point of auto adjustment</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>COARSE</name>
+       <description>Selects delay line tap for coarse or fixed delay portion of the line</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>DET_DLY</name>
+       <description>Number of HCLK between delay line launch and sampling</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>DELAY_ACT</name>
+       <description>Set if the delay is active</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--DVS Dynamic Voltage Scaling-->
+  <peripheral>
+   <name>FCR</name>
+   <description>Function Control Register.</description>
+   <baseAddress>0x40000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>FCTRL0</name>
+     <description>Function Control 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>I2C0DGEN0</name>
+       <description>I2C0 SDA Pad Deglitcher enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0DGEN1</name>
+       <description>I2C0 SCL Pad Deglitcher enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN0</name>
+       <description>I2C1 SDA Pad Deglitcher enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN1</name>
+       <description>I2C1 SCL Pad Deglitcher enable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2DGEN0</name>
+       <description>I2C2 SDA Pad Deglitcher enable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2DGEN1</name>
+       <description>I2C2 SCL Pad Deglitcher enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL0</name>
+     <description>Automatic Calibration 0.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ACEN</name>
+       <description>Auto-calibration Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACRUN</name>
+       <description>Autocalibration Run.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDTRM</name>
+       <description>Load Trim.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GAININV</name>
+       <description>Invert Gain.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ATOMIC</name>
+       <description>Atomic mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MU</name>
+       <description>MU value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>HIRC96MACTMROUT</name>
+       <description>HIRC96M Trim Value.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL1</name>
+     <description>Automatic Calibration 1.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INITTRM</name>
+       <description>Initial Trim Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL2</name>
+     <description>Automatic Calibration 2</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONECNT</name>
+       <description>Auto-callibration Done Counter Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>ACDIV</name>
+       <description>Auto-callibration Div Setting.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>URVBOOTADDR</name>
+     <description>RISC-V Boot Address.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>URVCTRL</name>
+     <description>RISC-V Control Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MEMSEL</name>
+       <description>RAM2, RAM3 exclusive ownership.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IFLUSHEN</name>
+       <description>URV instruction flush enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FCR Function Control Register.-->
+  <peripheral>
+   <name>FLC</name>
+   <description>Flash Memory Control.</description>
+   <prependToName>FLSH_</prependToName>
+   <baseAddress>0x40029000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Flash_Controller</name>
+    <description>Flash Controller interrupt.</description>
+    <value>23</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ADDR</name>
+     <description>Flash Write Address.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address for next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Flash Clock Divide. The clock (PLL0) is divided by this value to generate a 1 MHz clock for Flash controller.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000064</resetValue>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Flash Clock Divide. The clock is divided by this value to generate a 1MHz clock for flash controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Flash Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WR</name>
+       <description>Write.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="WR">
+       <name>ME</name>
+       <description>Mass Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="WR">
+       <name>PGE</name>
+       <description>Page Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERASE_CODE</name>
+       <description>Erase Code.  The ERASE_CODE must be set up property before erase operation can be initiated. These bits are automatically cleared after the operation is complete.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>erasePage</name>
+         <description>Enable Page Erase.</description>
+         <value>0x55</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>eraseAll</name>
+         <description>Enable Mass Erase. The debug port must be enabled.</description>
+         <value>0xAA</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PEND</name>
+       <description>Flash Pending.  When Flash operation is in progress (busy), Flash reads and writes will fail. When PEND is set, write to all Flash registers, with exception of the Flash interrupt register, are ignored.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LVE</name>
+       <description>Low Voltage enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNLOCK</name>
+       <description>Flash Unlock.  The correct unlock code must be written to these four bits before any Flash write or erase operation is allowed.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Flash Unlocked.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Flash Locked.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Flash Interrupt Register.</description>
+     <addressOffset>0x024</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Flash Done Interrupt.  This bit is set to 1 upon Flash write or erase completion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AF</name>
+       <description>Flash Access Fail.  This bit is set when an attempt is made to write the flash while the flash is busy or the flash is locked. This bit can only be set to 1 by hardware.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONEIE</name>
+       <description>Flash Done Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DONEIE">
+       <name>AFIE</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCDATA</name>
+     <description>ECC Data Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>EVEN</name>
+       <description>Error Correction Code Odd Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>ODD</name>
+       <description>Error Correction Code Even Data.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA[%s]</name>
+     <description>Flash Write Data.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACTRL</name>
+     <description>Access Control Register. Writing the ACTRL register with the following values in the order shown, allows read and write access to the system and user Information block:
+    pflc-actrl = 0x3a7f5ca3;
+    pflc-actrl = 0xa1e34f20;
+    pflc-actrl = 0x9608b2c1. When unlocked, a write of any word will disable access to system and user information block. Readback of this register is always zero.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ACTRL</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR0</name>
+     <description>WELR0</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>WELR0</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR1</name>
+     <description>WELR1</description>
+     <addressOffset>0x88</addressOffset>
+     <fields>
+      <field>
+       <name>WELR1</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR0</name>
+     <description>RLR0</description>
+     <addressOffset>0x90</addressOffset>
+     <fields>
+      <field>
+       <name>RLR0</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR1</name>
+     <description>RLR1</description>
+     <addressOffset>0x98</addressOffset>
+     <fields>
+      <field>
+       <name>RLR1</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FLC Flash Memory Control.-->
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x40000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SYSCTRL</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>BSTAPEN</name>
+       <description>Boundary Scan TAP enable. When enabled, the JTAG port is conneted to the Boundary Scan TAP instead of the ARM ICE.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH_PAGE_FLIP</name>
+       <description>Flips the Flash bottom and top halves. (Depending on the total flash size, each half is either 256K or 512K). Initiating a flash page flip will cause a flush of both the data buffer on the DCODE bus and the internal instruction buffer.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Physical layout matches logical layout.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>swapped</name>
+         <description>Bottom half mapped to logical top half and vice versa.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICC0_FLUSH</name>
+       <description>Code Cache Flush. This bit is used to flush the code caches and the instruction buffer of the Cortex-M4. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROMDONE</name>
+       <description>ROM_DONE status. Used to disable SWD interface during system initialization procedure</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CCHK</name>
+       <description>Compute ROM Checksum. This bit is self-cleared when calculation is completed. Once set, software clearing this bit is ignored and the bit will remain set until the operation is completed.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SWD_DIS</name>
+       <description> Serial Wire Debug Disable. This bit is used to disable the serial wire debug interface This bit is only writeable if (FMV lock word is not programmed) or if (ICE lock word is not programmed and the ROM_DONE bit is not set).</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHKRES</name>
+       <description>ROM Checksum Result. This bit is only valid when CHKRD=1.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pass</name>
+         <description>ROM Checksum Correct.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fail</name>
+         <description>ROM Checksum Fail.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OVR</name>
+       <description>Operating Voltage Range.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA">
+       <name>WDT0</name>
+       <description>Watchdog Timer 0 Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO1</name>
+       <description>GPIO1 Reset. Setting this bit to 1 resets GPIO1 pins to their default states.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR0</name>
+       <description>Timer 0 Reset. Setting this bit to 1 resets Timer 0 blocks.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR1</name>
+       <description>Timer 1 Reset. Setting this bit to 1 resets Timer 1 blocks.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR2</name>
+       <description>Timer 2 Reset. Setting this bit to 1 resets Timer 2 blocks.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR3</name>
+       <description>Timer 3 Reset. Setting this bit to 1 resets Timer 3 blocks.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART0</name>
+       <description>UART 0 Reset. Setting this bit to 1 resets all UART 0 blocks.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART1</name>
+       <description>UART 1 Reset. Setting this bit to 1 resets all UART 1 blocks.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI1</name>
+       <description>SPI 1 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>I2C0</name>
+       <description>I2C 0 Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>RTC</name>
+       <description>Real Time Clock Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SMPHR</name>
+       <description>Semaphore Reset.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TRNG</name>
+       <description>TRNG Reset. This reset is only available during the manufacture testing phase.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>CNN</name>
+       <description>CNN Reset.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>ADC</name>
+       <description>ADC Reset.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART2</name>
+       <description>UART2 Reset. Setting this bit to 1 resets all UART 2 blocks.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SOFT</name>
+       <description>Soft Reset. Setting this bit to 1 resets everything except the CPU and the watchdog timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>PERIPH</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SYS</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>SYSCLK_DIV</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the PLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_SEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ISO</name>
+         <description>The internal 60 MHz oscillator is used for the system clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INRO</name>
+         <description>8 kHz LIRC is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>The internal 100 MHz oscillator is used for the system clock.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBRO</name>
+         <description>The internal 7.3725 MHz oscillator is used for the system clock.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERTCO</name>
+         <description> 32 kHz is used for the system clock.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EXTCLK</name>
+         <description> External clock on GPIO0.30.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_RDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>32 kHz Crystal Oscillator Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>ISO_EN</name>
+       <description>60 MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>IPO_EN</name>
+       <description>100 MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_EN">
+       <name>IBRO_EN</name>
+       <description>7.3725 MHz High Frequency Internal Reference Clock Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_VS</name>
+       <description>7.3725 MHz High Frequency Internal Reference Clock Voltage Select. This register bit is used to select the power supply to the IBRO.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Vcor</name>
+         <description>VCore Supply</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1V</name>
+         <description>Dedicated 1V regulated supply.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERTCO_RDY</name>
+       <description>32 kHz Crystal Oscillator Ready</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>ISO_RDY</name>
+       <description>60 MHz HIRC Ready.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>IPO_RDY</name>
+       <description>100 MHz HIRC Ready.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>IBRO_RDY</name>
+       <description>7.3725 MHz HIRC Ready.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ERTCO_RDY">
+       <name>INRO_RDY</name>
+       <description>8 kHz Low Frequency Reference Clock Ready.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PM</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This two bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sleep</name>
+         <description>Cortex-M4 Active, RISC-V Sleep Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>standby</name>
+         <description>Standby Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>backup</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>lpm</name>
+         <description>LPM or CM4 Deep Sleep Mode.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>upm</name>
+         <description>UPM.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>powerdown</name>
+         <description>Power Down Mode.</description>
+         <value>10</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO_WE</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wake Up Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wake Up Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>RTC_WE</name>
+       <description>RTC Alarm Wake Up Enable. This bit enables RTC alarm as wakeup source. If enabled, the desired RTC alarm must be configured via the RTC control registers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>WUT_WE</name>
+       <description>WUT Wake Up Enable. This bit enables the Wake-Up Timer as wakeup source. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>AINCOMP_WE</name>
+       <description>AIN COMP Wake Up Enable. This bit enables AIN COMP as wakeup source. </description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ISO_PD</name>
+       <description>60 MHz power down. This bit selects the 60 MHz clock power state in DEEPSLEEP mode.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ISO_PD">
+       <name>IPO_PD</name>
+       <description>100 MHz power down. This bit selects 100 MHz clock power state in DEEPSLEEP mode. </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ISO_PD">
+       <name>IBRO_PD</name>
+       <description>7.3725 MHz power down. This bit selects 7.3725 MHz clock power state in DEEPSLEEP mode. </description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIV</name>
+     <description>Peripheral Clock Divider.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>ADCFRQ</name>
+       <description>ADC clock Frequency. These bits define the ADC clock frequency. fADC = fPCLK / (ADCFRQ)</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CNNCLKDIV</name>
+       <description>CNN Clock Divider.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div2</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div1</name>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CNNCLKSEL</name>
+       <description>CNN Clock Select.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>PCLK</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ISO</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0</name>
+       <description>GPIO0 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>GPIO1</name>
+       <description>GPIO1 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>DMA</name>
+       <description>DMA Clock Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI1</name>
+       <description>SPI 1 Clock Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART0</name>
+       <description>UART 0 Clock Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART1</name>
+       <description>UART 1 Clock Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C0</name>
+       <description>I2C 0 Clock Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR0</name>
+       <description>Timer 0 Clock Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR1</name>
+       <description>Timer 1 Clock Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR2</name>
+       <description>Timer 2 Clock Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR3</name>
+       <description>Timer 3 Clock Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>ADC</name>
+       <description>ADC Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>CNN</name>
+       <description>CNN Clock Disable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C1</name>
+       <description>I2C 1 Clock Disable.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>PT</name>
+       <description>Pluse Train Clock Disable.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCTRL</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 2.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM0ECC</name>
+       <description>SYSRAM0 ECC Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMZ</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM Block 0 Zeroization.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM1</name>
+       <description>System RAM Block 1 Zeroization.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM2</name>
+       <description>System RAM Block 2 Zeroization.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM3</name>
+       <description>System RAM Block 3 Zeroization.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>SYSRAM0ECC</name>
+       <description>System RAM 0 ECC Zeroization.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICC0</name>
+       <description>Instruction Cachei 0 Zeroization.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICC1</name>
+       <description>Instruction Cachei 1 Zeroization.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSST</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICELOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>I2C1</name>
+       <description>I2C1 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>PT</name>
+       <description>PT Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>OWM</name>
+       <description>OWM Reset.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>CRC</name>
+       <description>CRC Reset.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AES</name>
+       <description>AES Reset.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPI0</name>
+       <description>SPI 0 Reset.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SMPHR</name>
+       <description>SMPHR Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2S</name>
+       <description>I2S Reset.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2C2</name>
+       <description>I2C2 Reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>DVS</name>
+       <description>DVS Reset.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SIMO</name>
+       <description>SIMO Reset.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>CPU1</name>
+       <description>CPU1 Reset.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>UART2</name>
+       <description>UART2 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="UART2">
+       <name>TRNG</name>
+       <description>TRNG Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SMPHR</name>
+       <description>SMPHR Clock Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>OWM</name>
+       <description>One-Wire Clock Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>CRC</name>
+       <description>CRC Clock Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>AES</name>
+       <description>AES Clock Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SPI0</name>
+       <description>SPI 0 Clock Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>PCIF</name>
+       <description>Parallel Camera Interface Clock Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>I2S</name>
+       <description>I2S Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>I2C2</name>
+       <description>I2C2 Clock Disable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>WDT0</name>
+       <description>Watch Dog Timer 0 Clock Disable.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>CPU1</name>
+       <description>CPU1 Clock Disable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVENTEN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX</name>
+       <description>Enable RXEV pin event. When this bit is set, a logic high of GPIO1.8 will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO1.9.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REVISION</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSIE</name>
+     <description>System Status Interrupt Enable Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEUNLOCK</name>
+       <description>ARM ICE Unlock Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCERR</name>
+     <description>ECC Error Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCCED</name>
+     <description>ECC Not Double Error Detect Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCIE</name>
+     <description>ECC IRQ Enable Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Interrup Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCADDR</name>
+     <description>ECC Error Address Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ECCERRAD</name>
+       <description>ECC Error Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPR</name>
+     <description>General Purpose Register.</description>
+     <addressOffset>0x80</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCR Global Control Registers.-->
+  <peripheral>
+   <name>GCFR</name>
+   <description>Global Control Function Register.</description>
+   <baseAddress>0x40005800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>REG0</name>
+     <description>Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>cnnx16_0_pwr_en</name>
+       <description>CNNx16_0 Power Domain Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_1_pwr_en</name>
+       <description>CNNx16_1 Power Domain Enable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_2_pwr_en</name>
+       <description>CNNx16_2 Power Domain Enable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_3_pwr_en</name>
+       <description>CNNx16_3 Power Domain Enable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REG1</name>
+     <description>Register 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>cnnx16_0_ram_en</name>
+       <description>CNNx16_0 RAM Power Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_1_ram_en</name>
+       <description>CNNx16_1 RAM Power Enable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_2_ram_en</name>
+       <description>CNNx16_2 RAM Power Enable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_3_ram_en</name>
+       <description>CNNx16_3 RAM Power Enable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REG2</name>
+     <description>Register 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>cnnx16_0_iso</name>
+       <description>CNNx16_0 Power Domain Isolation</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_1_iso</name>
+       <description>CNNx16_1 Power Domain Isolation</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_2_iso</name>
+       <description>CNNx16_2 Power Domain Isolation</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_3_iso</name>
+       <description>CNNx16_3 Power Domain Isolation</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REG3</name>
+     <description>Register 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>cnnx16_0_rst</name>
+       <description>CNNx16_0 Power Domain Reset</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_1_rst</name>
+       <description>CNNx16_1 Power Domain Reset</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_2_rst</name>
+       <description>CNNx16_2 Power Domain Reset</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_3_rst</name>
+       <description>CNNx16_3 Power Domain Reset</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCFR Global Control Function Register.-->
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x40008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN0</name>
+     <description>GPIO Function Enable Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_SET</name>
+     <description>GPIO Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_OUT bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_IN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTMODE</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTMODE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTPOL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTPOL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INEN</name>
+     <description>GPIO Input Enable</description>
+     <addressOffset>0x30</addressOffset>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_INTFL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WKEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DUALEDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DUALEDGE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL0</name>
+     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL0</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL1</name>
+     <description>GPIO Input Mode Config 2. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL1</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_SET</name>
+     <description>GPIO Alternate Function Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN2</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_SET</name>
+     <description>GPIO Alternate Function 2 Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN2 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_CLR</name>
+     <description>GPIO Wake Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN2 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x7C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HYSEN</name>
+     <description>GPIO Input Hysteresis Enable.</description>
+     <addressOffset>0xA8</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_HYSEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SRSEL</name>
+     <description>GPIO Slew Rate Enable Register.</description>
+     <addressOffset>0xAC</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_SRSEL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>FAST</name>
+         <description>Fast Slew Rate selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SLOW</name>
+         <description>Slow Slew Rate selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS0</name>
+     <description>GPIO Drive Strength  Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS0</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ld</name>
+         <description>GPIO port pin is in low-drive mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hd</name>
+         <description>GPIO port pin is in high-drive mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PS</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VSSEL</name>
+     <description>GPIO Voltage Select.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GPIO0 Individual I/O for each GPIO-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO1</name>
+   <description>Individual I/O for each GPIO 1</description>
+   <baseAddress>0x40009000</baseAddress>
+   <interrupt>
+    <name>GPIO1</name>
+    <description>GPIO1 IRQ</description>
+    <value>25</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO1 Individual I/O for each GPIO 1-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO2</name>
+   <description>Individual I/O for each GPIO 2</description>
+   <baseAddress>0x40080400</baseAddress>
+   <interrupt>
+    <name>GPIO2</name>
+    <description>GPIO2 IRQ</description>
+    <value>26</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO2 Individual I/O for each GPIO 2-->
+  <peripheral>
+   <name>I2C0</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>I2C</groupName>
+   <baseAddress>0x4001D000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2C0</name>
+    <description>I2C0 IRQ</description>
+    <value>13</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>I2C Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable I2C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable I2C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave_mode</name>
+         <description>Slave Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master_mode</name>
+         <description>Master Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_EN</name>
+       <description>General Call Address Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Ignore Gneral Call Address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Acknowledge general call address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_EN</name>
+       <description>Interactive Receive Mode.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interactive Receive Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interactive Receive Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_ACK</name>
+       <description>Data Acknowledge. This bit defines the acknowledge bit returned by the I2C receiver while IRXM = 1 HW forces ACK to 0 when IRXM = 0.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ack</name>
+         <description>return ACK (pulling SDA LOW).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>return NACK (leaving SDA HIGH).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_OUT</name>
+       <description>SCL Output. This bits control SCL output when SWOE =1.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_scl_low</name>
+         <description>Drive SCL low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_scl</name>
+         <description>Release SCL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDA_OUT</name>
+       <description>SDA Output. This bits control SDA output when SWOE = 1. </description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_sda_low</name>
+         <description>Drive SDA low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_sda</name>
+         <description>Release SDA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL</name>
+       <description>SCL status. This bit reflects the logic gate of SCL signal. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDA</name>
+       <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BB_MODE</name>
+       <description>Software Output Enable.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>outputs_disable</name>
+         <description>I2C Outputs SCLO and SDAO disabled. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputs_enable</name>
+         <description>I2C Outputs SCLO and SDAO enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read. This bit reflects the R/W bit of an address match (AMI = 1) or general call match (GCI = 1). This bit is valid 3 cycles after the relevant interrupt bit is set.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKSTR_DIS</name>
+       <description>This bit will disable slave clock stretching when set.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Slave clock stretching enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Slave clock stretching disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ONE_MST_MODE</name>
+       <description>SCL Push-Pull Mode. This bit controls whether SCL is operated in a the I2C standard open-drain mode, or in a non-standard push-pull mode where the Hi-Z output isreplaced with Drive-1. The non-standard mode should only be used when operating as a master and communicating with slaves that are guaranteed to never drive SCL low. </description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Standard open-drain operation:
+					drive low for 0, Hi-Z for 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Non-standard push-pull operation:
+					drive low for 0, drive high for 1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HS_EN</name>
+       <description>High speed mode enable</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>Bus Status.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>I2C Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>I2C Bus Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>RX empty.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX Full.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX Empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>TX Full.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_BUSY</name>
+       <description>Clock Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_actively_driving_scl_clock</name>
+         <description>Device not actively driving SCL clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>actively_driving_scl_clock</name>
+         <description>Device operating as master and actively driving SCL clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL0</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <name>INT_FL0_Done</name>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Interactive Receive Interrupt.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave General Call Address Match Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave Address Match Interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Receive Threshold Interrupt. This bit is automaticcaly cleared when RX_FIFO is below the threshold level.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. RX_FIFO equal or more bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>Transmit Threshold Interrupt. This bit is automaticcaly cleared when TX_FIFO is above the threshold level.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP Interrupt.</description>
+       <bitRange>[6:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Address Acknowledge Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Arbritation error Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>timeout Error Interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Address NACK Error Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Data NACK Error Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Do Not Respond Error Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Start Error Interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Stop Error Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>Transmit Lock Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN0</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when DONE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Description not available.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when RX_MODE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave mode general call address match received input enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when GEN_CTRL_ADDR = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave mode incoming address match interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when ADDR_MATCH = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Above Treshold Level Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Below Treshold Level Interrupt Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Stop Interrupt Enable</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when STOP = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Received Address ACK from Slave Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Master Mode Arbitration Lost Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>Timeout Error Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Master Mode Address NACK Received Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Master Mode Data NACK Received Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Slave Mode Do Not Respond Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Out of Sequence START condition detected interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Out of Sequence STOP condition detected interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>TX FIFO Locked Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL1</name>
+     <description>Interrupt Status Register 1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt. When operating as a slave receiver, this bit is set when you reach the first data bit and the RX FIFO and shift register are both full.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt. When operating as a slave transmitter, this bit is set when you reach the first data bit and the TX FIFO is empty and the master is still asking for more data (i.e the master hasn't sent a NACK yet).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Status Flag.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN1</name>
+     <description>Interrupt Staus Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOLEN</name>
+     <description>FIFO Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RX_DEPTH</name>
+       <description>Receive FIFO Length.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DEPTH</name>
+       <description>Transmit FIFO Length.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL0</name>
+     <description>Receive Control Register 0.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>DNR</name>
+       <description>Do Not Respond.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Always respond to address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>not_respond_rx_fifo_empty</name>
+         <description>Do not respond to address match when RX_FIFO is not empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Receive FIFO Flush. This bit is automatically cleared to 0 after the operation. Setting this bit to 1 will affect RX_FIFO status.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush RX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_LVL</name>
+       <description>Receive FIFO Threshold. These bits define the RX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL1</name>
+     <description>Receive Control Register 1.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Receive Count Bits. These bits define the number of bytes to be received in a transaction, except for the case RXCNT = 0. RXCNT = 0 means 256 bytes to be received in a transaction.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Receive FIFO Count. These bits reflect the number of byte in the RX_FIFO. These bits are flushed when I2CEN = 0.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL0</name>
+     <description>Transmit Control Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_MODE</name>
+       <description>Transmit FIFO Preaload Mode. Setting this bit will allow for high speed application to preload the transmit FIFO prior to Slave Address Match.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TX_READY_MODE</name>
+       <description>Transmit FIFO Ready Manual Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW control of I2CTXRDY enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW control of I2CTXRDY disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO General Call Address Match Auto Flush Disable.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Write Auto Flush Disable.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Read Auto Flush Disable.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NACK_FLUSH_DIS</name>
+       <description>TX FIFO received NACK Auto Flush Disable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Transmit FIFO Flush. This bit is automatically cleared to 0 after the operation.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush TX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_VAL</name>
+       <description>Transmit FIFO Threshold. These bits define the TX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL1</name>
+     <description>Transmit Control Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_RDY</name>
+       <description>Transmit FIFO Preload Ready.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Transmit FIFO Count. These bits reflect the number of bytes in the TX_FIFO.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MSTCTRL</name>
+     <description>Master Control Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Setting this bit to 1 will start a master transfer.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>RESTART</name>
+       <description>Setting this bit to 1 will generate a repeated START.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Setting this bit to 1 will generate a STOP condition.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>EX_ADDR_EN</name>
+       <description>Slave Extend Address Select.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKLO</name>
+     <description>Clock Low Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock low. In master mode, these bits define the SCL low period. In slave mode, these bits define the time SCL will be held low after data is outputted.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKHI</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>HI</name>
+       <description>Clock High. In master mode, these bits define the SCL high period.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HSCLK</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock Low. This field sets the Hs-Mode clock low count. In Slave mode, this is the time SCL is held low after data is output on SDA.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Clock High. This field sets the Hs-Mode clock high count. In Slave mode, this is the time SCL is held high after data is output on SDA</description>
+       <bitRange>[15:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TIMEOUT</name>
+     <description>Timeout Register</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_TO_VAL</name>
+       <description>Timeout</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>SLAVE_MULTI[%s]</name>
+     <description>Slave Address Register.</description>
+     <alternateRegister>SLAVE0</alternateRegister>
+     <addressOffset>0x4C</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Slave Address.</description>
+       <bitRange>[9:0]</bitRange>
+      </field>
+      <field>
+       <name>DIS</name>
+       <description>Slave Disable.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>EXT_ADDR_EN</name>
+       <description>Extended Address Select.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLAVE0</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE1</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x50</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE2</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x54</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE3</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x58</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2C0 Inter-Integrated Circuit.-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C1</name>
+   <description>Inter-Integrated Circuit. 1</description>
+   <baseAddress>0x4001E000</baseAddress>
+   <interrupt>
+    <name>I2C1</name>
+    <description>I2C1 IRQ</description>
+    <value>36</value>
+   </interrupt>
+  </peripheral>
+<!--I2C1 Inter-Integrated Circuit. 1-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C2</name>
+   <description>Inter-Integrated Circuit. 2</description>
+   <baseAddress>0x4001F000</baseAddress>
+   <interrupt>
+    <name>I2C2</name>
+    <description>I2C2 IRQ</description>
+    <value>62</value>
+   </interrupt>
+  </peripheral>
+<!--I2C2 Inter-Integrated Circuit. 2-->
+  <peripheral>
+   <name>I2S</name>
+   <description>Inter-IC Sound Interface.</description>
+   <groupName>I2S</groupName>
+   <baseAddress>0x40060000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2S</name>
+    <description>I2S IRQ</description>
+    <value>99</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0CH0</name>
+     <description>Global mode channel.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>LSB_FIRST</name>
+       <description>LSB Transmit Receive First.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_FILT</name>
+       <description>PDM Filter.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_EN</name>
+       <description>PDM Enable.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>USEDDR</name>
+       <description>DDR.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_INV</name>
+       <description>Invert PDM.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_MODE</name>
+       <description>SCK Select.</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>WS_POL</name>
+       <description>WS polarity select. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB_LOC</name>
+       <description>MSB location. </description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ALIGN</name>
+       <description>Align to MSB or LSB.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EXT_SEL</name>
+       <description>External SCK/WS selection.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>STEREO</name>
+       <description>Stereo mode of I2S.</description>
+       <bitRange>[13:12]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WSIZE</name>
+       <description>Data size when write to FIFO.</description>
+       <bitRange>[15:14]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable. </description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable. </description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Flushes the TX/RX FIFO buffer. </description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RST</name>
+       <description>Write 1 to reset channel. </description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_LSB</name>
+       <description>Bit Field Control. </description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>depth of receive FIFO for threshold interrupt generation. </description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1CH0</name>
+     <description>Local channel Setup.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>BITS_WORD</name>
+       <description>I2S word length.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>I2S clock enable.</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SMP_SIZE</name>
+       <description>I2S sample size length.</description>
+       <bitRange>[13:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ADJUST</name>
+       <description>LSB/MSB Justify.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>I2S clock frequency divisor.</description>
+       <bitRange>[31:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FILTCH0</name>
+     <description>Filter.</description>
+     <addressOffset>0x20</addressOffset>
+    </register>
+    <register>
+     <name>DMACH0</name>
+     <description>DMA Control.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DMA_TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger.</description>
+       <bitRange>[6:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA channel enable.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_THD_VAL</name>
+       <description>RX FIFO Level DMA Trigger.</description>
+       <bitRange>[14:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA channel enable.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Number of data word in the TX FIFO.</description>
+       <bitRange>[23:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Number of data word in the RX FIFO.</description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOCH0</name>
+     <description>I2S Fifo.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>ISR Status.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Status for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Status for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Status for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Status for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Enable for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Enable for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Enable for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Enable for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EXTSETUP</name>
+     <description>Ext Control.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>EXT_BITS_WORD</name>
+       <description>Word Length for ch_mode.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wakeup Enable.</description>
+     <addressOffset>0x5C</addressOffset>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wakeup Flags.</description>
+     <addressOffset>0x60</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2S Inter-IC Sound Interface.-->
+  <peripheral>
+   <name>ICC0</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x4002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x800</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>INFO</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SZ</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCH</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEM</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ICC0 Instruction Cache Controller Registers-->
+  <peripheral>
+   <name>LPCMP</name>
+   <description>Low Power Comparator</description>
+   <baseAddress>0x40088000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>LPCMP</name>
+    <description>Low Power Comparato</description>
+    <value>103</value>
+   </interrupt>
+   <registers>
+    <register>
+     <dim>3</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CTRL[%s]</name>
+     <description>Comparator Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Comparator Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>POL</name>
+       <description>Polarity Select</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTEN</name>
+       <description>IRQ Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUT</name>
+       <description>Raw Compartor Input.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTFL</name>
+       <description>IRQ Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--LPCMP Low Power Comparator-->
+  <peripheral>
+   <name>LPGCR</name>
+   <description>Low Power Global Control.</description>
+   <baseAddress>0x40080000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RST</name>
+     <description>Low Power Reset Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO2</name>
+       <description>Low Power GPIO 2 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>WDT1</name>
+       <description>Low Power Watchdog Timer 1 Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR4</name>
+       <description>Low Power Timer 4 Reset.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR5</name>
+       <description>Low Power Timer 5 Reset.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>UART3</name>
+       <description>Low Power UART 3 Reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>LPCOMP</name>
+       <description>Low Power Comparator Reset.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS</name>
+     <description>Low Power Peripheral Clock Disable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO2</name>
+       <description>Low Power GPIO 2 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>WDT1</name>
+       <description>Low Power Watchdog 1 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR4</name>
+       <description>Low Power Timer 4 Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR5</name>
+       <description>Low Power Timer 5 Clock Disable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>UART3</name>
+       <description>Low Power UART 3 Clock Disable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>LPCOMP</name>
+       <description>Low Power Comparator Clock Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--LPGCR Low Power Global Control.-->
+  <peripheral>
+   <name>MCR</name>
+   <description>Misc Control.</description>
+   <baseAddress>0x40006C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>ECCEN</name>
+     <description>ECC Enable Register</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>ECC System RAM0 Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPO_MTRIM</name>
+     <description>IPO Manual Register</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>MTRIM</name>
+       <description>Manual Trim Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>TRIM_RANGE</name>
+       <description>Trim Range Select.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>Output Enable Register</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>SQWOUT_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PDOWN_OUT_EN</name>
+       <description>Power Down Output Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP_CTRL</name>
+     <description>Comparator Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Comparator Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>POL</name>
+       <description>Polarity Select</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INT_EN</name>
+       <description>IRQ Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUT</name>
+       <description>Comparator Output State.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INT_FL</name>
+       <description>IRQ Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Miscellaneous Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>INRO_EN</name>
+       <description>INRO Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>ERTCO Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SIMO_CLKSCL_EN</name>
+       <description>SIMO Clock Scaling Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SIMO_RSTD</name>
+       <description>SIMO System Reset Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO3_CTRL</name>
+     <description>GPIO3 Pin Control Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>P30_DO</name>
+       <description>GPIO3 Pin 0 Data Output.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P30_OE</name>
+       <description>GPIO3 Pin 0 Output Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P30_PE</name>
+       <description>GPIO3 Pin 0 Pull-up Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P30_IN</name>
+       <description>GPIO3 Pin 0 Input Status.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_DO</name>
+       <description>GPIO3 Pin 1 Data Output.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_OE</name>
+       <description>GPIO3 Pin 1 Output Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_PE</name>
+       <description>GPIO3 Pin 1 Pull-up Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_IN</name>
+       <description>GPIO3 Pin 1 Input Status.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--MCR Misc Control.-->
+  <peripheral>
+   <name>OWM</name>
+   <description>1-Wire Master Interface.</description>
+   <baseAddress>0x4003D000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>OneWire</name>
+    <value>67</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CFG</name>
+     <description>1-Wire Master Configuration.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>long_line_mode</name>
+       <description>Long Line Mode.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>force_pres_det</name>
+       <description>Force Line During Presence Detect.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_en</name>
+       <description>Bit Bang Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_mode</name>
+       <description>Provide an extra output control to control an external pullup.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_enable</name>
+       <description>Enable External Pullup.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>single_bit_mode</name>
+       <description>Enable Single Bit TX/RX Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>overdrive</name>
+       <description>Enables overdrive speed for 1-Wire operations.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>int_pullup_enable</name>
+       <description>Enable intenral pullup.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_DIV_1US</name>
+     <description>1-Wire Master Clock Divisor.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>divisor</name>
+       <description>Clock Divisor for 1Mhz.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL_STAT</name>
+     <description>1-Wire Master Control/Status.</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>start_ow_reset</name>
+       <description>Start OW Reset.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>sra_mode</name>
+       <description>SRA Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_oe</name>
+       <description>Bit Bang Output Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ow_input</name>
+       <description>OW Input State.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>od_spec_mode</name>
+       <description>Overdrive Spec Mode.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>presence_detect</name>
+       <description>Presence Pulse Detected.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>1-Wire Master Data Buffer.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>tx_rx</name>
+       <description>TX/RX Buffer.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>1-Wire Master Interrupt Flags.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>TX Data Empty Interrupt Flag.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>RX Data Ready Interrupt Flag</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Flag.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Flag.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>1-Wire Master Interrupt Enables.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>Tx Data Empty Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>Rx Data Ready Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Enable.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--OWM 1-Wire Master Interface.-->
+  <peripheral>
+   <name>PT</name>
+   <description>Pulse Train</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C020</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0010</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RATE_LENGTH</name>
+     <description>Pulse Train Configuration</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>rate_control</name>
+       <description>Pulse Train Enable and Rate Control. Set to 0 to disable the Pulse Train.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>27</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>mode</name>
+       <description>Pulse Train Output Mode/Train Length</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>32_BIT</name>
+         <description>Pulse train, 32 bit pattern.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SQUARE_WAVE</name>
+         <description>Square wave mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_BIT</name>
+         <description>Pulse train, 2 bit pattern.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_BIT</name>
+         <description>Pulse train, 3 bit pattern.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_BIT</name>
+         <description>Pulse train, 4 bit pattern.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5_BIT</name>
+         <description>Pulse train, 5 bit pattern.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_BIT</name>
+         <description>Pulse train, 6 bit pattern.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7_BIT</name>
+         <description>Pulse train, 7 bit pattern.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_BIT</name>
+         <description>Pulse train, 8 bit pattern.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9_BIT</name>
+         <description>Pulse train, 9 bit pattern.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_BIT</name>
+         <description>Pulse train, 10 bit pattern.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11_BIT</name>
+         <description>Pulse train, 11 bit pattern.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_BIT</name>
+         <description>Pulse train, 12 bit pattern.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13_BIT</name>
+         <description>Pulse train, 13 bit pattern.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14_BIT</name>
+         <description>Pulse train, 14 bit pattern.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15_BIT</name>
+         <description>Pulse train, 15 bit pattern.</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_BIT</name>
+         <description>Pulse train, 16 bit pattern.</description>
+         <value>16</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>17_BIT</name>
+         <description>Pulse train, 17 bit pattern.</description>
+         <value>17</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>18_BIT</name>
+         <description>Pulse train, 18 bit pattern.</description>
+         <value>18</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>19_BIT</name>
+         <description>Pulse train, 19 bit pattern.</description>
+         <value>19</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>20_BIT</name>
+         <description>Pulse train, 20 bit pattern.</description>
+         <value>20</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>21_BIT</name>
+         <description>Pulse train, 21 bit pattern.</description>
+         <value>21</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>22_BIT</name>
+         <description>Pulse train, 22 bit pattern.</description>
+         <value>22</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>23_BIT</name>
+         <description>Pulse train, 23 bit pattern.</description>
+         <value>23</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>24_BIT</name>
+         <description>Pulse train, 24 bit pattern.</description>
+         <value>24</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>25_BIT</name>
+         <description>Pulse train, 25 bit pattern.</description>
+         <value>25</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>26_BIT</name>
+         <description>Pulse train, 26 bit pattern.</description>
+         <value>26</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>27_BIT</name>
+         <description>Pulse train, 27 bit pattern.</description>
+         <value>27</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>28_BIT</name>
+         <description>Pulse train, 28 bit pattern.</description>
+         <value>28</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>29_BIT</name>
+         <description>Pulse train, 29 bit pattern.</description>
+         <value>29</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30_BIT</name>
+         <description>Pulse train, 30 bit pattern.</description>
+         <value>30</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>31_BIT</name>
+         <description>Pulse train, 31 bit pattern.</description>
+         <value>31</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRAIN</name>
+     <description>Write the repeating bit pattern that is shifted out, LSB first, when configured in Pulse Train mode. See PT_RATE_LENGTH.mode for setting the length.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>LOOP</name>
+     <description>Pulse Train Loop Count</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>count</name>
+       <description>Number of loops for this pulse train to repeat.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>delay</name>
+       <description>Delay between loops of the Pulse Train in PT Peripheral Clock cycles</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>12</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESTART</name>
+     <description> Pulse Train Auto-Restart Configuration.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt_x_select</name>
+       <description>Auto-Restart PT X Select</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_x_loop_exit</name>
+       <description>Enable Auto-Restart on PT X Loop Exit</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt_y_select</name>
+       <description>Auto-Restart PT Y Select</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_y_loop_exit</name>
+       <description>Enable Auto-Restart on PT Y Loop Exit</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PT Pulse Train-->
+  <peripheral derivedFrom="PT">
+   <name>PT1</name>
+   <description>Pulse Train 1</description>
+   <baseAddress>0x4003C030</baseAddress>
+  </peripheral>
+<!--PT1 Pulse Train 1-->
+  <peripheral derivedFrom="PT">
+   <name>PT2</name>
+   <description>Pulse Train 2</description>
+   <baseAddress>0x4003C040</baseAddress>
+  </peripheral>
+<!--PT2 Pulse Train 2-->
+  <peripheral derivedFrom="PT">
+   <name>PT3</name>
+   <description>Pulse Train 3</description>
+   <baseAddress>0x4003C050</baseAddress>
+  </peripheral>
+<!--PT3 Pulse Train 3-->
+  <peripheral>
+   <name>PTG</name>
+   <description>Pulse Train Generation</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0020</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>PT</name>
+    <description>Pulse Train IRQ</description>
+    <value>59</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ENABLE</name>
+     <description>Global Enable/Disable Controls for All Pulse Trains</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Enable/Disable control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Enable/Disable control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Enable/Disable control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Enable/Disable control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESYNC</name>
+     <description>Global Resync (All Pulse Trains) Control</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Resync control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Resync control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Resync control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Resync control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Pulse Train Interrupt Flags</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Pulse Train Interrupt Enable/Disable</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_EN</name>
+     <description>Pulse Train Global Safe Enable.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_DIS</name>
+     <description>Pulse Train Global Safe Disable.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PTG Pulse Train Generation-->
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x40006800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>LPCN</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAMRET0</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 0 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET1</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 1 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET2</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 2 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET3</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPMCLKSEL</name>
+       <description>Low Power Mode APB Clock Select.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPMFAST</name>
+       <description>Low Power Mode Clock Select.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BG_DIS</name>
+       <description>Bandgap OFF. This controls the System Bandgap in DeepSleep mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>Bandgap is always ON.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>Bandgap is OFF in DeepSleep mode (default).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LPWKST_CLR</name>
+       <description>Low Power Wakeup Status Register Clear</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST0</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO0.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN0</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register derivedFrom="LPWKST0">
+     <name>LPWKST1</name>
+     <description>Low Power I/O Wakeup Status Register 1. This register indicates the low power wakeup status for GPIO1.</description>
+     <addressOffset>0x0C</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN1</name>
+     <description>Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup functionality for GPIO1.</description>
+     <addressOffset>0x10</addressOffset>
+    </register>
+    <register derivedFrom="LPWKST0">
+     <name>LPWKST2</name>
+     <description>Low Power I/O Wakeup Status Register 2. This register indicates the low power wakeup status for GPIO2.</description>
+     <addressOffset>0x14</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN2</name>
+     <description>Low Power I/O Wakeup Enable Register 2. This register enables low power wakeup functionality for GPIO2.</description>
+     <addressOffset>0x18</addressOffset>
+    </register>
+    <register derivedFrom="LPWKST0">
+     <name>LPWKST3</name>
+     <description>Low Power I/O Wakeup Status Register 3. This register indicates the low power wakeup status for GPIO3.</description>
+     <addressOffset>0x1C</addressOffset>
+    </register>
+    <register derivedFrom="LPWKEN0">
+     <name>LPWKEN3</name>
+     <description>Low Power I/O Wakeup Enable Register 3. This register enables low power wakeup functionality for GPIO3.</description>
+     <addressOffset>0x20</addressOffset>
+    </register>
+    <register>
+     <name>LPPWST</name>
+     <description>Low Power Peripheral Wakeup Status Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>AINCOMP0</name>
+       <description>Analog Input Comparator Wakeup Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BACKUP</name>
+       <description>Backup Mode Wakeup Flag.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESET</name>
+       <description>Reset Detected Wakeup Flag.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWEN</name>
+     <description>Low Power Peripheral Wakeup Enable Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>AINCOMP0</name>
+       <description> AINCOMP0 Wakeup Enable. This bit allows wakeup from the AINCOMP0.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WDT0</name>
+       <description> WDT0 Wakeup Enable. This bit allows wakeup from the WDT0.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WDT1</name>
+       <description> WDT1 Wakeup Enable. This bit allows wakeup from the WDT1.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CPU1</name>
+       <description> CPU1 Wakeup Enable. This bit allows wakeup from the CPU1.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR0</name>
+       <description> TMR0 Wakeup Enable. This bit allows wakeup from the TMR0.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR1</name>
+       <description> TMR1 Wakeup Enable. This bit allows wakeup from the TMR1.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR2</name>
+       <description> TMR2 Wakeup Enable. This bit allows wakeup from the TMR2.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR3</name>
+       <description> TMR3 Wakeup Enable. This bit allows wakeup from the TMR3.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR4</name>
+       <description> TMR4 Wakeup Enable. This bit allows wakeup from the TMR4.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR5</name>
+       <description> TMR5 Wakeup Enable. This bit allows wakeup from the TMR5.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART0</name>
+       <description> UART0 Wakeup Enable. This bit allows wakeup from the UART0.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART1</name>
+       <description> UART1 Wakeup Enable. This bit allows wakeup from the UART1.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART2</name>
+       <description> UART2 Wakeup Enable. This bit allows wakeup from the UART2.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART3</name>
+       <description> UART3 Wakeup Enable. This bit allows wakeup from the UART3.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C0</name>
+       <description> I2C0 Wakeup Enable. This bit allows wakeup from the I2C0.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C1</name>
+       <description> I2C1 Wakeup Enable. This bit allows wakeup from the I2C1.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C2</name>
+       <description> I2C2 Wakeup Enable. This bit allows wakeup from the I2C2.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2S</name>
+       <description> I2S Wakeup Enable. This bit allows wakeup from the I2S.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SPI1</name>
+       <description> SPI1 Wakeup Enable. This bit allows wakeup from the SPI1.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPCMP</name>
+       <description> LPCMP Wakeup Enable. This bit allows wakeup from the LPCMP.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GP0</name>
+     <description>General Purpose Register 0</description>
+     <addressOffset>0x48</addressOffset>
+    </register>
+    <register>
+     <name>GP1</name>
+     <description>General Purpose Register 1</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--PWRSEQ Power Sequencer / Low Power Control Register.-->
+  <peripheral>
+   <name>RTC</name>
+   <description>Real Time Clock and Alarm.</description>
+   <baseAddress>0x40006000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>RTC</name>
+    <description>RTC interrupt.</description>
+    <value>3</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC</name>
+       <description>Sub-Seconds Counter (12-bit).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TODA</name>
+     <description>Time-of-day Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-day Alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSECA</name>
+     <description>RTC sub-second alarm.  This register contains the reload value for the sub-second alarm.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>This register contains the reload value for the sub-second alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>RTC Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Real Time Clock Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM_IE</name>
+       <description>Alarm Time-of-Day Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM_IE</name>
+       <description>Alarm Sub-second Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>RTC Busy. This bit is set to 1 by hardware when changes to RTC registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>RTC Ready. This bit is set to 1 by hardware when the RTC count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the RTC count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY_IE</name>
+       <description>RTC Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-Day Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>Sub-second Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_SEL</name>
+       <description>Frequency Output Selection. When SQE=1, these bits specify the output frequency on the SQW pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq1Hz</name>
+         <description>1 Hz (Compensated).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq512Hz</name>
+         <description>512 Hz (Compensated).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq4KHz</name>
+         <description>4 KHz.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clkDiv8</name>
+         <description>RTC Input Clock / 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_EN</name>
+       <description>Asynchronous Counter Read Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_EN</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical RTC bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIM</name>
+     <description>RTC Trim Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>RTC Trim. This register contains the 2's complement value that specifies the trim resolution. Each increment or decrement of the bit adds or subtracts 1ppm at each 4KHz clock value, with a maximum correction of +/- 127ppm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VRTC_TMR</name>
+       <description>VBAT Timer Value. When RTC is running off of VBAT, this field is incremented every 32 seconds.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>RTC Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>FILTER_EN</name>
+       <description>Enables analog deglitch filter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_SEL</name>
+       <description>If IBIAS_EN is 1, selects 4x,2x mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HYST_EN</name>
+       <description>Enables high current hysteresis buffer.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_EN</name>
+       <description>Enables higher 4x,2x current modes.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYPASS</name>
+       <description>RTC Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SQW_32K</name>
+       <description>RTC 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--RTC Real Time Clock and Alarm.-->
+  <peripheral>
+   <name>SEMA</name>
+   <description>The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.</description>
+   <baseAddress>0x4003E000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>SEMAPHORES[%s]</name>
+     <description>Read to test and set, returns prior value. Write 0 to clear semaphore.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>sema</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>irq0</name>
+     <description>Semaphore IRQ0 register.</description>
+     <addressOffset>0x40</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>en</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cm4_irq</name>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>mail0</name>
+     <description>Semaphore Mailbox 0 register.</description>
+     <addressOffset>0x44</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>data</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>irq1</name>
+     <description>Semaphore IRQ1 register.</description>
+     <addressOffset>0x48</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>en</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>rv32_irq</name>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>mail1</name>
+     <description>Semaphore Mailbox 1 register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>data</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>status</name>
+     <description>Semaphore status bits. 0 indicates the semaphore is free, 1 indicates taken.</description>
+     <addressOffset>0x100</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>status0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SEMA The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.-->
+  <peripheral>
+   <name>SIMO</name>
+   <description>Single Inductor Multiple Output Switching Converter</description>
+   <baseAddress>0x40004400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>VREGO_A</name>
+     <description>Buck Voltage Regulator A Control Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETA</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGEA</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGO_B</name>
+     <description>Buck Voltage Regulator B Control Register</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETB</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGEB</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGO_C</name>
+     <description>Buck Voltage Regulator C Control Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETC</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGEC</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGO_D</name>
+     <description>Buck Voltage Regulator D Control Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETD</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGED</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPKA</name>
+     <description>High Side FET Peak Current VREGO_A/VREGO_B Register</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IPKSETA</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IPKSETB</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPKB</name>
+     <description>High Side FET Peak Current VREGO_C/VREGO_D Register</description>
+     <addressOffset>0x0018</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IPKSETC</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IPKSETD</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAXTON</name>
+     <description>Maximum High Side FET Time On Register</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TONSET</name>
+       <description>Sets the maximum on time for the high side FET, each increment represents 500ns</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_A</name>
+     <description>Buck Cycle Count VREGO_A Register</description>
+     <addressOffset>0x0020</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADA</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_B</name>
+     <description>Buck Cycle Count VREGO_B Register</description>
+     <addressOffset>0x0024</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADB</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_C</name>
+     <description>Buck Cycle Count VREGO_C Register</description>
+     <addressOffset>0x0028</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADC</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_D</name>
+     <description>Buck Cycle Count VREGO_D Register</description>
+     <addressOffset>0x002C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADD</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_A</name>
+     <description>Buck Cycle Count Alert VERGO_A Register</description>
+     <addressOffset>0x0030</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRA</name>
+       <description>Threshold for ILOADA to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_B</name>
+     <description>Buck Cycle Count Alert VERGO_B Register</description>
+     <addressOffset>0x0034</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRB</name>
+       <description>Threshold for ILOADB to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_C</name>
+     <description>Buck Cycle Count Alert VERGO_C Register</description>
+     <addressOffset>0x0038</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRC</name>
+       <description>Threshold for ILOADC to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_D</name>
+     <description>Buck Cycle Count Alert VERGO_D Register</description>
+     <addressOffset>0x003C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRD</name>
+       <description>Threshold for ILOADD to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_OUT_READY</name>
+     <description>Buck Regulator Output Ready Register</description>
+     <addressOffset>0x0040</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUCKOUTRDYA</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notrdy</name>
+         <description>Output voltage not in range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rdy</name>
+         <description>Output voltage in range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="BUCKOUTRDYA">
+       <name>BUCKOUTRDYB</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BUCKOUTRDYA">
+       <name>BUCKOUTRDYC</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BUCKOUTRDYA">
+       <name>BUCKOUTRDYD</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_A</name>
+     <description>Zero Cross Calibration VERGO_A Register</description>
+     <addressOffset>0x0044</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALA</name>
+       <description>Zero Cross Calibrartion Value VREGO_A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_B</name>
+     <description>Zero Cross Calibration VERGO_B Register</description>
+     <addressOffset>0x0048</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALB</name>
+       <description>Zero Cross Calibrartion Value VREGO_B</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_C</name>
+     <description>Zero Cross Calibration VERGO_C Register</description>
+     <addressOffset>0x004C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALC</name>
+       <description>Zero Cross Calibrartion Value VREGO_C</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_D</name>
+     <description>Zero Cross Calibration VERGO_D Register</description>
+     <addressOffset>0x0050</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALD</name>
+       <description>Zero Cross Calibrartion Value VREGO_D</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIMO Single Inductor Multiple Output Switching Converter-->
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x40000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SISTAT</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>MAGIC</name>
+       <description>Magic Word Validation.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>magicNotSet</name>
+         <description>Magic word was not set (OTP has not been initialized properly).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>magicSet</name>
+         <description>Magic word was set (OTP contains valid settings).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRCERR</name>
+       <description>CRC Error Status.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No CRC errors occurred during the read of the OTP memory block.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>A CRC error occurred while reading the OTP. The address of the failure location in the OTP memory is stored in the ERRADDR register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADDR</name>
+     <description>Read-only field set by the SIB block if a CRC error occurs during the read of the OTP memory. Contains the failing address in OTP memory (when CRCERR equals 1).</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ERRADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FSTAT</name>
+     <description>funcstat register.</description>
+     <addressOffset>0x100</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>FPU</name>
+       <description>FPU Function.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADC</name>
+       <description>10-bit Sigma Delta ADC.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SMPHR</name>
+       <description>SMPHR function.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFSTAT</name>
+     <description>Security function status register.</description>
+     <addressOffset>0x104</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TRNG</name>
+       <description> TRNG Function.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AES</name>
+       <description>AES Block.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIR System Initialization Registers.-->
+  <peripheral>
+   <name>SPI0</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x400BE000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>56</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FIFO32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>FIFO16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>FIFO8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Start Select Control. Used in Master mode to control the behavior of the Slave Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DEASSERT</name>
+         <description>SPI De-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ASSERT</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_ACTIVE</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3</name>
+         <description>SS3 is selected.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Rising_Edge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Falling_Edge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>16</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1</name>
+         <description>1 bits per character.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2</name>
+         <description>2 bits per character.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3</name>
+         <description>3 bits per character.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4</name>
+         <description>4 bits per character.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5</name>
+         <description>5 bits per character.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6</name>
+         <description>6 bits per character.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7</name>
+         <description>7 bits per character.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8</name>
+         <description>8 bits per character.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9</name>
+         <description>9 bits per character.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10</name>
+         <description>10 bits per character.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11</name>
+         <description>11 bits per character.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12</name>
+         <description>12 bits per character.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13</name>
+         <description>13 bits per character.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14</name>
+         <description>14 bits per character.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15</name>
+         <description>15 bits per character.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin (s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_POL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3_high</name>
+         <description>SS3 active high.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSTIME</name>
+     <description>Register for controlling SPI peripheral/Slave Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PRE</name>
+       <description>Slave Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POST</name>
+       <description>Slave Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPI0 SPI peripheral.-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI1</name>
+   <description>SPI peripheral. 1</description>
+   <baseAddress>0x40046000</baseAddress>
+   <interrupt>
+    <name>SPI1</name>
+    <description>SPI1 IRQ</description>
+    <value>32</value>
+   </interrupt>
+  </peripheral>
+<!--SPI1 SPI peripheral. 1-->
+  <peripheral>
+   <name>TMR</name>
+   <description>Low-Power Configurable Timer</description>
+   <baseAddress>0x40010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR</name>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Timer Counter Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>The current count value for the timer. This field increments as the timer counts.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Timer Compare Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>Timer PWM Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PWM</name>
+       <description>Timer PWM Match:
+                In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
+                In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Timer Interrupt Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ_A</name>
+       <description>Interrupt Flag for Timer A.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_A</name>
+       <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_A</name>
+       <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IRQ_B</name>
+       <description>Interrupt Flag for Timer B.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_B</name>
+       <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_B</name>
+       <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MODE_A</name>
+       <description>Mode Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_A</name>
+       <description>Clock Divider Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_A</name>
+       <description>Timer Polarity for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_A</name>
+       <description>PWM Synchronization Mode for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_A</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_A</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_A</name>
+       <description>PWM Phase A-Prime Output Disable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_A</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Write 1 to Enable CLK_TMR for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_A</name>
+       <description>Enable for Timer A</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MODE_B</name>
+       <description>Mode Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_B</name>
+       <description>Clock Divider Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_B</name>
+       <description>Timer Polarity for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_B</name>
+       <description>PWM Synchronization Mode for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_B</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_B</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_B</name>
+       <description>PWM Phase A-Prime Output Disable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_B</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Write 1 to Enable CLK_TMR for Timer B</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_B</name>
+       <description>Enable for Timer B</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO_A</name>
+       <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_A</name>
+       <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>LO_B</name>
+       <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_B</name>
+       <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Timer Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKSEL_A</name>
+       <description>Timer Clock Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Timer A Enable Status</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_A</name>
+       <description>CLK_TMR Ready Flag for Timer A</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_A</name>
+       <description>Event Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_A</name>
+       <description>Negative Edge Trigger for Event for Timer A</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_A</name>
+       <description>Interrupt Enable for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_A</name>
+       <description>Capture Event Select for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_A</name>
+       <description>Software Capture Event for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_A</name>
+       <description>Wake-Up Enable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTEN_A</name>
+       <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTBEN_A</name>
+       <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads of the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKSEL_B</name>
+       <description>Timer Clock Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Timer B Enable Status</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_B</name>
+       <description>CLK_TMR Ready Flag for Timer B</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_B</name>
+       <description>Event Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_B</name>
+       <description>Negative Edge Trigger for Event for Timer B</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_B</name>
+       <description>Interrupt Enable for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_B</name>
+       <description>Capture Event Select for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_B</name>
+       <description>Software Capture Event for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_B</name>
+       <description>Wake-Up Enable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CASCADE</name>
+       <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Timer Wakeup Status Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>A</name>
+       <description>Wake-Up Flag for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>B</name>
+       <description>Wake-Up Flag for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TMR Low-Power Configurable Timer-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR1</name>
+   <description>Low-Power Configurable Timer 1</description>
+   <baseAddress>0x40011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+<!--TMR1 Low-Power Configurable Timer 1-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR2</name>
+   <description>Low-Power Configurable Timer 2</description>
+   <baseAddress>0x40012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+<!--TMR2 Low-Power Configurable Timer 2-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR3</name>
+   <description>Low-Power Configurable Timer 3</description>
+   <baseAddress>0x40013000</baseAddress>
+   <interrupt>
+    <name>TMR3</name>
+    <description>TMR3 IRQ</description>
+    <value>8</value>
+   </interrupt>
+  </peripheral>
+<!--TMR3 Low-Power Configurable Timer 3-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR4</name>
+   <description>Low-Power Configurable Timer 4</description>
+   <baseAddress>0x40080C00</baseAddress>
+   <interrupt>
+    <name>TMR4</name>
+    <description>TMR4 IRQ</description>
+    <value>9</value>
+   </interrupt>
+  </peripheral>
+<!--TMR4 Low-Power Configurable Timer 4-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR5</name>
+   <description>Low-Power Configurable Timer 5</description>
+   <baseAddress>0x40081000</baseAddress>
+   <interrupt>
+    <name>TMR5</name>
+    <description>TMR5 IRQ</description>
+    <value>10</value>
+   </interrupt>
+  </peripheral>
+<!--TMR5 Low-Power Configurable Timer 5-->
+  <peripheral>
+   <name>TRIMSIR</name>
+   <description>Trim System Initilazation Registers</description>
+   <baseAddress>0x40005400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RTC</name>
+     <description>RTC Trim System Initialization Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>X1TRIM</name>
+       <description>RTC X1 Trim.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>X2TRIM</name>
+       <description>RTC X2 Trim.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SIMO</name>
+     <description>SIMO Trim System Initialization Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>SIMO Clock Divide.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV16</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV32</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV64</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV128</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPOLO</name>
+     <description>IPO Low Trim System Initialization Register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>IPO_LIMITLO</name>
+       <description>IPO Low Limit Trim.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Control Trim System Initialization Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>VDDA_LIMITLO</name>
+       <description>VDDA Low Trim Limit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VDDA_LIMITHI</name>
+       <description>VDDA High Trim Limit.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>IPO_LIMITHI</name>
+       <description>IPO High Trim Limit.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>INRO_SEL</name>
+       <description>INRO Clock Select.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>8KHZ</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16KHZ</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30KHZ</name>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INRO_TRIM</name>
+       <description>INRO Clock Trim.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INRO</name>
+     <description>RTC Trim System Initialization Register.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>TRIM16K</name>
+       <description>INRO 16KHz Trim.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>TRIM30K</name>
+       <description>INRO 30KHz Trim.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>LPCLKSEL</name>
+       <description>INRO Low Power Mode Clock Select.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>8KHZ</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16KHZ</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30KHZ</name>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRIMSIR Trim System Initilazation Registers-->
+  <peripheral>
+   <name>TRNG</name>
+   <description>Random Number Generator.</description>
+   <baseAddress>0x4004D000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TRNG</name>
+    <description>TRNG interrupt.</description>
+    <value>4</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>TRNG Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000003</resetValue>
+     <fields>
+      <field>
+       <name>RND_IE</name>
+       <description>To enable IRQ generation when a new 32-bit Random number is ready.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEYGEN</name>
+       <description>AES Key Generate. When enabled, the key for securing NVSRAM is generated and transferred to the secure key register automatically without user visibility or intervention. This bit is cleared by hardware once the key has been transferred to the secure key register.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>To wipe the Battery Backed key.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>RDY</name>
+       <description>32-bit random data is ready to read from TRNG_DATA register. Reading TRNG_DATA when RND_RDY=0 will return all 0's. IRQ is generated when RND_RDY=1 if TRNG_CN.RND_IRQ_EN=1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Busy</name>
+         <description>TRNG Busy</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Ready</name>
+         <description>32 bit random data is ready</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data. The content of this register is valid only when RNG_IS =1. When TNRG is disabled, read returns 0x0000 0000.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRNG Random Number Generator.-->
+  <peripheral>
+   <name>UART</name>
+   <description>UART Low Power Registers</description>
+   <baseAddress>0x40042000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control register</description>
+     <addressOffset>0x0000</addressOffset>
+     <fields>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>This field specifies the depth of receive FIFO for interrupt generation (value 0 and &gt; 16 are ignored) </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EN</name>
+       <description>Parity Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EO</name>
+       <description>when PAREN=1 selects odd or even parity odd is 1 even is 0</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_MD</name>
+       <description>Selects parity based on 1s or 0s count (when PAREN=1) </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_DIS</name>
+       <description>CTS Sampling Disable </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Flushes the TX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Flushes the RX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHAR_SIZE</name>
+       <description>Selects UART character size</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5bits</name>
+         <description>5 bits</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6bits</name>
+         <description>6 bits</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7bits</name>
+         <description>7 bits</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8bits</name>
+         <description>8 bits</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPBITS</name>
+       <description>Selects the number of stop bits that will be generated</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HFC_EN</name>
+       <description>Enables/disables hardware flow control</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RTSDC</name>
+       <description>Hardware Flow Control RTS Mode</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKEN</name>
+       <description>Baud clock enable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKSRC</name>
+       <description>To select the UART clock source for the UART engine (except APB registers). Secondary clock (used for baud rate generator) can be asynchronous from APB clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Peripheral_Clock</name>
+         <description>apb clock</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>External_Clock</name>
+         <description>Clock 1</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK2</name>
+         <description>Clock 2</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK3</name>
+         <description>Clock 3</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPFE_EN</name>
+       <description>Data/Parity bit frame error detection enable</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKRDY</name>
+       <description>Baud clock Ready read only bit</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UCAGM</name>
+       <description>UART Clock Auto Gating mode</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FDM</name>
+       <description>Fractional Division Mode</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DESM</name>
+       <description>RX Dual Edge Sampling Mode</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TX_BUSY</name>
+       <description>Read-only flag indicating the UART transmit status</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_BUSY</name>
+       <description>Read-only flag indicating the UART receiver status</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Indicates the number of bytes currently in the RX FIFO (0-RX FIFO_ELTS) </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Indicates the number of bytes currently in the TX FIFO (0-TX FIFO_ELTS) </description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interrupt Enable control register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Enable Interrupt For RX Frame Error</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Enable Interrupt For RX Parity Error</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Enable Interrupt For CTS signal change Error</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Enable Interrupt For RX FIFO Overrun Error</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Enable Interrupt For RX FIFO reaches the number of bytes configured by RXTHD</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Enable Interrupt For TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Enable Interrupt For TX FIFO has half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Interrupt status flags Control register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Flag for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Flag for RX Parity Error interrupt</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Flag for CTS signal change interrupt (hardware flow control disabled) </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Flag for RX FIFO Overrun interrupt</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Flag for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Flag for interrupt when TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Flag for interrupt when TX FIFO is half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Clock Divider register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Baud rate divisor value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSR</name>
+     <description>Over Sampling Rate register</description>
+     <addressOffset>0x0014</addressOffset>
+     <fields>
+      <field>
+       <name>OSR</name>
+       <description>OSR</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXPEEK</name>
+     <description>TX FIFO Output Peek register</description>
+     <addressOffset>0x0018</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read TX FIFO next data. Reading from this field does not affect the contents of TX FIFO. Note that the parity bit is available from this field.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PNR</name>
+     <description> Pin register</description>
+     <addressOffset>0x001C</addressOffset>
+     <fields>
+      <field>
+       <name>CTS</name>
+       <description>Current sampled value of CTS IO</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RTS</name>
+       <description>This bit controls the value to apply on the RTS IO. If set to 1, the RTS IO is set to high level. If set to 0, the RTS IO is set to low level.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Read/Write register</description>
+     <addressOffset>0x0020</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Parity error flag for next byte to be read from FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration register</description>
+     <addressOffset>0x0030</addressOffset>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger If the TX FIFO level is less than this value, then the TX FIFO DMA interface will send a signal to system DMA to notify that TX FIFO is ready to receive data from memory.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX DMA channel enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Rx FIFO Level DMA Trigger If the RX FIFO level is greater than this value, then the RX FIFO DMA interface will send a signal to the system DMA to notify that RX FIFO has characters to transfer to memory.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX DMA channel enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wake up enable Control register</description>
+     <addressOffset>0x0034</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Enable for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Enable for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Enable for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wake up Flags register</description>
+     <addressOffset>0x0038</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Flag for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Flag for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Flag for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--UART UART Low Power Registers-->
+  <peripheral derivedFrom="UART">
+   <name>UART1</name>
+   <description>UART Low Power Registers 1</description>
+   <baseAddress>0x40043000</baseAddress>
+  </peripheral>
+<!--UART1 UART Low Power Registers 1-->
+  <peripheral derivedFrom="UART">
+   <name>UART2</name>
+   <description>UART Low Power Registers 2</description>
+   <baseAddress>0x40044000</baseAddress>
+  </peripheral>
+<!--UART2 UART Low Power Registers 2-->
+  <peripheral derivedFrom="UART">
+   <name>UART3</name>
+   <description>UART Low Power Registers 3</description>
+   <baseAddress>0x40081400</baseAddress>
+  </peripheral>
+<!--UART3 UART Low Power Registers 3-->
+  <peripheral>
+   <name>WDT</name>
+   <description>Windowed Watchdog Timer</description>
+   <baseAddress>0x40003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WWDT</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INT_LATE_VAL</name>
+       <description>Windowed Watchdog Interrupt Upper Limit. Sets the number of WDTCLK cycles until a windowed watchdog timer interrupt is generated (if enabled) if the CPU does not write the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE_VAL</name>
+       <description>Windowed Watchdog Reset Upper Limit. Sets the number of WDTCLK cycles until a system reset occurs (if enabled) if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Windowed Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_LATE</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Late.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_INT_EN</name>
+       <description>Windowed Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_RST_EN</name>
+       <description>Windowed Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Soon.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY_VAL</name>
+       <description>Windowed Watchdog Interrupt Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A windowed watchdog timer interrupt is generated (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY_VAL</name>
+       <description>Windowed Watchdog Reset Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A system reset occurs (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKRDY_IE</name>
+       <description>Switch Ready Interrupt Enable. Fires an interrupt when it is safe to swithc the clock.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY</name>
+       <description>Clock Status.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WIN_EN</name>
+       <description>Enables the Windowed Watchdog Function.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Windowed Mode Disabled (i.e. Compatibility Mode).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Windowed Mode Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Soon.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Late.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Windowed Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>RESET</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD_UPPER_LIMIT then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD_UPPER_LIMIT then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKSEL</name>
+     <description>Windowed Watchdog Timer Clock Select Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SOURCE</name>
+       <description>WWDT Clock Selection Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CNT</name>
+     <description>Windowed Watchdog Timer Count Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Current Value of the Windowed Watchdog Timer Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WDT Windowed Watchdog Timer-->
+  <peripheral derivedFrom="WDT">
+   <name>WDT1</name>
+   <description>Windowed Watchdog Timer 1</description>
+   <baseAddress>0x40080800</baseAddress>
+   <interrupt>
+    <name>WDT1</name>
+    <description>WDT1 IRQ</description>
+    <value>57</value>
+   </interrupt>
+  </peripheral>
+<!--WDT1 Windowed Watchdog Timer 1-->
+  <peripheral>
+   <name>WUT</name>
+   <description>32-bit reloadable timer that can be used for timing and wakeup.</description>
+   <baseAddress>0x40006400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Wakeup_Timer</name>
+    <description>WUT IRQ</description>
+    <value>53</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Count.  This register stores the current timer count.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Timer Count Value. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Compare.  This register stores the compare value, which is used to set the maximum count value to initiate a reload of the timer to 0x0001.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x0000FFFF</resetValue>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>Timer Compare Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Clear Interrupt. Writing a value (0 or 1) to a bit in this register clears the associated interrupt.</description>
+     <addressOffset>0x0C</addressOffset>
+     <modifiedWriteValues>oneToClear</modifiedWriteValues>
+     <fields>
+      <field>
+       <name>IRQ_CLR</name>
+       <description>Clear Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>TMODE</name>
+       <description>Timer Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>oneShot</name>
+         <description>One Shot Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Continuous Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>counter</name>
+         <description>Counter Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>capture</name>
+         <description>Capture Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>compare</name>
+         <description>Compare Mode.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>gated</name>
+         <description>Gated Mode.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>captureCompare</name>
+         <description>Capture/Compare Mode.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES</name>
+       <description>Prescaler.  Set the Timer's prescaler value. The prescaler divides the PCLK input to the timer and sets the Timer's Count Clock, F_CNT_CLK = PCLK(HZ)/prescaler. The Timer's prescaler setting is a 4-bit value with pres3:pres[2:0].</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TPOL</name>
+       <description>Timer input/output polarity bit.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>activeHi</name>
+         <description>Active High.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activeLo</name>
+         <description>Active Low.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TEN</name>
+       <description>Timer Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES3</name>
+       <description>MSB of prescaler value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>NOLLCMP</name>
+       <description>Non-overlapping Low Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A and next rising edge of PWM output 0A'.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>NOLHCMP</name>
+       <description>Non-overlapping High Compare.  The 8-bit timer count value of non-overlapping time between falling edge of PWM output 0A' and next rising edge of PWM output 0A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET</name>
+     <description>Preset register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>PRESET</name>
+       <description>Preset Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RELOAD</name>
+     <description>Reload register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>RELOAD</name>
+       <description>Rerload Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SNAPSHOT</name>
+     <description>Snapshot register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>SNAPSHOT</name>
+       <description>Snapshot Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WUT 32-bit reloadable timer that can be used for timing and wakeup.-->
+ </peripherals>
+</device>

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX78002/Include/max78002.svd
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX78002/Include/max78002.svd
@@ -1,0 +1,20370 @@
+<?xml version='1.0' encoding='utf-8'?>
+<device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:noNamespaceSchemaLocation="svd_schema.xsd">
+ <vendor>Maxim-Integrated</vendor>
+ <vendorID>Maxim</vendorID>
+ <name>max78002</name>
+ <series>ARMCM4</series>
+ <version>1.0</version>
+ <description>MAX78002 Machine Learning System-on-Chip.</description>
+ <cpu>
+  <name>CM4</name>
+  <revision>r2p1</revision>
+  <endian>little</endian>
+  <mpuPresent>true</mpuPresent>
+  <fpuPresent>true</fpuPresent>
+  <nvicPrioBits>3</nvicPrioBits>
+  <vendorSystickConfig>false</vendorSystickConfig>
+ </cpu>
+ <addressUnitBits>8</addressUnitBits>
+ <width>32</width>
+ <size>0x20</size>
+ <access>read-write</access>
+ <resetValue>0x00000000</resetValue>
+ <resetMask>0xFFFFFFFF</resetMask>
+ <peripherals>
+  <peripheral>
+   <name>ADC</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>ADC</groupName>
+   <baseAddress>0x40034000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>ADC</name>
+    <description>ADC IRQ</description>
+    <value>20</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0</name>
+     <description>Control Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADC_EN</name>
+       <description>ADC Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable ADC.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable ADC.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BIAS_EN</name>
+       <description>Bias Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Bias.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Bias.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SKIP_CAL</name>
+       <description>Skip Calibration Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no_skip</name>
+         <description>Do not skip calibration.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>skip</name>
+         <description>Skip calibration.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CHOP_FORCE</name>
+       <description>Chop Force Control.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Do not force chop mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Force chop Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RESETB</name>
+       <description>Reset ADC.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>reset</name>
+         <description>reset ADC.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>activate</name>
+         <description>activate ADC.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Control Register 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Start conversion control.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>stop</name>
+         <description>Stop conversions.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start conversions.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TRIG_MODE</name>
+       <description>Trigger mode control.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>software</name>
+         <description>software trigger mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hardware</name>
+         <description>hardware trigger mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CNV_MODE</name>
+       <description>Conversion mode control.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>atomic</name>
+         <description>Do one conversion sequence.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Do continuous conversion sequences.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SAMP_CK_OFF</name>
+       <description>Sample clock off control.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>always</name>
+         <description>Sample clock always generated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cnv_only</name>
+         <description>Sample clock generated only when converting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TRIG_SEL</name>
+       <description>Hardware trigger source select.</description>
+       <bitRange>[6:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TS_SEL</name>
+       <description>Temp sensor select.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Temp sensor is not one of the slots in the sequence.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Temp sensor is one of the slots in the sequence.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AVG</name>
+       <description>Number of samples to average for each output data code.</description>
+       <bitRange>[10:8]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>avg1</name>
+         <description>1 Sample per output code.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg2</name>
+         <description>2 Samples per output code.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg4</name>
+         <description>4 Samples per output code.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg8</name>
+         <description>8 Samples per output code.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg16</name>
+         <description>16 Samples per output code.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>avg32</name>
+         <description>32 Samples per output code.</description>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NUM_SLOTS</name>
+       <description>Number of slots enabled for the conversion sequence</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>CLKSEL</name>
+       <description>Clock source select.</description>
+       <bitRange>[1:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>HCLK</name>
+         <description>Select HCLK.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK_ADC0</name>
+         <description>Select CLK_ADC0.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK_ADC1</name>
+         <description>Select CLK_ADC1.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK_ADC2</name>
+         <description>Select CLK_ADC2.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>Clock divider control.</description>
+       <bitRange>[6:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <description>Divide by 2.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <description>Divide by 4.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV8</name>
+         <description>Divide by 8.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV16</name>
+         <description>Divide by 16.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <description>Divide by 1.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAMPCLKCTRL</name>
+     <description>Sample Clock Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TRACK_CNT</name>
+       <description>Number of cycles for SAMPLE_CLK high time.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>IDLE_CNT</name>
+       <description>Number of cycles for SAMPLE_CLK low time.</description>
+       <bitRange>[31:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL0</name>
+     <description>Channel Select Register 0.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>slot0_id</name>
+       <description>channel assignment for slot 0.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot1_id</name>
+       <description>channel assignment for slot 1.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot2_id</name>
+       <description>channel assignment for slot 2.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot3_id</name>
+       <description>channel assignment for slot 3.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL1</name>
+     <description>Channel Select Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>slot4_id</name>
+       <description>channel assignment for slot 4.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot5_id</name>
+       <description>channel assignment for slot 5.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot6_id</name>
+       <description>channel assignment for slot 6.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot7_id</name>
+       <description>channel assignment for slot 7.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL2</name>
+     <description>Channel Select Register 2.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>slot8_id</name>
+       <description>channel assignment for slot 8.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot9_id</name>
+       <description>channel assignment for slot 9.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot10_id</name>
+       <description>channel assignment for slot 10.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot11_id</name>
+       <description>channel assignment for slot 11.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL3</name>
+     <description>Channel Select Register 3.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>slot12_id</name>
+       <description>channel assignment for slot 12.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot13_id</name>
+       <description>channel assignment for slot 13.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot14_id</name>
+       <description>channel assignment for slot 14.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot15_id</name>
+       <description>channel assignment for slot 15.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL4</name>
+     <description>Channel Select Register 4.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>slot16_id</name>
+       <description>channel assignment for slot 16.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot17_id</name>
+       <description>channel assignment for slot 17.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot18_id</name>
+       <description>channel assignment for slot 18.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot19_id</name>
+       <description>channel assignment for slot 19.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL5</name>
+     <description>Channel Select Register 5.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>slot20_id</name>
+       <description>channel assignment for slot 20.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot21_id</name>
+       <description>channel assignment for slot 21.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot22_id</name>
+       <description>channel assignment for slot 22.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot23_id</name>
+       <description>channel assignment for slot 23.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL6</name>
+     <description>Channel Select Register 6.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>slot24_id</name>
+       <description>channel assignment for slot 24.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot25_id</name>
+       <description>channel assignment for slot 25.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot26_id</name>
+       <description>channel assignment for slot 26.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot27_id</name>
+       <description>channel assignment for slot 27.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSEL7</name>
+     <description>Channel Select Register 7.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>slot28_id</name>
+       <description>channel assignment for slot 28.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot29_id</name>
+       <description>channel assignment for slot 29.</description>
+       <bitRange>[12:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot30_id</name>
+       <description>channel assignment for slot 30.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>slot31_id</name>
+       <description>channel assignment for slot 31.</description>
+       <bitRange>[28:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESTART</name>
+     <description>Restart Count Control Register</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Number of sample periods to skip before restarting a continuous mode sequence</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAFMT</name>
+     <description>Channel Data Format Register</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Data format control</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFODMACTRL</name>
+     <description>FIFO and DMA control</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>DMA_EN</name>
+       <description>DMA Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable DMA.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable DMA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>FIFO Flush.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal FIFO operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_FORMAT</name>
+       <description>DATA format control.</description>
+       <bitRange>[3:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>data_status</name>
+         <description>Data and Status in FIFO.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>data_only</name>
+         <description>Only Data in FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>raw_data_only</name>
+         <description>Only Raw Data in FIFO.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THRESH</name>
+       <description>FIFO Threshold. These bits define the FIFO interrupt threshold.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data Register (FIFO).</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Conversion data.</description>
+       <bitRange>[15:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CHAN</name>
+       <description>Channel for the data.</description>
+       <bitRange>[20:16]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>INVALID</name>
+       <description>Invalid status for the data.</description>
+       <bitRange>[24:24]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLIPPED</name>
+       <description>Clipped status for the data.</description>
+       <bitRange>[31:31]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>READY</name>
+       <description>Indication that the ADC is in ON power state</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EMPTY</name>
+       <description>FIFO Empty</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>FULL</name>
+       <description>FIFO full</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>FIFO_LEVEL</name>
+       <description>Number of entries in FIFO available to read</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CHSTATUS</name>
+     <description>Channel Status</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>CLIPPED</name>
+       <description />
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>READY</name>
+       <description>ADC is ready.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Conversion start is aborted.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>START_DET</name>
+       <description>Conversion start is detected.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SEQ_STARTED</name>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SEQ_DONE</name>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CONV_DONE</name>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLIPPED</name>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_LVL</name>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_UFL</name>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_OFL</name>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Interrupt Flags Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>READY</name>
+       <description>ADC is ready.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Conversion start is aborted.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>START_DET</name>
+       <description>Conversion start is detected.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>SEQ_STARTED</name>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>SEQ_DONE</name>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>CONV_DONE</name>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>CLIPPED</name>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>FIFO_LVL</name>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>FIFO_UFL</name>
+       <bitRange>[9:9]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>FIFO_OFL</name>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRADDROFFSET</name>
+     <description>SFR Address Offset Register</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>OFFSET</name>
+       <description>Address Offset for SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRADDR</name>
+     <description>SFR Address Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address to SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRWRDATA</name>
+     <description>SFR Write Data Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>DATA to SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRRDDATA</name>
+     <description>SFR Read Data Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>DATA from SAR Digital</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFRSTATUS</name>
+     <description>SFR Status Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>NACK</name>
+       <description>NACK status for SAR Digital SFR communication</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ADC Inter-Integrated Circuit.-->
+  <peripheral>
+   <name>AES</name>
+   <description>AES Keys.</description>
+   <baseAddress>0x40007400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>AES Control Register</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>AES Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>DMA Request To Read Data Output FIFO</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>DMA Request To Write Data Input FIFO</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start AES Calculation</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FLUSH</name>
+       <description>Flush the data input FIFO</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FLUSH</name>
+       <description>Flush the data output FIFO</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_SIZE</name>
+       <description>Encryption Key Size</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>AES128</name>
+         <description>128 Bits.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES192</name>
+         <description>192 Bits.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>AES256</name>
+         <description>256 Bits.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TYPE</name>
+       <description>Encryption Type Selection</description>
+       <bitRange>[9:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>AES Status Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>AES Busy Status</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_EM</name>
+       <description>Data input FIFO empty status</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPUT_FULL</name>
+       <description>Data input FIFO full status</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_EM</name>
+       <description>Data output FIFO empty status</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPUT_FULL</name>
+       <description>Data output FIFO full status</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>AES Interrupt Flag Register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>AES Interrupt Enable Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>AES Done Interrupt Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_CHANGE</name>
+       <description>External AES Key Changed Interrupt Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ZERO</name>
+       <description>External AES Key Zero Interrupt Enable</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OV</name>
+       <description>Data Output FIFO Overrun Interrupt Enable</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>KEY_ONE</name>
+       <description>KEY_ONE</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>AES Data Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>AES FIFO</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--AES AES Keys.-->
+  <peripheral>
+   <name>AESKEYS</name>
+   <description>AES Key Registers.</description>
+   <baseAddress>0x40007800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>KEY0</name>
+     <description>AES Key 0.</description>
+     <addressOffset>0x000</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY1</name>
+     <description>AES Key 1.</description>
+     <addressOffset>0x080</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY2</name>
+     <description>AES Key 2.</description>
+     <addressOffset>0x100</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY3</name>
+     <description>AES Key 3.</description>
+     <addressOffset>0x180</addressOffset>
+     <size>32</size>
+    </register>
+   </registers>
+  </peripheral>
+<!--AESKEYS AES Key Registers.-->
+  <peripheral>
+   <name>CAMERAIF</name>
+   <description>Parallel Camera Interface.</description>
+   <baseAddress>0x4000E000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>CameraIF</name>
+    <value>91</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>VER</name>
+     <description>Hardware Version.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>minor</name>
+       <description>Minor Version Number.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>major</name>
+       <description>Major Version Number.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO_SIZE</name>
+     <description>FIFO Depth.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>fifo_size</name>
+       <description>FIFO size.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register.</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>READ_MODE</name>
+       <description>Read Mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Camera Interface Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>single_img</name>
+         <description>Single Image Capture.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Continuous Image Capture.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>Data Width.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>8bit</name>
+         <description>8 bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10bit</name>
+         <description>10 bit.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12bit</name>
+         <description>12 bit.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DS_TIMING_EN</name>
+       <description>DS Timing Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Timing from VSYNC and HSYNC.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Timing embedded in data using SAV and EAV codes.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FIFO_THRSH</name>
+       <description>Data FIFO Threshold.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_DMA</name>
+       <description>DMA Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>DMA disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>DMA enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_DMA_THRSH</name>
+       <description>DMA Threshold.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>THREE_CH_EN</name>
+       <description>Three-channel mode enable.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PCIF_SYS</name>
+       <description>PCIF Control.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PCIF disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PCIF enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interupt Enable Register.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IMG_DONE</name>
+       <description>Image Done.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_FULL</name>
+       <description>FIFO Full.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_THRESH</name>
+       <description>FIFO Threshold Level Met.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_NOT_EMPTY</name>
+       <description>FIFO Not Empty.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Interupt Flag Register.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IMG_DONE</name>
+       <description>Image Done.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_FULL</name>
+       <description>FIFO Full.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_THRESH</name>
+       <description>FIFO Threshold Level Met.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_NOT_EMPTY</name>
+       <description>FIFO Not Empty.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS_TIMING_CODES</name>
+     <description>DS Timing Code Register.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SAV</name>
+       <description>Start Active Video Code.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EAV</name>
+       <description>End Active Video Code.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO_DATA</name>
+     <description>FIFO DATA Register.</description>
+     <addressOffset>0x0030</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data from FIFO to be read by DMA.</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CAMERAIF Parallel Camera Interface.-->
+  <peripheral>
+   <name>CRC</name>
+   <description>CRC Registers.</description>
+   <baseAddress>0x4000F000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>CRC Control</description>
+     <addressOffset>0x0000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>CRC Enable</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_EN</name>
+       <description>DMA Request Enable</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB</name>
+       <description>MSB Select</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BYTE_SWAP_IN</name>
+       <description>Byte Swap CRC Data Input</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BYTE_SWAP_OUT</name>
+       <description>Byte Swap CRC Value Output</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>CRC Busy</description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN32</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN16</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATAIN8</name>
+     <description>CRC Data Input</description>
+     <addressOffset>0x0004</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>CRC Data</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>POLY</name>
+     <description>CRC Polynomial</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>POLY</name>
+       <description>CRC Polynomial</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VAL</name>
+     <description>Current CRC Value</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>VALUE</name>
+       <description>Current CRC Value</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CRC CRC Registers.-->
+  <peripheral>
+   <name>CSI2</name>
+   <description>Camera Serial Interface Registers.</description>
+   <baseAddress>0x40062000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CFG_NUM_LANES</name>
+     <description>CFG_NUM_LANES.</description>
+     <addressOffset>0x000</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>LANES</name>
+       <description>Num Lanes for RX controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_CLK_LANE_EN</name>
+     <description>CFG_CLK_LANE_EN.</description>
+     <addressOffset>0x004</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enable lane clock setting for controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_DATA_LANE_EN</name>
+     <description>CFG_DATA_LANE_EN.</description>
+     <addressOffset>0x008</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enable data lane setting for controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_FLUSH_COUNT</name>
+     <description>CFG_FLUSH_COUNT.</description>
+     <addressOffset>0x00C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Flush count setting for controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_BIT_ERR</name>
+     <description>CFG_BIT_ERR.</description>
+     <addressOffset>0x010</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>MBE</name>
+       <description>Multiple bit ECC error.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SBE</name>
+       <description>Single bit ECC error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HEADER</name>
+       <description>Header bit location of single bit ECC error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>CRC</name>
+       <description>CRC error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VID_ERR_SEND_LVL</name>
+       <description>Video Error Send Level.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VID_ERR_FIFO_WR_OV</name>
+       <description>Video Error Fifo Overflow.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IRQ_STATUS</name>
+     <description>IRQ_STATUS.</description>
+     <addressOffset>0x014</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>CRC</name>
+       <description>CRC error.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SBE</name>
+       <description>Single bit ECC error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MBE</name>
+       <description>Multiple bit ECC error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ULPS_ACTIVE</name>
+       <description>ULPS active status change.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ULPS_MARK_ACTIVE</name>
+       <description>ULPS mark active status change.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VID_ERR_SEND_LVL</name>
+       <description>Video Error Send Level.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VID_ERR_FIFO_WR_OV</name>
+       <description>Video Error Fifo Overflow.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IRQ_ENABLE</name>
+     <description>IRQ_ENABLE.</description>
+     <addressOffset>0x018</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>CRC</name>
+       <description>CRC error.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SBE</name>
+       <description>Single bit ECC error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MBE</name>
+       <description>Multiple bit ECC error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ULPS_ACTIVE</name>
+       <description>ULPS active status change.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ULPS_MARK_ACTIVE</name>
+       <description>ULPS mark active status change.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VID_ERR_SEND_LVL</name>
+       <description>Video Error Send Level.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VID_ERR_FIFO_WR_OV</name>
+       <description>Video Error Fifo Overflow.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IRQ_CLR</name>
+     <description>IRQ_CLR.</description>
+     <addressOffset>0x01C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>CRC</name>
+       <description>CRC error.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SBE</name>
+       <description>Single bit ECC error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MBE</name>
+       <description>Multiple bit ECC error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ULPS_ACTIVE</name>
+       <description>ULPS active status change.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ULPS_MARK_ACTIVE</name>
+       <description>ULPS mark active status change.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VID_ERR_SEND_LVL</name>
+       <description>Video Error Send Level.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VID_ERR_FIFO_WR_OV</name>
+       <description>Video Error Fifo Overflow.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ULPS_CLK_STATUS</name>
+     <description>ULPS_CLK_STATUS.</description>
+     <addressOffset>0x020</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>FIFO</name>
+       <description>FIFO Read/Write register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ULPS_STATUS</name>
+     <description>ULPS_STATUS.</description>
+     <addressOffset>0x024</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DATA_LANE0</name>
+       <description>Data Lane 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_LANE1</name>
+       <description>Data Lane 1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ULPS_CLK_MARK_STATUS</name>
+     <description>ULPS_CLK_MARK_STATUS.</description>
+     <addressOffset>0x028</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>CLK_LANE</name>
+       <description>Clock Lane.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ULPS_MARK_STATUS</name>
+     <description>ULPS_MARK_STATUS.</description>
+     <addressOffset>0x02C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DATA_LANE0</name>
+       <description>Data Lane 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_LANE1</name>
+       <description>Data Lane 1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PPI_ERRSOT_HS</name>
+     <description>PPI_ERRSOT_HS.</description>
+     <addressOffset>0x030</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>PPI_ERRSOTSYNC_HS</name>
+     <description>PPI_ERRSOTSYNC_HS.</description>
+     <addressOffset>0x034</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>PPI_ERRESC</name>
+     <description>PPI_ERRESC.</description>
+     <addressOffset>0x038</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>PPI_ERRSYNCESC</name>
+     <description>PPI_ERRSYNCESC.</description>
+     <addressOffset>0x03C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>PPI_ERRCONTROL</name>
+     <description>PPI_ERRCONTROL.</description>
+     <addressOffset>0x040</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CFG_CPHY_EN</name>
+     <description>CFG_CPHY_EN.</description>
+     <addressOffset>0x044</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CFG_PPI_16_EN</name>
+     <description>CFG_PPI_16_EN.</description>
+     <addressOffset>0x048</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CFG_PACKET_INTERFACE_EN</name>
+     <description>CFG_PACKET_INTERFACE_EN.</description>
+     <addressOffset>0x04C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CFG_VCX_EN</name>
+     <description>CFG_VCX_EN.</description>
+     <addressOffset>0x050</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CFG_BYTE_DATA_FORMAT</name>
+     <description>CFG_BYTE_DATA_FORMAT.</description>
+     <addressOffset>0x054</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CFG_DISABLE_PAYLOAD_0</name>
+     <description>CFG_DISABLE_PAYLOAD_0.</description>
+     <addressOffset>0x058</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>NULL</name>
+       <description>NULL.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BLANK</name>
+       <description>BLANK.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EMBEDDED</name>
+       <description>EMBEDDED.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>YUV420_8BIT</name>
+       <description>YUV420_8BIT.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>YUV420_10BIT</name>
+       <description>YUV420_10BIT.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>YUV420_8BIT_LEG</name>
+       <description>YUV420_8BIT_LEG.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>YUV420_8BIT_CSP</name>
+       <description>YUV420_8BIT_CSP.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>YUV420_10BIT_CSP</name>
+       <description>YUV420_10BIT_CSP.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>YUV422_8BIT</name>
+       <description>YUV422_8BIT.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>YUV422_10BIT</name>
+       <description>YUV422_10BIT.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RGB444</name>
+       <description>RGB444.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RGB555</name>
+       <description>RGB555.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RGB565</name>
+       <description>RGB565.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RGB666</name>
+       <description>RGB666.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RGB888</name>
+       <description>RGB888.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAW6</name>
+       <description>RAW6.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAW7</name>
+       <description>RAW7.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAW8</name>
+       <description>RAW8.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAW10</name>
+       <description>RAW10.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAW12</name>
+       <description>RAW12.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAW14</name>
+       <description>RAW14.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAW16</name>
+       <description>RAW16.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAW20</name>
+       <description>RAW20.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_DISABLE_PAYLOAD_1</name>
+     <description>CFG_DISABLE_PAYLOAD_1.</description>
+     <addressOffset>0x05C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>USR_DEF_TYPE30</name>
+       <description>User defined type 0x30.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>USR_DEF_TYPE31</name>
+       <description>User defined type 0x31.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>USR_DEF_TYPE32</name>
+       <description>User defined type 0x32.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>USR_DEF_TYPE33</name>
+       <description>User defined type 0x33.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>USR_DEF_TYPE34</name>
+       <description>User defined type 0x34.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>USR_DEF_TYPE35</name>
+       <description>User defined type 0x35.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>USR_DEF_TYPE36</name>
+       <description>User defined type 0x36.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>USR_DEF_TYPE37</name>
+       <description>User defined type 0x37.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_VID_IGNORE_VC</name>
+     <description>CFG_VID_IGNORE_VC.</description>
+     <addressOffset>0x080</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CFG_VID_VC</name>
+     <description>CFG_VID_VC.</description>
+     <addressOffset>0x084</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CFG_P_FIFO_SEND_LEVEL</name>
+     <description>CFG_P_FIFO_SEND_LEVEL.</description>
+     <addressOffset>0x088</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CFG_VID_VSYNC</name>
+     <description>CFG_VID_VSYNC.</description>
+     <addressOffset>0x08C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CFG_VID_HSYNC_FP</name>
+     <description>CFG_VID_HSYNC_FP.</description>
+     <addressOffset>0x090</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CFG_VID_HSYNC</name>
+     <description>CFG_VID_HSYNC.</description>
+     <addressOffset>0x094</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CFG_VID_HSYNC_BP</name>
+     <description>CFG_VID_HSYNC_BP.</description>
+     <addressOffset>0x098</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>CFG_DATABUS16_SEL</name>
+     <description>CFG_DATABUS16_SEL.</description>
+     <addressOffset>0x400</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Enable 16-bit data bus.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_D0_SWAP_SEL</name>
+     <description>CFG_D0_SWAP_SEL.</description>
+     <addressOffset>0x404</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>SRC</name>
+       <description>Control Source.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>PAD_CDRX_L0</name>
+         <description>PAD_CDRX_L0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L1</name>
+         <description>PAD_CDRX_L1.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L2</name>
+         <description>PAD_CDRX_L2.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L3</name>
+         <description>PAD_CDRX_L3.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L4</name>
+         <description>PAD_CDRX_L4.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_D1_SWAP_SEL</name>
+     <description>CFG_D1_SWAP_SEL.</description>
+     <addressOffset>0x408</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>SRC</name>
+       <description>Control Source.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>PAD_CDRX_L0</name>
+         <description>PAD_CDRX_L0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L1</name>
+         <description>PAD_CDRX_L1.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L2</name>
+         <description>PAD_CDRX_L2.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L3</name>
+         <description>PAD_CDRX_L3.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L4</name>
+         <description>PAD_CDRX_L4.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_D2_SWAP_SEL</name>
+     <description>CFG_D2_SWAP_SEL.</description>
+     <addressOffset>0x40C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>SRC</name>
+       <description>Control Source.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>PAD_CDRX_L0</name>
+         <description>PAD_CDRX_L0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L1</name>
+         <description>PAD_CDRX_L1.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L2</name>
+         <description>PAD_CDRX_L2.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L3</name>
+         <description>PAD_CDRX_L3.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L4</name>
+         <description>PAD_CDRX_L4.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_D3_SWAP_SEL</name>
+     <description>CFG_D3_SWAP_SEL.</description>
+     <addressOffset>0x410</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>SRC</name>
+       <description>Control Source.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>PAD_CDRX_L0</name>
+         <description>PAD_CDRX_L0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L1</name>
+         <description>PAD_CDRX_L1.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L2</name>
+         <description>PAD_CDRX_L2.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L3</name>
+         <description>PAD_CDRX_L3.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L4</name>
+         <description>PAD_CDRX_L4.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_C0_SWAP_SEL</name>
+     <description>CFG_C0_SWAP_SEL.</description>
+     <addressOffset>0x414</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>SRC</name>
+       <description>Control Source.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>PAD_CDRX_L0</name>
+         <description>PAD_CDRX_L0.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L1</name>
+         <description>PAD_CDRX_L1.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L2</name>
+         <description>PAD_CDRX_L2.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L3</name>
+         <description>PAD_CDRX_L3.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PAD_CDRX_L4</name>
+         <description>PAD_CDRX_L4.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_DPDN_SWAP</name>
+     <description>CFG_DPDN_SWAP.</description>
+     <addressOffset>0x418</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>SWAP_DATA_LANE0</name>
+       <description>SWAP_DATA_LANE0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SWAP_DATA_LANE1</name>
+       <description>SWAP_DATA_LANE1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SWAP_DATA_LANE2</name>
+       <description>SWAP_DATA_LANE2.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SWAP_DATA_LANE3</name>
+       <description>SWAP_DATA_LANE3.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SWAP_CLK_LANE</name>
+       <description>SWAP_CLK_LANE.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RG_CFGCLK_1US_CNT</name>
+     <description>RG_CFGCLK_1US_CNT.</description>
+     <addressOffset>0x41C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>RG_HSRX_CLK_PRE_TIME_GRP0</name>
+     <description>RG_HSRX_CLK_PRE_TIME_GRP0.</description>
+     <addressOffset>0x420</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>RG_HSRX_DATA_PRE_TIME_GRP0</name>
+     <description>RG_HSRX_DATA_PRE_TIME_GRP0.</description>
+     <addressOffset>0x424</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>RESET_DESKEW</name>
+     <description>RESET_DESKEW.</description>
+     <addressOffset>0x428</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DATA_LANE0</name>
+       <description>DATA_LANE0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_LANE1</name>
+       <description>DATA_LANE1.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_LANE2</name>
+       <description>DATA_LANE2.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_LANE3</name>
+       <description>DATA_LANE3.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PMA_RDY</name>
+     <description>PMA_RDY.</description>
+     <addressOffset>0x42C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>XCFGI_DW00</name>
+     <description>XCFGI_DW00.</description>
+     <addressOffset>0x430</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>XCFGI_DW01</name>
+     <description>XCFGI_DW01.</description>
+     <addressOffset>0x434</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>XCFGI_DW02</name>
+     <description>XCFGI_DW02.</description>
+     <addressOffset>0x438</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>XCFGI_DW03</name>
+     <description>XCFGI_DW03.</description>
+     <addressOffset>0x43C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>XCFGI_DW04</name>
+     <description>XCFGI_DW04.</description>
+     <addressOffset>0x440</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>XCFGI_DW05</name>
+     <description>XCFGI_DW05.</description>
+     <addressOffset>0x444</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>XCFGI_DW06</name>
+     <description>XCFGI_DW06.</description>
+     <addressOffset>0x448</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>XCFGI_DW07</name>
+     <description>XCFGI_DW07.</description>
+     <addressOffset>0x44C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>XCFGI_DW08</name>
+     <description>XCFGI_DW08.</description>
+     <addressOffset>0x450</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>XCFGI_DW09</name>
+     <description>XCFGI_DW09.</description>
+     <addressOffset>0x454</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>XCFGI_DW0A</name>
+     <description>XCFGI_DW0A.</description>
+     <addressOffset>0x458</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>XCFGI_DW0B</name>
+     <description>XCFGI_DW0B.</description>
+     <addressOffset>0x45C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>XCFGI_DW0C</name>
+     <description>XCFGI_DW0C.</description>
+     <addressOffset>0x460</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>XCFGI_DW0D</name>
+     <description>XCFGI_DW0D.</description>
+     <addressOffset>0x464</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>GPIO_MODE</name>
+     <description>GPIO_MODE.</description>
+     <addressOffset>0x468</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>GPIO_DP_IE</name>
+     <description>GPIO_DP_IE.</description>
+     <addressOffset>0x46C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>GPIO_DN_IE</name>
+     <description>GPIO_DN_IE.</description>
+     <addressOffset>0x470</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>GPIO_DP_C</name>
+     <description>GPIO_DP_C.</description>
+     <addressOffset>0x474</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>GPIO_DN_C</name>
+     <description>GPIO_DN_C.</description>
+     <addressOffset>0x478</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>VCONTROL</name>
+     <description>PMA_RDY.</description>
+     <addressOffset>0x47C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>NORMAL_MODE</name>
+       <description>NORMAL_MODE.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LP_RX_DC_TEST</name>
+       <description>LP_RX_DC_TEST.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LP_RX_DC_1</name>
+       <description>LP_RX_DC_1.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LP_RX_DC_0</name>
+       <description>LP_RX_DC_0.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAL_SEN_1</name>
+       <description>CAL_SEN_1.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAL_SEN_0</name>
+       <description>CAL_SEN_0.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HSRT_0</name>
+       <description>HSRT_0.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HSRT_1</name>
+       <description>HSRT_1.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LP_RX_PARTBERT</name>
+       <description>LP_RX_PARTBERT.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HS_INT_LOOPBACK</name>
+       <description>HS_INT_LOOPBACK.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HS_RX_PARTBERT</name>
+       <description>HS_RX_PARTBERT.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HS_RX_PRBS9</name>
+       <description>HS_RX_PRBS9.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SUSPEND_MODE</name>
+       <description>SUSPEND_MODE.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MPSOV1</name>
+     <description>MPSOV1.</description>
+     <addressOffset>0x480</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>MPSOV2</name>
+     <description>MPSOV2.</description>
+     <addressOffset>0x484</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>MPSOV3</name>
+     <description>MPSOV3.</description>
+     <addressOffset>0x488</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>RG_CDRX_DSIRX_EN</name>
+     <description>RG_CDRX_DSIRX_EN.</description>
+     <addressOffset>0x490</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>RXMODE</name>
+       <description>RXMODE.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CSI</name>
+         <description>CSI RX Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DSI</name>
+         <description>DSI RX Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RG_CDRX_L012_SUBLVDS_EN</name>
+     <description>RG_CDRX_L012_SUBLVDS_EN.</description>
+     <addressOffset>0x494</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>RG_CDRX_L012_HSRT_CTRL</name>
+     <description>RG_CDRX_L012_HSRT_CTRL.</description>
+     <addressOffset>0x498</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>RG_CDRX_BISTHS_PLL_EN</name>
+     <description>RG_CDRX_BISTHS_PLL_EN.</description>
+     <addressOffset>0x49C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>RG_CDRX_BISTHS_PLL_PRE_DIV2</name>
+     <description>RG_CDRX_BISTHS_PLL_PRE_DIV2.</description>
+     <addressOffset>0x4A0</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>RXMODE</name>
+       <description>RXMODE.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CSI</name>
+         <description>CSI RX Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DSI</name>
+         <description>DSI RX Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RG_CDRX_BISTHS_PLL_FBK_INT</name>
+     <description>RG_CDRX_BISTHS_PLL_FBK_INT.</description>
+     <addressOffset>0x4A4</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>DBG1_MUX_SEL</name>
+     <description>DBG1_MUX_SEL.</description>
+     <addressOffset>0x4A8</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>DBG2_MUX_SEL</name>
+     <description>DBG2_MUX_SEL.</description>
+     <addressOffset>0x4AC</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>DBG1_MUX_DOUT</name>
+     <description>DBG1_MUX_DOUT.</description>
+     <addressOffset>0x4B0</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>DBG2_MUX_DOUT</name>
+     <description>DBG2_MUX_DOUT.</description>
+     <addressOffset>0x4B4</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>AON_POWER_READY_N</name>
+     <description>AON_POWER_READY_N.</description>
+     <addressOffset>0x4B8</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>DPHY_RST_N</name>
+     <description>DPHY_RST_N.</description>
+     <addressOffset>0x4BC</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>RXBYTECLKHS_INV</name>
+     <description>RXBYTECLKHS_INV.</description>
+     <addressOffset>0x4C0</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>VFIFO_CFG0</name>
+     <description>Video FIFO Configuration Register 0.</description>
+     <addressOffset>0x500</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>VC</name>
+       <description>CSI Virtual Channel.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>DMAMODE</name>
+       <description>DMA Mode, the condition to trigger DMA request..</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>NO_DMA</name>
+         <description>No DMA.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DMA_REQ</name>
+         <description>Immediately send DMA request.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>FIFO_THD</name>
+         <description>Wait for FIFO above threshold.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>FIFO_FULL</name>
+         <description>Wait for FIFO is full.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AHBWAIT</name>
+       <description>AHB Wait Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FIFORM</name>
+       <description>FIFO Read Mode.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERRDE</name>
+       <description>Error Detection Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FBWM</name>
+       <description>Full Band Width mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_CFG1</name>
+     <description>Video FIFO Configuration Register 1.</description>
+     <addressOffset>0x504</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>AHBWCYC</name>
+       <description>Maximal AHB Wait Clock Cycles.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>WAIT_FIRST_FS</name>
+       <description>WAIT_FIRST_FS.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ACCU_FRAME_CTRL</name>
+       <description>ACCU_FRAME_CTRL.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ACCU_LINE_CTRL</name>
+       <description>ACCU_LINE_CTRL.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ACCU_LINE_CNT</name>
+       <description>ACCU_LINE_CNT.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ACCU_PIXEL_CNT</name>
+       <description>ACCU_PIXEL_CNT.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ACCU_PIXEL_ZERO</name>
+       <description>ACCU_PIXEL_ZERO.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_CTRL</name>
+     <description>Video FIFO Control Register.</description>
+     <addressOffset>0x508</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>FIFOEN</name>
+       <description>Video FIFO Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EN</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Write 1 to flush FIFO contents.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>THD</name>
+       <description>FIFO Threshold.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_STS</name>
+     <description>Video FIFO Status Register.</description>
+     <addressOffset>0x50C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>FEMPTY</name>
+       <description>FIFO empty.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FTHD</name>
+       <description>FIFO above threshold.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FFULL</name>
+       <description>FIFO full.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNDERRUN</name>
+       <description>FIFO underrun</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OVERRUN</name>
+       <description>FIFO overrun</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTSYNC</name>
+       <description>CSI out of sync</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FMTERR</name>
+       <description>CSI Pixel Format Error</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AHBWTO</name>
+       <description>AHB wait time out</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FS</name>
+       <description>CSI Frame Start</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FE</name>
+       <description>CSI Frame End</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LS</name>
+       <description>CSI Line Start</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LE</name>
+       <description>CSI Line End</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FELT</name>
+       <description>FIFO remaining entity count</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>FMT</name>
+       <description>CSI pixel format of current transaction</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_LINE_NUM</name>
+     <description>Video FIFO CSI Line Number Per Frame.</description>
+     <addressOffset>0x510</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>LINE_NUM</name>
+       <description>Number of lines per frame.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_PIXEL_NUM</name>
+     <description>Video FIFO CSI Pixel Number Per Line.</description>
+     <addressOffset>0x514</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>PIXEL_NUM</name>
+       <description>Number of pixels per line.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_LINE_CNT</name>
+     <description>Video FIFO CSI Line Count.</description>
+     <addressOffset>0x518</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>LINE_CNT</name>
+       <description>Number of received lines in current frame.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_PIXEL_CNT</name>
+     <description>Video FIFO CSI Pixel Count.</description>
+     <addressOffset>0x51C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>PIXEL_CNT</name>
+       <description>Number of received pixels in current line in a frame.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_FRAME_STS</name>
+     <description>Video FIFO Frame Status Register.</description>
+     <addressOffset>0x520</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>FRAME_STATE</name>
+       <description>Frame State.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>ERROR_CODE</name>
+       <description>Error Codes.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_RAW_CTRL</name>
+     <description>Video FIFO RAW-to-RGB Control Register.</description>
+     <addressOffset>0x524</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>RAW_CEN</name>
+       <description>RAW conversion enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAW_FF_AFO</name>
+       <description>RAW conversion FIFO automatic flush-out.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAW_FF_FO</name>
+       <description>RAW conversion FIFO flush-out trigger.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAW_FMT</name>
+       <description>RAW format.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>RGRG_GBGB</name>
+         <description>RGRG GBGB</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GRGR_BGBG</name>
+         <description>GRGR BGBG</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GBGB_RGRG</name>
+         <description>GBGB RGRG</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>BGBG_GRGR</name>
+         <description>BGBG GRGR</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RGB_TYP</name>
+       <description>RGB type.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>RGB444</name>
+         <description>RGB444.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RGB555</name>
+         <description>RGB555.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RGB565</name>
+         <description>RGB565.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RGB666</name>
+         <description>RGB666.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>RGG888</name>
+         <description>RGG888.</description>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_RAW_BUF0_ADDR</name>
+     <description>Video FIFO RAW-to-RGB Line Buffer0 Address.</description>
+     <addressOffset>0x528</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>RAM address for RAW conversion buffer 0, word-aligned.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>30</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_RAW_BUF1_ADDR</name>
+     <description>Video FIFO RAW-to-RGB Line Buffer1 Address.</description>
+     <addressOffset>0x52C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>RAM address for RAW conversion buffer 1, word-aligned.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>30</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_AHBM_CTRL</name>
+     <description>Video FIFO AHB Master Control Register.</description>
+     <addressOffset>0x530</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>AHBMEN</name>
+       <description>AHB Master Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AHBMCLR</name>
+       <description>AHB Master Status Clear.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BSTLEN</name>
+       <description>AHB Burst Length.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>VFIFO_THD</name>
+         <description>Video FIFO THD.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ONE_WORD</name>
+         <description>ONE_WORD.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>FOUR_WORDS</name>
+         <description>FOUR_WORDS.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EIGHT_WORDS</name>
+         <description>EIGHT_WORDS.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_AHBM_STS</name>
+     <description>Video FIFO AHB Master Status Register.</description>
+     <addressOffset>0x534</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>HRDY_TO</name>
+       <description>AHB master HREADY time-out.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IDLE_TO</name>
+       <description>AHB master Idle time-out.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRANS_MAX</name>
+       <description>AHB master maximal transfer count occurrence.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_AHBM_START_ADDR</name>
+     <description>Video FIFO AHB Master Start Address Register.</description>
+     <addressOffset>0x538</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>AHBM_START_ADDR</name>
+       <description>AHB master transfer starting address, word-aligned.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>30</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_AHBM_ADDR_RANGE</name>
+     <description>Video FIFO AHB Master Address Range Register.</description>
+     <addressOffset>0x53C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>AHBM_ADDR_RANGE</name>
+       <description>AHB master address range.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_AHBM_MAX_TRANS</name>
+     <description>Video FIFO AHB Master Maximal Transfer Number Register.</description>
+     <addressOffset>0x540</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>AHBM_MAX_TRANS</name>
+       <description>AHB master maximal number of transfer word count.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VFIFO_AHBM_TRANS_CNT</name>
+     <description>Video FIFO AHB Master Transfer Count Register.</description>
+     <addressOffset>0x544</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>AHBM_TRANS_CNT</name>
+       <description>AHB master number of words been transferred.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RX_EINT_VFF_IE</name>
+     <description>RX Video FIFO Interrupt Enable Register.</description>
+     <addressOffset>0x600</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>FNEMPTY</name>
+       <description>Video FIFO not empty interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FTHD</name>
+       <description>Video FIFO above threshold interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FFULL</name>
+       <description>Video FIFO full interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNDERRUN</name>
+       <description>Video FIFO underrun interrupt enable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OVERRUN</name>
+       <description>Video FIFO overrun interrupt enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTSYNC</name>
+       <description>CSI out of sync interrupt enable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FMTERR</name>
+       <description>CSI Pixel Format Error interrupt enable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AHBWTO</name>
+       <description>AHB wait time out interrupt enable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FS</name>
+       <description>CSI Frame Start interrupt enable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FE</name>
+       <description>CSI Frame End interrupt enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LS</name>
+       <description>CSI Line Start interrupt enable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LE</name>
+       <description>CSI Line End interrupt enable</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAW_OVR</name>
+       <description>Raw FIFO Overrun Interrupt Enable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAW_AHBERR</name>
+       <description>Raw AHB Error Interrupt Enable</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FNEMP_MD</name>
+       <description>Video FIFO not empty detection mode</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FTHD_MD</name>
+       <description>Video FIFO threshold detection mode</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FFUL_MD</name>
+       <description>Video FIFO full detection mode</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AHBM_RDTO</name>
+       <description>AHBM_RDTO</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AHBM_IDTO</name>
+       <description>AHBM_IDTO</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AHBM_MAX</name>
+       <description>AHBM_MAX</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RX_EINT_VFF_IF</name>
+     <description>RX Video FIFO Interrupt Flag Register.</description>
+     <addressOffset>0x604</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>FNEMPTY</name>
+       <description>Video FIFO not empty interrupt flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FTHD</name>
+       <description>Video FIFO above threshold interrupt flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FFULL</name>
+       <description>Video FIFO full interrupt flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNDERRUN</name>
+       <description>Video FIFO underrun interrupt flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OVERRUN</name>
+       <description>Video FIFO overrun interrupt flag</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTSYNC</name>
+       <description>CSI out of sync interrupt flag</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FMTERR</name>
+       <description>CSI Pixel Format Error interrupt flag</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AHBWTO</name>
+       <description>AHB wait time out interrupt flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FS</name>
+       <description>CSI Frame Start interrupt flag</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FE</name>
+       <description>CSI Frame End interrupt flag</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LS</name>
+       <description>CSI Line Start interrupt flag</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LE</name>
+       <description>CSI Line End interrupt flag</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAW_OVR</name>
+       <description>Raw FIFO Overrun Interrupt Enable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RAW_AHBERR</name>
+       <description>Raw AHB Error Interrupt Enable</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AHBM_RDTO</name>
+       <description>AHBM_RDTO</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AHBM_IDTO</name>
+       <description>AHBM_IDTO</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AHBM_MAX</name>
+       <description>AHBM_MAX</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RX_EINT_PPI_IE</name>
+     <description>RX D-PHY Interrupt Enable Register.</description>
+     <addressOffset>0x608</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DL0STOP</name>
+       <description>DPHY Data Lane0 Stop State (ppi_stopstate_lan0) interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1STOP</name>
+       <description>DPHY Data Lane1 Stop State (ppi_stopstate_lan1) interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CL0STOP</name>
+       <description>DPHY Clock Lane0 Stop State (ppi_stopstate_clk0) interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ECONT0</name>
+       <description>DPHY Data Lane0 LP0 Contention Error (ppi_errcontentionp0_lan0) interrupt enable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ECONT1</name>
+       <description>DPHY Data Lane0 LP1 Contention Error (ppi_errcontentionp1_lan0) interrupt enable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ESOT</name>
+       <description>DPHY Data Lane0 Start-of-Transmission (SoT) Error (ppi_errsoths_lan0) interrupt enable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1ESOT</name>
+       <description>DPHY Data Lane1 Start-of-Transmission (SoT) Error (ppi_errsoths_lan1) interrupt enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ESOTS</name>
+       <description>DPHY Data Lane0 SOT Synchronization Error (ppi_errsotsynchs_lan0) interrupt enable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1ESOTS</name>
+       <description>DPHY Data Lane1 SOT Synchronization Error (ppi_errsotsynchs_lan1) interrupt enable</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0EESC</name>
+       <description>DPHY Data Lane0 Escape Entry Error (ppi_erresc_lan0) interrupt enable</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1EESC</name>
+       <description>DPHY Data Lane1 Escape Entry Error (ppi_erresc_lan1) interrupt enable</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ESESC</name>
+       <description>DPHY Data Lane0 Low-Power Data Transmission Synchronization Error (ppi_errsyncesc_lan0) interrupt enable</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1ESESC</name>
+       <description>DPHY Data Lane1 Low-Power Data Transmission Synchronization Error (ppi_errsyncesc_lan0) interrupt enable</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ECTL</name>
+       <description>DPHY Data Lane0 Control Error (ppi_errcontrol_lan0) interrupt enable</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1ECTL</name>
+       <description>DPHY Data Lane1 Control Error (ppi_errcontrol_lan0) interrupt enable</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RX_EINT_PPI_IF</name>
+     <description>RX D-PHY Interrupt Flag Register.</description>
+     <addressOffset>0x60C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DL0STOP</name>
+       <description>DPHY Data Lane0 Stop State (ppi_stopstate_lan0) interrupt flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1STOP</name>
+       <description>DPHY Data Lane1 Stop State (ppi_stopstate_lan1) interrupt flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CL0STOP</name>
+       <description>DPHY Clock Lane0 Stop State (ppi_stopstate_clk0) interrupt flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ECONT0</name>
+       <description>DPHY Data Lane0 LP0 Contention Error (ppi_errcontentionp0_lan0) interrupt flag</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ECONT1</name>
+       <description>DPHY Data Lane0 LP1 Contention Error (ppi_errcontentionp1_lan0) interrupt flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ESOT</name>
+       <description>DPHY Data Lane0 Start-of-Transmission (SoT) Error (ppi_errsoths_lan0) interrupt flag</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1ESOT</name>
+       <description>DPHY Data Lane1 Start-of-Transmission (SoT) Error (ppi_errsoths_lan1) interrupt flag</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ESOTS</name>
+       <description>DPHY Data Lane0 SOT Synchronization Error (ppi_errsotsynchs_lan0) interrupt flag</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1ESOTS</name>
+       <description>DPHY Data Lane1 SOT Synchronization Error (ppi_errsotsynchs_lan1) interrupt flag</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0EESC</name>
+       <description>DPHY Data Lane0 Escape Entry Error (ppi_erresc_lan0) interrupt flag</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1EESC</name>
+       <description>DPHY Data Lane1 Escape Entry Error (ppi_erresc_lan1) interrupt flag</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ESESC</name>
+       <description>DPHY Data Lane0 Low-Power Data Transmission Synchronization Error (ppi_errsyncesc_lan0) interrupt flag</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1ESESC</name>
+       <description>DPHY Data Lane1 Low-Power Data Transmission Synchronization Error (ppi_errsyncesc_lan0) interrupt flag</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ECTL</name>
+       <description>DPHY Data Lane0 Control Error (ppi_errcontrol_lan0) interrupt flag</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1ECTL</name>
+       <description>DPHY Data Lane1 Control Error (ppi_errcontrol_lan0) interrupt flag</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RX_EINT_CTRL_IE</name>
+     <description>RX Controller Interrupt Enable Register.</description>
+     <addressOffset>0x610</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EECC2</name>
+       <description>CSI RX ECC 2-bit Error interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EECC1</name>
+       <description>CSI RX ECC 1-bit Error interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ECRC</name>
+       <description>CSI RX CRC Error interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EID</name>
+       <description>CSI RX Packet Header Data ID Error interrupt enable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PKTFFOV</name>
+       <description>CSI RX Packet FIFO Overrun interrupt enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ULPSA</name>
+       <description>CSI Data Lane0 ULPSS Active interrupt enable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1ULPSA</name>
+       <description>CSI Data Lane1 ULPSS Active interrupt enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ULPSM</name>
+       <description>CSI Data Lane0 ULPSS Mark interrupt enable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1ULPSM</name>
+       <description>CSI Data Lane1 ULPSS Mark interrupt enable</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CL0ULPSA</name>
+       <description>CSI Clock Lane0 ULPSS Active interrupt enable</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CL0ULPSM</name>
+       <description>CSI Data Lane0 ULPSS Mark interrupt enable</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RX_EINT_CTRL_IF</name>
+     <description>RX Controller Interrupt Flag Register.</description>
+     <addressOffset>0x614</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>EECC2</name>
+       <description>CSI RX ECC 2-bit Error interrupt flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EECC1</name>
+       <description>CSI RX ECC 1-bit Error interrupt flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ECRC</name>
+       <description>CSI RX CRC Error interrupt flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EID</name>
+       <description>CSI RX Packet Header Data ID Error interrupt flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PKTFFOV</name>
+       <description>CSI RX Packet FIFO Overrun interrupt flag</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ULPSA</name>
+       <description>CSI Data Lane0 ULPSS Active interrupt flag</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1ULPSA</name>
+       <description>CSI Data Lane1 ULPSS Active interrupt flag</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0ULPSM</name>
+       <description>CSI Data Lane0 ULPSS Mark interrupt flag</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1ULPSM</name>
+       <description>CSI Data Lane1 ULPSS Mark interrupt flag</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CL0ULPSA</name>
+       <description>CSI Clock Lane0 ULPSS Active interrupt flag</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CL0ULPSM</name>
+       <description>CSI Data Lane0 ULPSS Mark interrupt flag</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PPI_STOPSTATE</name>
+     <description>DPHY PPI Stop State Register.</description>
+     <addressOffset>0x700</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DL0STOP</name>
+       <description>CSI Data Lane0 Stop State.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL1STOP</name>
+       <description>CSI Data Lane1 Stop State.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CL0STOP</name>
+       <description>CSI Clock Lane0 Stop State.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PPI_TURNAROUND_CFG</name>
+     <description>DPHY PPI Turn-Around Configuration Register.</description>
+     <addressOffset>0x704</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DL0TAREQ</name>
+       <description>CSI Data Lane0 turn around request.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0TADIS</name>
+       <description>CSI Data Lane0 turn around disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DL0FRCRX</name>
+       <description>CSI Data Lane0 force RX mode.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--CSI2 Camera Serial Interface Registers.-->
+  <peripheral>
+   <name>DMA</name>
+   <description>DMA Controller Fully programmable, chaining capable DMA channels.</description>
+   <baseAddress>0x40028000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DMA0</name>
+    <value>28</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA1</name>
+    <value>29</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA2</name>
+    <value>30</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA3</name>
+    <value>31</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA4</name>
+    <value>68</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA5</name>
+    <value>69</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA6</name>
+    <value>70</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA7</name>
+    <value>71</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA8</name>
+    <value>72</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA9</name>
+    <value>73</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA10</name>
+    <value>74</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA11</name>
+    <value>75</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA12</name>
+    <value>76</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA13</name>
+    <value>77</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA14</name>
+    <value>78</value>
+   </interrupt>
+   <interrupt>
+    <name>DMA15</name>
+    <value>79</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>INTEN</name>
+     <description>DMA Control Register.</description>
+     <addressOffset>0x000</addressOffset>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel 0 Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <description>Channel 1 Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <description>Channel 2 Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <description>Channel 3 Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH4</name>
+       <description>Channel 4 Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH5</name>
+       <description>Channel 5 Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH6</name>
+       <description>Channel 6 Interrupt Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH7</name>
+       <description>Channel 7 Interrupt Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>DMA Interrupt Register.</description>
+     <addressOffset>0x004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Channel Interrupt. To clear an interrupt, all active interrupt bits of the DMA_ST must be cleared. The interrupt bits are set only if their corresponding interrupt enable bits are set in DMA_CN.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <cluster>
+     <dim>8</dim>
+     <dimIncrement>0x20</dimIncrement>
+     <name>CH[%s]</name>
+     <description>DMA Channel registers.</description>
+     <headerStructName>dma_ch</headerStructName>
+     <addressOffset>0x100</addressOffset>
+     <access>read-write</access>
+     <register>
+      <name>CTRL</name>
+      <description>DMA Channel Control Register.</description>
+      <addressOffset>0x000</addressOffset>
+      <fields>
+       <field>
+        <name>EN</name>
+        <description>Channel Enable.  This bit is automatically cleared when DMA_ST.CH_ST changes from 1 to 0.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>RLDEN</name>
+        <description>Reload Enable. Setting this bit to 1 enables DMA_SRC, DMA_DST and DMA_CNT to be reloaded with their corresponding reload registers upon count-to-zero. This bit is also writeable in the Count Reload Register. Refer to the description on Buffer Chaining for use of this bit. If buffer chaining is not used this bit must be written with a 0. This bit should be set after the reload registers have been programmed.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>PRI</name>
+        <description>DMA Priority.</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>high</name>
+          <description>Highest Priority.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medHigh</name>
+          <description>Medium High Priority.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>medLow</name>
+          <description>Medium Low Priority.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>low</name>
+          <description>Lowest Priority.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>REQUEST</name>
+        <description>Request Select. Select DMA request line for this channel. If memory-to-memory is selected, the channel operates as if the request is always active.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>6</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>MEMTOMEM</name>
+          <description>Memory To Memory</description>
+          <value>0x00</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1RX</name>
+          <description>SPI1 RX</description>
+          <value>0x01</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0RX</name>
+          <description>UART0 RX</description>
+          <value>0x04</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1RX</name>
+          <description>UART1 RX</description>
+          <value>0x05</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0RX</name>
+          <description>I2C0 RX</description>
+          <value>0x07</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1RX</name>
+          <description>I2C1 RX</description>
+          <value>0x08</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>ADC</name>
+          <description>ADC</description>
+          <value>0x09</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2RX</name>
+          <description>I2C2 RX</description>
+          <value>0x0A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>CSI2RX</name>
+          <description>CSI2 RX</description>
+          <value>0x0C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>PCIFRX</name>
+          <description>PCIF RX</description>
+          <value>0x0D</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2RX</name>
+          <description>UART2 RX</description>
+          <value>0x0E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0RX</name>
+          <description>SPI0 RX</description>
+          <value>0x0F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESRX</name>
+          <description>AES RX</description>
+          <value>0x10</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2SRX</name>
+          <description>I2S RX</description>
+          <value>0x1E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI1TX</name>
+          <description>SPI1 TX</description>
+          <value>0x21</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART0TX</name>
+          <description>UART0 TX</description>
+          <value>0x24</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART1TX</name>
+          <description>UART1 TX</description>
+          <value>0x25</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C0TX</name>
+          <description>I2C0 TX</description>
+          <value>0x27</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C1TX</name>
+          <description>I2C1 TX</description>
+          <value>0x28</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2C2TX</name>
+          <description>I2C2 TX</description>
+          <value>0x2A</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>CRCTX</name>
+          <description>CRC TX</description>
+          <value>0x2C</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>UART2TX</name>
+          <description>UART2 TX</description>
+          <value>0x2E</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>SPI0TX</name>
+          <description>SPI0 TX</description>
+          <value>0x2F</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>AESTX</name>
+          <description>AES TX</description>
+          <value>0x30</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>I2STX</name>
+          <description>I2S TX</description>
+          <value>0x3E</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_WAIT</name>
+        <description>Request Wait Enable.  When enabled, delay timer start until DMA request transitions from active to inactive.</description>
+        <bitOffset>10</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_PER</name>
+        <description>Timeout Period Select.</description>
+        <bitOffset>11</bitOffset>
+        <bitWidth>3</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>to4</name>
+          <description>Timeout of 3 to 4 prescale clocks.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to8</name>
+          <description>Timeout of 7 to 8 prescale clocks.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to16</name>
+          <description>Timeout of 15 to 16 prescale clocks.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to32</name>
+          <description>Timeout of 31 to 32 prescale clocks.</description>
+          <value>3</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to64</name>
+          <description>Timeout of 63 to 64 prescale clocks.</description>
+          <value>4</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to128</name>
+          <description>Timeout of 127 to 128 prescale clocks.</description>
+          <value>5</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to256</name>
+          <description>Timeout of 255 to 256 prescale clocks.</description>
+          <value>6</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>to512</name>
+          <description>Timeout of 511 to 512 prescale clocks.</description>
+          <value>7</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>TO_CLKDIV</name>
+        <description>Pre-Scale Select. Selects the Pre-Scale divider for timer clock input.</description>
+        <bitOffset>14</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable timer.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div256</name>
+          <description>hclk / 256.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div64k</name>
+          <description>hclk / 64k.</description>
+          <value>2</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>div16M</name>
+          <description>hclk / 16M.</description>
+          <value>3</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCWD</name>
+        <description>Source Width. In most cases, this will be the data width of each AHB transactions. However, the width will be reduced in the cases where DMA_CNT indicates a smaller value.</description>
+        <bitOffset>16</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>SRCINC</name>
+        <description>Source Increment Enable. This bit enables DMA_SRC increment upon every AHB transaction. This bit is forced to 0 for DMA receive from peripherals.</description>
+        <bitOffset>18</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTWD</name>
+        <description>Destination Width. Indicates the width of the each AHB transactions to the destination peripheral or memory. (The actual width may be less than this if there are insufficient bytes in the DMA FIFO for the full width).</description>
+        <bitOffset>20</bitOffset>
+        <bitWidth>2</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>byte</name>
+          <description>Byte.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>halfWord</name>
+          <description>Halfword.</description>
+          <value>1</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>word</name>
+          <description>Word.</description>
+          <value>2</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>DSTINC</name>
+        <description>Destination Increment Enable. This bit enables DMA_DST increment upon every AHB transaction. This bit is forced to 0 for DMA transmit to peripherals.</description>
+        <bitOffset>22</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>BURST_SIZE</name>
+        <description>Burst Size. The number of bytes to be transferred into and out of the DMA FIFO in a single burst.  Burst size equals 1 + value stored in this field.</description>
+        <bitOffset>24</bitOffset>
+        <bitWidth>5</bitWidth>
+       </field>
+       <field>
+        <name>DIS_IE</name>
+        <description>Channel Disable Interrupt Enable. When enabled, the IPEND will be set to 1 whenever CH_ST changes from 1 to 0.</description>
+        <bitOffset>30</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IE</name>
+        <description>Count-to-zero Interrupts Enable. When enabled, the IPEND will be set to 1 whenever a count-to-zero event occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>STATUS</name>
+      <description>DMA Channel Status Register.</description>
+      <addressOffset>0x004</addressOffset>
+      <fields>
+       <field>
+        <name>STATUS</name>
+        <description>Channel Status. This bit is used to indicate to the programmer when it is safe to change the configuration, address, and count registers for the channel. Whenever this bit is cleared by hardware,  the DMA_CFG.CHEN bit is also cleared (if not cleared already).</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>IPEND</name>
+        <description>Channel Interrupt.</description>
+        <bitOffset>1</bitOffset>
+        <bitWidth>1</bitWidth>
+        <access>read-only</access>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>inactive</name>
+          <description>No interrupt is pending.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>pending</name>
+          <description>An interrupt is pending.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+       <field>
+        <name>CTZ_IF</name>
+        <description>Count-to-Zero (CTZ) Interrupt Flag</description>
+        <bitOffset>2</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>RLD_IF</name>
+        <description>Reload Event Interrupt Flag.</description>
+        <bitOffset>3</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>BUS_ERR</name>
+        <description>Bus Error. Indicates that an AHB abort was received and the channel has been disabled.</description>
+        <bitOffset>4</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+       <field>
+        <name>TO_IF</name>
+        <description>Time-Out Event Interrupt Flag.</description>
+        <bitOffset>6</bitOffset>
+        <bitWidth>1</bitWidth>
+        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRC</name>
+      <description>Source Device Address. If SRCINC=1, the counter bits are incremented by 1,2, or 4, depending on the data width of each AHB cycle. For peripheral transfers, some or all of the actual address bits are fixed. If SRCINC=0, this register remains constant. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with the contents of DMA_SRC_RLD.</description>
+      <addressOffset>0x008</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DST</name>
+      <description>Destination Device Address. For peripheral transfers, some or all of the actual address bits are fixed. If DSTINC=1, this register is incremented on every AHB write out of the DMA FIFO. They are incremented by 1, 2, or 4, depending on the data width of each AHB cycle. In the case where a count-to-zero condition occurs while RLDEN=1, the register is reloaded with DMA_DST_RLD.</description>
+      <addressOffset>0x00C</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <bitOffset>0</bitOffset>
+        <bitWidth>32</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNT</name>
+      <description>DMA Counter. The user loads this register with the number of bytes to transfer. This counter decreases on every AHB cycle into the DMA FIFO. The decrement will be 1, 2, or 4 depending on the data width of each AHB cycle. When the counter reaches 0, a count-to-zero condition is triggered.</description>
+      <addressOffset>0x010</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>DMA Counter.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>SRCRLD</name>
+      <description>Source Address Reload Value. The value of this register is loaded into DMA0_SRC upon a count-to-zero condition.</description>
+      <addressOffset>0x014</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Source Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>DSTRLD</name>
+      <description>Destination Address Reload Value. The value of this register is loaded into DMA0_DST upon a count-to-zero condition.</description>
+      <addressOffset>0x018</addressOffset>
+      <fields>
+       <field>
+        <name>ADDR</name>
+        <description>Destination Address Reload Value.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>31</bitWidth>
+       </field>
+      </fields>
+     </register>
+     <register>
+      <name>CNTRLD</name>
+      <description>DMA Channel Count Reload Register.</description>
+      <addressOffset>0x01C</addressOffset>
+      <fields>
+       <field>
+        <name>CNT</name>
+        <description>Count Reload Value. The value of this register is loaded into DMA0_CNT upon a count-to-zero condition.</description>
+        <bitOffset>0</bitOffset>
+        <bitWidth>24</bitWidth>
+       </field>
+       <field>
+        <name>EN</name>
+        <description>Reload Enable. This bit should be set after the address reload registers have been programmed. This bit is automatically cleared to 0 when reload occurs.</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+        <enumeratedValues>
+         <enumeratedValue>
+          <name>dis</name>
+          <description>Disable.</description>
+          <value>0</value>
+         </enumeratedValue>
+         <enumeratedValue>
+          <name>en</name>
+          <description>Enable.</description>
+          <value>1</value>
+         </enumeratedValue>
+        </enumeratedValues>
+       </field>
+      </fields>
+     </register>
+    </cluster>
+   </registers>
+  </peripheral>
+<!--DMA DMA Controller Fully programmable, chaining capable DMA channels.-->
+  <peripheral>
+   <name>DVS</name>
+   <description>Dynamic Voltage Scaling</description>
+   <prependToName>DVS_</prependToName>
+   <baseAddress>0x40003C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0030</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>DVS</name>
+    <description>Dynamic Voltage Scaling Interrupt</description>
+    <value>83</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTL</name>
+     <description>Control Register</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>MON_ENA</name>
+       <description>Enable the DVS monitoring circuit</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ENA</name>
+       <description>Enable the power supply adjustment based on measurements</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PS_FB_DIS</name>
+       <description>Power Supply Feedback Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTRL_TAP_ENA</name>
+       <description>Use the TAP Select for automatic adjustment or monitoring</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PROP_DLY</name>
+       <description>Additional delay to monitor lines</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>MON_ONESHOT</name>
+       <description>Measure delay once</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GO_DIRECT</name>
+       <description>Operate in automatic mode or move directly</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DIRECT_REG</name>
+       <description>Step incrementally to target voltage</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PRIME_ENA</name>
+       <description>Include a delay line priming signal before monitoring</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LIMIT_IE</name>
+       <description>Enable Limit Error Interrupt</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RANGE_IE</name>
+       <description>Enable Range Error Interrupt</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_IE</name>
+       <description>Enable Adjustment Error Interrupt</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>REF_SEL</name>
+       <description>Select TAP used for voltage adjustment</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>INC_VAL</name>
+       <description>Step size to increment voltage when in automatic mode</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>DVS_PS_APB_DIS</name>
+       <description>Prevent the application code from adjusting Vcore</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DVS_HI_RANGE_ANY</name>
+       <description>Any high range signal from a delay line will cause a voltage adjustment</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FB_TO_IE</name>
+       <description>Enable Voltage Adjustment Timeout Interrupt</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FC_LV_IE</name>
+       <description>Enable Low Voltage Interrupt</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PD_ACK_ENA</name>
+       <description>Prevent DVS from ack'ing a request to enter a low power mode until in the idle state</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ABORT</name>
+       <description>Causes the DVS to enter the idle state immediately on a request to enter a low power mode</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>Status Fields</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000000</resetValue>
+     <fields>
+      <field>
+       <name>DVS_STATE</name>
+       <description>State machine state</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_UP_ENA</name>
+       <description>DVS Raising voltage</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_DWN_ENA</name>
+       <description>DVS Lowering voltage</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ACTIVE</name>
+       <description>Adjustment to a Direct Voltage</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTR_TAP_OK</name>
+       <description>Tap Enabled and the Tap is withing Hi/Low limits</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTR_TAP_SEL</name>
+       <description>Status of selected center tap delay line detect output</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SLOW_TRIP_DET</name>
+       <description>Provides the current combined status of all selected Low Range delay lines</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FAST_TRIP_DET</name>
+       <description>Provides the current combined status of all selected High Range delay lines</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PS_IN_RANGE</name>
+       <description>Indicates if the power supply is in range</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PS_VCNTR</name>
+       <description>Voltage Count value sent to the power supply</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>MON_DLY_OK</name>
+       <description>Indicates the monitor delay count is at 0</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_DLY_OK</name>
+       <description>Indicates the adjustment delay count is at 0</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LO_LIMIT_DET</name>
+       <description>Power supply voltage counter is at low limit</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HI_LIMIT_DET</name>
+       <description>Power supply voltage counter is at high limit</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VALID_TAP</name>
+       <description>At least one delay line has been enabled</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LIMIT_ERR</name>
+       <description>Interrupt flag that indicates a voltage count is at/beyond manufacturer limits</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RANGE_ERR</name>
+       <description>Interrupt flag that indicates a tap has an invalid value</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADJ_ERR</name>
+       <description>Interrupt flag that indicates up and down adjustment requested simultaneously</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>REF_SEL_ERR</name>
+       <description>Indicates the ref select register  bit is out of range</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FB_TO_ERR</name>
+       <description>Interrupt flag that indicates a timeout while adjusting the voltage</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FB_TO_ERR_S</name>
+       <description>Interrupt flag that mirror FB_TO_ERR and is write one clear</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FC_LV_DET_INT</name>
+       <description>Interrupt flag that indicates the power supply voltage requested is below the low threshold</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FC_LV_DET_S</name>
+       <description>Interrupt flag that mirrors FC_LV_DET_INT</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DIRECT</name>
+     <description>Direct control of target voltage</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>VOLTAGE</name>
+       <description>Sets the target power supply value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MON</name>
+     <description>Monitor Delay</description>
+     <addressOffset>0x00C</addressOffset>
+     <fields>
+      <field>
+       <name>DLY</name>
+       <description>Number of prescaled clocks between delay line samples</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+      <field>
+       <name>PRE</name>
+       <description>Number of clocks before DVS_MON_DLY is decremented</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADJ_UP</name>
+     <description>Up Delay Register</description>
+     <addressOffset>0x010</addressOffset>
+     <fields>
+      <field>
+       <name>DLY</name>
+       <description>Number of prescaled clocks between updates of the adjustment delay counter</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PRE</name>
+       <description>Number of clocks before DVS_ADJ_UP_DLY is decremented</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADJ_DWN</name>
+     <description>Down Delay Register</description>
+     <addressOffset>0x014</addressOffset>
+     <fields>
+      <field>
+       <name>DLY</name>
+       <description>Number of prescaled clocks between updates of the adjustment delay counter</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>PRE</name>
+       <description>Number of clocks before DVS_ADJ_DWN_DLY is decremented</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>THRES_CMP</name>
+     <description>Up Delay Register</description>
+     <addressOffset>0x018</addressOffset>
+     <fields>
+      <field>
+       <name>VCNTR_THRES_CNT</name>
+       <description>Value used to determine 'low voltage' range</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VCNTR_THRES_MASK</name>
+       <description>Mask applied to threshold and vcount to determine if the device is in a low voltage range</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>5</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>TAP_SEL[%s]</name>
+     <description>DVS Tap Select Register</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Select delay line tap for lower bound of auto adjustment</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>LO_TAP_STAT</name>
+       <description>Returns last delay line tap value</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTR_TAP_STAT</name>
+       <description>Returns last delay line tap value</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HI_TAP_STAT</name>
+       <description>Returns last delay line tap value</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Selects delay line tap for high point of auto adjustment</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>CTR</name>
+       <description>Selects delay line tap for center point of auto adjustment</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>COARSE</name>
+       <description>Selects delay line tap for coarse or fixed delay portion of the line</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>DET_DLY</name>
+       <description>Number of HCLK between delay line launch and sampling</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>DELAY_ACT</name>
+       <description>Set if the delay is active</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--DVS Dynamic Voltage Scaling-->
+  <peripheral>
+   <name>FCR</name>
+   <description>Function Control Register.</description>
+   <baseAddress>0x40000800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>FCTRL0</name>
+     <description>Function Control 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>USBCLKSEL</name>
+       <description>USB Core Clock Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>I2C0DGEN0</name>
+       <description>I2C0 SDA Pad Deglitcher enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C0DGEN1</name>
+       <description>I2C0 SCL Pad Deglitcher enable.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN0</name>
+       <description>I2C1 SDA Pad Deglitcher enable.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C1DGEN1</name>
+       <description>I2C1 SCL Pad Deglitcher enable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2DGEN0</name>
+       <description>I2C2 SDA Pad Deglitcher enable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>I2C2DGEN1</name>
+       <description>I2C2 SCL Pad Deglitcher enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Deglitcher disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Deglitcher enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL0</name>
+     <description>Automatic Calibration 0.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ACEN</name>
+       <description>Auto-calibration Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ACRUN</name>
+       <description>Autocalibration Run.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LDTRM</name>
+       <description>Load Trim.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>GAININV</name>
+       <description>Invert Gain.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ATOMIC</name>
+       <description>Atomic mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Not Running.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>run</name>
+         <description>Running.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MU</name>
+       <description>MU value.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>HIRC96MACTMROUT</name>
+       <description>HIRC96M Trim Value.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL1</name>
+     <description>Automatic Calibration 1.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INITTRM</name>
+       <description>Initial Trim Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTOCAL2</name>
+     <description>Automatic Calibration 2</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONECNT</name>
+       <description>Auto-callibration Done Counter Setting.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>ACDIV</name>
+       <description>Auto-callibration Div Setting.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>URVBOOTADDR</name>
+     <description>RISC-V Boot Address.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>URVCTRL</name>
+     <description>RISC-V Control Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MEMSEL</name>
+       <description>RAM2, RAM3 exclusive ownership.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IFLUSHEN</name>
+       <description>URV instruction flush enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>XO32MKS</name>
+     <description>RISC-V Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLK</name>
+       <description>Kick Start XO Counter Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Kick Start XO Enable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DRIVER</name>
+       <description>Kick Start XO Driver</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>PULSE</name>
+       <description>Kick Start XO 2X Pulse</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKSEL</name>
+       <description>Kick Start XO Clock Select</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>none</name>
+         <description>No kick start clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>test</name>
+         <description>Test Clock in P1.2 (TMR3[22]=1).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ISO</name>
+         <description>Internal secondary oscilator</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>Internal Primary Oscilator</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TS0</name>
+     <description>Temp Sensor trim0</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>GAIN</name>
+       <description>Unsigned gain for temp sensor normalization Temp degrees C = (ADC result * TS_GAIN) + TS_OFFSET.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TS1</name>
+     <description>Temp Sensor trim1</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>OFFSET</name>
+       <description>Signed gain for temp sensor normalization Temp degrees C = (ADC result * TS_GAIN) + TS_OFFSET.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>14</bitWidth>
+      </field>
+      <field>
+       <name>TS_OFFSET_SIGN</name>
+       <description>Sign extension of TS_OFFSET[13:0]</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>18</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCREFTRIM0</name>
+     <description>Temp Sensor trim1</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VREFP</name>
+       <description>Trimming code for VREFP output of reference buffer</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VREFM</name>
+       <description>Trimming code for VREFM output of reference buffer</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VCM</name>
+       <description>Trimming code for VCM output of reference buffer</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>VX2_TUNE</name>
+       <description>Controls tuning capacitor in fine DAC (offset binary)</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCREFTRIM1</name>
+     <description>Temp Sensor trim1</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VREFP</name>
+       <description>Trimming code for VREFP output of reference buffer</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VREFM</name>
+       <description>Trimming code for VREFM output of reference buffer</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VCM</name>
+       <description>Trimming code for VCM output of reference buffer</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>VX2_TUNE</name>
+       <description>Controls tuning capacitor in fine DAC (offset binary)</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCREFTRIM2</name>
+     <description>Temp Sensor trim1</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VREFP</name>
+       <description>Trimming code for VREFP output of reference buffer</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VREFM</name>
+       <description>Trimming code for VREFM output of reference buffer</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VCM</name>
+       <description>Trimming code for VCM output of reference buffer</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>VX2_TUNE</name>
+       <description>Controls tuning capacitor in fine DAC (offset binary)</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FCR Function Control Register.-->
+  <peripheral>
+   <name>FLC</name>
+   <description>Flash Memory Control.</description>
+   <prependToName>FLSH_</prependToName>
+   <baseAddress>0x40029000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>Flash_Controller</name>
+    <description>Flash Controller interrupt.</description>
+    <value>23</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ADDR</name>
+     <description>Flash Write Address.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Address for next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Flash Clock Divide. The clock (PLL0) is divided by this value to generate a 1 MHz clock for Flash controller.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetValue>0x00000064</resetValue>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Flash Clock Divide. The clock is divided by this value to generate a 1MHz clock for flash controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Flash Control Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WR</name>
+       <description>Write.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="WR">
+       <name>ME</name>
+       <description>Mass Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="WR">
+       <name>PGE</name>
+       <description>Page Erase.  This bit is automatically cleared after the operation.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WDTH</name>
+       <description>Data Width.  This bits selects write data width.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>size128</name>
+         <description>128-bit.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>size32</name>
+         <description>32-bit.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ERASE_CODE</name>
+       <description>Erase Code.  The ERASE_CODE must be set up property before erase operation can be initiated. These bits are automatically cleared after the operation is complete.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>erasePage</name>
+         <description>Enable Page Erase.</description>
+         <value>0x55</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>eraseAll</name>
+         <description>Enable Mass Erase. The debug port must be enabled.</description>
+         <value>0xAA</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PEND</name>
+       <description>Flash Pending.  When Flash operation is in progress (busy), Flash reads and writes will fail. When PEND is set, write to all Flash registers, with exception of the Flash interrupt register, are ignored.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>LVE</name>
+       <description>Low Voltage enable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UNLOCK</name>
+       <description>Flash Unlock.  The correct unlock code must be written to these four bits before any Flash write or erase operation is allowed.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>Flash Unlocked.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>Flash Locked.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTR</name>
+     <description>Flash Interrupt Register.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Flash Done Interrupt.  This bit is set to 1 upon Flash write or erase completion.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AF</name>
+       <description>Flash Access Fail.  This bit is set when an attempt is made to write the flash while the flash is busy or the flash is locked. This bit can only be set to 1 by hardware.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No Failure.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>Failure occurs.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DONEIE</name>
+       <description>Flash Done Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DONEIE">
+       <name>AFIE</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>DATA[%s]</name>
+     <description>Flash Write Data.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data next operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ACTRL</name>
+     <description>Access Control Register. Writing the ACTRL register with the following values in the order shown, allows read and write access to the system and user Information block:
+    pflc-actrl = 0x3a7f5ca3;
+    pflc-actrl = 0xa1e34f20;
+    pflc-actrl = 0x9608b2c1. When unlocked, a write of any word will disable access to system and user information block. Readback of this register is always zero.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>ACTRL</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR0</name>
+     <description>WELR0</description>
+     <addressOffset>0x80</addressOffset>
+     <fields>
+      <field>
+       <name>WELR0</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR0</name>
+     <description>RLR0</description>
+     <addressOffset>0x84</addressOffset>
+     <fields>
+      <field>
+       <name>RLR0</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR1</name>
+     <description>WELR1</description>
+     <addressOffset>0x88</addressOffset>
+     <fields>
+      <field>
+       <name>WELR1</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR1</name>
+     <description>RLR1</description>
+     <addressOffset>0x8C</addressOffset>
+     <fields>
+      <field>
+       <name>RLR1</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR2</name>
+     <description>WELR2</description>
+     <addressOffset>90</addressOffset>
+     <fields>
+      <field>
+       <name>WELR2</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR2</name>
+     <description>RLR2</description>
+     <addressOffset>0x94</addressOffset>
+     <fields>
+      <field>
+       <name>RLR2</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR3</name>
+     <description>WELR3</description>
+     <addressOffset>0x98</addressOffset>
+     <fields>
+      <field>
+       <name>WELR3</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR3</name>
+     <description>RLR3</description>
+     <addressOffset>0x9C</addressOffset>
+     <fields>
+      <field>
+       <name>RLR3</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WELR4</name>
+     <description>WELR4</description>
+     <addressOffset>0xA0</addressOffset>
+     <fields>
+      <field>
+       <name>WELR4</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RLR4</name>
+     <description>RLR4</description>
+     <addressOffset>0xA4</addressOffset>
+     <fields>
+      <field>
+       <name>RLR4</name>
+       <description>Access control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--FLC Flash Memory Control.-->
+  <peripheral>
+   <name>GCR</name>
+   <description>Global Control Registers.</description>
+   <baseAddress>0x40000000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SYSCTRL</name>
+     <description>System Control.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0xFFFFFFFE</resetMask>
+     <fields>
+      <field>
+       <name>BSTAPEN</name>
+       <description>Boundary Scan TAP enable. When enabled, the JTAG port is conneted to the Boundary Scan TAP instead of the ARM ICE.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FLASH_PAGE_FLIP</name>
+       <description>Flips the Flash bottom and top halves. (Depending on the total flash size, each half is either 256K or 512K). Initiating a flash page flip will cause a flush of both the data buffer on the DCODE bus and the internal instruction buffer.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Physical layout matches logical layout.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>swapped</name>
+         <description>Bottom half mapped to logical top half and vice versa.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ICC0_FLUSH</name>
+       <description>Code Cache Flush. This bit is used to flush the code caches and the instruction buffer of the Cortex-M4. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>normal</name>
+         <description>Normal Code Cache Operation</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Code Caches and CPU instruction buffer are flushed </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ROMDONE</name>
+       <description>ROM_DONE status. Used to disable SWD interface during system initialization procedure</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CCHK</name>
+       <description>Compute ROM Checksum. This bit is self-cleared when calculation is completed. Once set, software clearing this bit is ignored and the bit will remain set until the operation is completed.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>complete</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SWD_DIS</name>
+       <description> Serial Wire Debug Disable. This bit is used to disable the serial wire debug interface This bit is only writeable if (FMV lock word is not programmed) or if (ICE lock word is not programmed and the ROM_DONE bit is not set).</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHKRES</name>
+       <description>ROM Checksum Result. This bit is only valid when CHKRD=1.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pass</name>
+         <description>ROM Checksum Correct.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>fail</name>
+         <description>ROM Checksum Fail.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>OVR</name>
+       <description>Operating Voltage Range.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>V0_9</name>
+         <description>0.9V</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>V1_0</name>
+         <description>1.0V</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>V1_1</name>
+         <description>1.1V</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST0</name>
+     <description>Reset.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>DMA Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="DMA">
+       <name>WDT0</name>
+       <description>Watchdog Timer 0 Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO0</name>
+       <description>GPIO0 Reset. Setting this bit to 1 resets GPIO0 pins to their default states.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>GPIO1</name>
+       <description>GPIO1 Reset. Setting this bit to 1 resets GPIO1 pins to their default states.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR0</name>
+       <description>Timer 0 Reset. Setting this bit to 1 resets Timer 0 blocks.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR1</name>
+       <description>Timer 1 Reset. Setting this bit to 1 resets Timer 1 blocks.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR2</name>
+       <description>Timer 2 Reset. Setting this bit to 1 resets Timer 2 blocks.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TMR3</name>
+       <description>Timer 3 Reset. Setting this bit to 1 resets Timer 3 blocks.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART0</name>
+       <description>UART 0 Reset. Setting this bit to 1 resets all UART 0 blocks.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART1</name>
+       <description>UART 1 Reset. Setting this bit to 1 resets all UART 1 blocks.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SPI1</name>
+       <description>SPI 1 Reset. Setting this bit to 1 resets all SPI 1 blocks.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>I2C0</name>
+       <description>I2C 0 Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>RTC</name>
+       <description>Real Time Clock Reset.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SMPHR</name>
+       <description>Semaphore Reset.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>USB</name>
+       <description>USB Reset.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>TRNG</name>
+       <description>TRNG Reset. This reset is only available during the manufacture testing phase.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>CNN</name>
+       <description>CNN Reset.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>ADC</name>
+       <description>ADC Reset.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>UART2</name>
+       <description>UART2 Reset. Setting this bit to 1 resets all UART 2 blocks.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SOFT</name>
+       <description>Soft Reset. Setting this bit to 1 resets everything except the CPU and the watchdog timer.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>PERIPH</name>
+       <description>Peripheral Reset. Setting this bit to 1 resets all peripherals. The CPU core, the watchdog timer, and all GPIO pins are unaffected by this reset.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="DMA">
+       <name>SYS</name>
+       <description>System Reset. Setting this bit to 1 resets the CPU core and all peripherals, including the watchdog timer.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <fields>
+      <field>
+       <name>SYSCLK_DIV</name>
+       <description>Prescaler Select. This 3 bit field sets the system operating frequency by controlling the prescaler that divides the output of the IPLL0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>Divide by 1.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2</name>
+         <description>Divide by 2.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <description>Divide by 4.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <description>Divide by 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <description>Divide by 16.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div32</name>
+         <description>Divide by 32.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div64</name>
+         <description>Divide by 64.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div128</name>
+         <description>Divide by 128.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_SEL</name>
+       <description>Clock Source Select. This 3 bit field selects the source for the system clock.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ISO</name>
+         <description>The internal 60 MHz oscillator is used for the system clock.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPLL</name>
+         <description>The internal 120 MHz IPLL is used for the system clock.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EBO</name>
+         <description>The external 25 MHz input is used for the system clock.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>INRO</name>
+         <description>8 kHz LIRC is used for the system clock.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO</name>
+         <description>The internal 100 MHz oscillator is used for the system clock.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IBRO</name>
+         <description>The internal 7.3725 MHz oscillator is used for the system clock.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ERTCO</name>
+         <description>External 32 kHz input is used for the system clock.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>EXTCLK</name>
+         <description>External clock input is used for the system clock.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SYSCLK_RDY</name>
+       <description>Clock Ready. This read only bit reflects whether the currently selected system clock source is running.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Switchover to the new clock source (as selected by CLKSEL) has not yet occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>System clock running from CLKSEL clock source.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EBO_EN</name>
+       <description>External Base Oscillator</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Is Disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Is Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="EBO_EN">
+       <name>ERTCO_EN</name>
+       <description>32 kHz Oscillator Enable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="EBO_EN">
+       <name>ISO_EN</name>
+       <description>60 MHz Internal Oscillator Enable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="EBO_EN">
+       <name>IPO_EN</name>
+       <description>100 MHz Clock Enable.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="EBO_EN">
+       <name>IBRO_EN</name>
+       <description>7.3725 MHz Clock Enable.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_VS</name>
+       <description>7.3725 MHz High Frequency Internal Reference Clock Voltage Select. This register bit is used to select the power supply to the IBRO.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Vcor</name>
+         <description>VCore Supply</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>1V</name>
+         <description>Dedicated 1V regulated supply.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EBO_RDY</name>
+       <description>External Base Oscillator Ready.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>Is not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Is Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="EBO_RDY">
+       <name>ERTCO_RDY</name>
+       <description>32 kHz Crystal Oscillator Ready.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="EBO_RDY">
+       <name>ISO_RDY</name>
+       <description>60 MHz Oscillator Ready.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="EBO_RDY">
+       <name>IPO_RDY</name>
+       <description>100 MHz Clock Ready.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="EBO_RDY">
+       <name>IBRO_RDY</name>
+       <description>7.3725 MHz HIRC Ready.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="EBO_RDY">
+       <name>INRO_RDY</name>
+       <description>8 kHz Low Frequency Reference Clock Ready.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PM</name>
+     <description>Power Management.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>MODE</name>
+       <description>Operating Mode. This two bit field selects the current operating mode for the device. Note that code execution only occurs during ACTIVE mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Active Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>sleep</name>
+         <description>Cortex-M4 Active, RISC-V Sleep Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>standby</name>
+         <description>Standby Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>backup</name>
+         <description>Backup Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>lpm</name>
+         <description>LPM or CM4 Deep Sleep Mode.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>upm</name>
+         <description>UPM.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>powerdown</name>
+         <description>Power Down Mode.</description>
+         <value>10</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GPIO_WE</name>
+       <description>GPIO Wake Up Enable. This bit enables all GPIO pins as potential wakeup sources. Any GPIO configured for wakeup is capable of causing an exit from IDLE or STANDBY modes when this bit is set.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wake Up Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wake Up Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>RTC_WE</name>
+       <description>RTC Alarm Wake Up Enable. This bit enables RTC alarm as wakeup source. If enabled, the desired RTC alarm must be configured via the RTC control registers.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>USB_WE</name>
+       <description>USB Wake Up Enable. This bit enables USB IRQ as wakeup source</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>WUT_WE</name>
+       <description>WUT Wake Up Enable. This bit enables the Wake-Up Timer as wakeup source. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO_WE">
+       <name>AINCOMP_WE</name>
+       <description>AIN COMP Wake Up Enable. This bit enables AIN COMP as wakeup source. </description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ISO_PD</name>
+       <description>60 MHz power down. This bit selects the 60 MHz clock power state in DEEPSLEEP mode.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>active</name>
+         <description>Mode is Active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>deepsleep</name>
+         <description>Powered down in DEEPSLEEP.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="ISO_PD">
+       <name>IPO_PD</name>
+       <description>100 MHz power down. This bit selects 100 MHz clock power state in DEEPSLEEP mode. </description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="ISO_PD">
+       <name>IBRO_PD</name>
+       <description>7.3725 MHz power down. This bit selects 7.3725 MHz clock power state in DEEPSLEEP mode. </description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EBO_BP</name>
+       <description>EBO Bypass</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPLL_CTRL</name>
+     <description>IPLL Control</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RDY</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIV</name>
+     <description>Peripheral Clock Divider.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetValue>0x00000001</resetValue>
+     <fields>
+      <field>
+       <name>SDIOCLKDIV</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>IPO_DIV2</name>
+         <description>48 MHz</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPO_DIV4</name>
+         <description>24 MHz</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CNNCLKDIV</name>
+       <description>CNN Clock Divider.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div2</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div4</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div8</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div16</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div1</name>
+         <value>4</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CNNCLKSEL</name>
+       <description>CNN Clock Select.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>PCLK</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ISO</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IPLL</name>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS0</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO0</name>
+       <description>GPIO0 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>GPIO1</name>
+       <description>GPIO1 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>USB</name>
+       <description>USB Clock Disable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>DMA</name>
+       <description>DMA Clock Disable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>SPI1</name>
+       <description>SPI 1 Clock Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART0</name>
+       <description>UART 0 Clock Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>UART1</name>
+       <description>UART 1 Clock Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C0</name>
+       <description>I2C 0 Clock Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR0</name>
+       <description>Timer 0 Clock Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR1</name>
+       <description>Timer 1 Clock Disable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR2</name>
+       <description>Timer 2 Clock Disable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>TMR3</name>
+       <description>Timer 3 Clock Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>ADC</name>
+       <description>ADC Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>CNN</name>
+       <description>CNN Clock Disable.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>I2C1</name>
+       <description>I2C 1 Clock Disable.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO0">
+       <name>PT</name>
+       <description>Pluse Train Clock Disable.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMCTRL</name>
+     <description>Memory Clock Control Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>FWS</name>
+       <description>Flash Wait State. These bits define the number of wait-state cycles per Flash data read access. Minimum wait state is 2.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>SYSRAM0ECC</name>
+       <description>SYSRAM0 ECC Select.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MEMZ</name>
+     <description>Memory Zeroize Control.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>System RAM Block 0 Zeroization.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>nop</name>
+         <description>No operation/complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Start operation.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM1</name>
+       <description>System RAM Block 1 Zeroization.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM2</name>
+       <description>System RAM Block 2 Zeroization.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM3</name>
+       <description>System RAM Block 3 Zeroization.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM4</name>
+       <description>System RAM Block 4 Zeroization.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM5</name>
+       <description>System RAM Block 5 Zeroization.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM6</name>
+       <description>System RAM Block 6 Zeroization.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM7</name>
+       <description>System RAM Block 7 Zeroization.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>RAM0ECC</name>
+       <description>System RAM Block 0 ECC Zeroization.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICC0</name>
+       <description>Instruction Cache 0 Zeroization.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>ICC1</name>
+       <description>Instruction Cache 1 Zeroization.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="RAM0">
+       <name>USBFIFO</name>
+       <description>USB FIFO Zeroization.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSST</name>
+     <description>System Status Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>ICELOCK</name>
+       <description>ARM ICE Lock Status.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>unlocked</name>
+         <description>ICE is unlocked.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>locked</name>
+         <description>ICE is locked.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST1</name>
+     <description>Reset 1.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>I2C1</name>
+       <description>I2C1 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset_read</name>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>PT</name>
+       <description>PT Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SDHC</name>
+       <description>SDHC Reset.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>OWM</name>
+       <description>OWM Reset.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>CRC</name>
+       <description>CRC Reset.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>AES</name>
+       <description>AES Reset.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SPI0</name>
+       <description>SPI 0 Reset.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>CSI2PHY</name>
+       <description>CSI2 PHY Reset.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SMPHR</name>
+       <description>SMPHR Reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2S</name>
+       <description>I2S Reset.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>I2C2</name>
+       <description>I2C2 Reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>DVS</name>
+       <description>DVS Reset.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>SIMO</name>
+       <description>SIMO Reset.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>PCIF</name>
+       <description>PCIF Reset.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>CSI2</name>
+       <description>CSI2 Reset.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="I2C1">
+       <name>CPU1</name>
+       <description>CPU1 Reset.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS1</name>
+     <description>Peripheral Clock Disable.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>UART2</name>
+       <description>UART2 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="UART2">
+       <name>TRNG</name>
+       <description>TRNG Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SMPHR</name>
+       <description>SMPHR Clock Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SDHC</name>
+       <description>SDHC Clock Disable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>OWM</name>
+       <description>One-Wire Clock Disable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>CRC</name>
+       <description>CRC Clock Disable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>AES</name>
+       <description>AES Clock Disable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>SPI0</name>
+       <description>SPI0 AHB.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>PCIF</name>
+       <description>Parallel Camera Interface Clock Disable.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>I2S</name>
+       <description>I2S Clock Disable.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>I2C2</name>
+       <description>I2C2 Clock Disable.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>WDT0</name>
+       <description>Watch Dog Timer 0 Clock Disable.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>CSI2</name>
+       <description>CSI2 Clock Disable.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="UART2">
+       <name>CPU1</name>
+       <description>CPU1 Clock Disable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EVENTEN</name>
+     <description>Event Enable Register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>DMA</name>
+       <description>Enable DMA event. When this bit is set, a DMA event will cause an RXEV event to wake the CPU from WFE sleep mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX</name>
+       <description>Enable TXEV pin event. When this bit is set, TXEV event from the CPU is output to GPIO1.9.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REVISION</name>
+     <description>Revision Register.</description>
+     <addressOffset>0x50</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>REVISION</name>
+       <description>Manufacturer Chip Revision.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SYSIE</name>
+     <description>System Status Interrupt Enable Register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ICEUNLOCK</name>
+       <description>ARM ICE Unlock Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCERR</name>
+     <description>ECC Error Register</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCCED</name>
+     <description>ECC Not Double Error Detect Register</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Flag. Write 1 to clear.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCIE</name>
+     <description>ECC IRQ Enable Register</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>RAM</name>
+       <description>ECC System RAM0 Error Interrup Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ECCADDR</name>
+     <description>ECC Error Address Register</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ECCERRAD</name>
+       <description>ECC Error Address.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPR0</name>
+     <description>General Purpose Register 0</description>
+     <addressOffset>0x80</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCR Global Control Registers.-->
+  <peripheral>
+   <name>GCFR</name>
+   <description>Global Control Function Register.</description>
+   <baseAddress>0x40005800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>REG0</name>
+     <description>Register 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>cnnx16_0_pwr_en</name>
+       <description>CNNx16_0 Power Domain Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_1_pwr_en</name>
+       <description>CNNx16_1 Power Domain Enable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_2_pwr_en</name>
+       <description>CNNx16_2 Power Domain Enable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_3_pwr_en</name>
+       <description>CNNx16_3 Power Domain Enable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REG1</name>
+     <description>Register 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>cnnx16_0_ram_en</name>
+       <description>CNNx16_0 RAM Power Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_1_ram_en</name>
+       <description>CNNx16_1 RAM Power Enable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_2_ram_en</name>
+       <description>CNNx16_2 RAM Power Enable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_3_ram_en</name>
+       <description>CNNx16_3 RAM Power Enable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REG2</name>
+     <description>Register 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>cnnx16_0_iso</name>
+       <description>CNNx16_0 Power Domain Isolation</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_1_iso</name>
+       <description>CNNx16_1 Power Domain Isolation</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_2_iso</name>
+       <description>CNNx16_2 Power Domain Isolation</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_3_iso</name>
+       <description>CNNx16_3 Power Domain Isolation</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_0_data_ret_en</name>
+       <description>CNNx16_0 Pad Retention Control</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_1_data_ret_en</name>
+       <description>CNNx16_1 Pad Retention Control</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_2_data_ret_en</name>
+       <description>CNNx16_2 Pad Retention Control</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_3_data_ret_en</name>
+       <description>CNNx16_3 Pad Retention Control</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_0_ram_data_ret_en</name>
+       <description>CNNx16_0 RAM Pad Retention Control</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_1_ram_data_ret_en</name>
+       <description>CNNx16_1 RAM Pad Retention Control</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_2_ram_data_ret_en</name>
+       <description>CNNx16_2 RAM Pad Retention Control</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_3_ram_data_ret_en</name>
+       <description>CNNx16_3 RAM Pad Retention Control</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>REG3</name>
+     <description>Register 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>cnnx16_0_rst</name>
+       <description>CNNx16_0 Power Domain Reset</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_1_rst</name>
+       <description>CNNx16_1 Power Domain Reset</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_2_rst</name>
+       <description>CNNx16_2 Power Domain Reset</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cnnx16_3_rst</name>
+       <description>CNNx16_3 Power Domain Reset</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GCFR Global Control Function Register.-->
+  <peripheral>
+   <name>GPIO0</name>
+   <description>Individual I/O for each GPIO</description>
+   <groupName>GPIO</groupName>
+   <baseAddress>0x40008000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>GPIO0</name>
+    <description>GPIO0 interrupt.</description>
+    <value>24</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>EN0</name>
+     <description>GPIO Function Enable Register. Each bit controls the GPIO_EN setting for one GPIO pin on the associated port.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ALTERNATE</name>
+         <description>Alternate function enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GPIO</name>
+         <description>GPIO function is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_SET</name>
+     <description>GPIO Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN0_CLR</name>
+     <description>GPIO Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>GPIO Output Enable Register. Each bit controls the GPIO_OUT_EN setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>GPIO Output Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>GPIO Output Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_SET</name>
+     <description>GPIO Output Enable Set Function Enable Register. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN_CLR</name>
+     <description>GPIO Output Enable Clear Function Enable Register. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT</name>
+     <description>GPIO Output Register. Each bit controls the GPIO_OUT setting for one pin in the associated port.  This register can be written either directly, or by using the GPIO_OUT_SET and GPIO_OUT_CLR registers.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_OUT</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Drive Logic 0 (low) on GPIO output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>Drive logic 1 (high) on GPIO output.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_SET</name>
+     <description>GPIO Output Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_OUT to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_OUT bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUT_CLR</name>
+     <description>GPIO Output Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_OUT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>GPIO_OUT_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IN</name>
+     <description>GPIO Input Register. Read-only register to read from the logic states of the GPIO pins on this port.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_IN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTMODE</name>
+     <description>GPIO Interrupt Mode Register. Each bit in this register controls the interrupt mode setting for the associated GPIO pin on this port.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTMODE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>level</name>
+         <description>Interrupts for this pin are level triggered.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>edge</name>
+         <description>Interrupts for this pin are edge triggered.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTPOL</name>
+     <description>GPIO Interrupt Polarity Register. Each bit in this register controls the interrupt polarity setting for one GPIO pin in the associated port.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTPOL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>falling</name>
+         <description>Interrupts are latched on a falling edge or low level condition for this pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rising</name>
+         <description>Interrupts are latched on a rising edge or high condition for this pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INEN</name>
+     <description>GPIO Input Enable</description>
+     <addressOffset>0x30</addressOffset>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>GPIO Interrupt Enable Register. Each bit in this register controls the GPIO interrupt enable for the associated pin on the GPIO port.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupts are disabled for this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupts are enabled for this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_SET</name>
+     <description>GPIO Interrupt Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_INT_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_SET</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>set</name>
+         <description>Set GPIO_INT_EN bit in this position to '1'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN_CLR</name>
+     <description>GPIO Interrupt Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_INTEN_CLR</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Clear GPIO_INT_EN bit in this position to '0'</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>GPIO Interrupt Status Register. Each bit in this register contains the pending interrupt status for the associated GPIO pin in this port.</description>
+     <addressOffset>0x40</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>GPIO_INTFL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Interrupt is pending on this GPIO pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An Interrupt is pending on this GPIO pin.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL_CLR</name>
+     <description>GPIO Status Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_INT_STAT to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>GPIO Wake Enable Register. Each bit in this register controls the PMU wakeup enable for the associated GPIO pin in this port.</description>
+     <addressOffset>0x4C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_WKEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>PMU wakeup for this GPIO is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>PMU wakeup for this GPIO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_SET</name>
+     <description>GPIO Wake Enable Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_WAKE_EN to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN_CLR</name>
+     <description>GPIO Wake Enable Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_WAKE_EN to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DUALEDGE</name>
+     <description>GPIO Interrupt Dual Edge Mode Register. Each bit in this register selects dual edge mode for the associated GPIO pin in this port.</description>
+     <addressOffset>0x5C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DUALEDGE</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <description>No Effect.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Dual Edge mode is enabled. If edge-triggered interrupts are enabled on this GPIO pin, then both rising and falling edges will trigger interrupts regardless of the GPIO_INT_POL setting.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL0</name>
+     <description>GPIO Input Mode Config 1. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL0</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PADCTRL1</name>
+     <description>GPIO Input Mode Config 2. Each bit in this register enables the weak pull-up for the associated GPIO pin in this port.</description>
+     <addressOffset>0x64</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_PADCTRL1</name>
+       <description>The two bits in GPIO_PAD_CFG1 and GPIO_PAD_CFG2 for each GPIO pin work together to determine the pad mode when the GPIO is set to input mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>impedance</name>
+         <description>High Impedance.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pu</name>
+         <description>Weak pull-up mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pd</name>
+         <description>weak pull-down mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x68</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_SET</name>
+     <description>GPIO Alternate Function Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN1 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x6C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN1_CLR</name>
+     <description>GPIO Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN1 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x70</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2</name>
+     <description>GPIO Alternate Function Enable Register. Each bit in this register selects between primary/secondary functions for the associated GPIO pin in this port.</description>
+     <addressOffset>0x74</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_EN2</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>primary</name>
+         <description>Primary function selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>secondary</name>
+         <description>Secondary function selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_SET</name>
+     <description>GPIO Alternate Function 2 Set. Writing a 1 to one or more bits in this register sets the bits in the same positions in GPIO_EN2 to 1, without affecting other bits in that register.</description>
+     <addressOffset>0x78</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EN2_CLR</name>
+     <description>GPIO Wake Alternate Function Clear. Writing a 1 to one or more bits in this register clears the bits in the same positions in GPIO_EN2 to 0, without affecting other bits in that register.</description>
+     <addressOffset>0x7C</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HYSEN</name>
+     <description>GPIO Input Hysteresis Enable.</description>
+     <addressOffset>0xA8</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_HYSEN</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SRSEL</name>
+     <description>GPIO Slew Rate Enable Register.</description>
+     <addressOffset>0xAC</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_SRSEL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>FAST</name>
+         <description>Fast Slew Rate selected.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SLOW</name>
+         <description>Slow Slew Rate selected.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS0</name>
+     <description>GPIO Drive Strength  Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB0</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS0</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ld</name>
+         <description>GPIO port pin is in low-drive mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>hd</name>
+         <description>GPIO port pin is in high-drive mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DS1</name>
+     <description>GPIO Drive Strength 1 Register. Each bit in this register selects the drive strength for the associated GPIO pin in this port. Refer to the Datasheet for sink/source current of GPIO pins in each mode.</description>
+     <addressOffset>0xB4</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO_DS1</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PS</name>
+     <description>GPIO Pull Select Mode.</description>
+     <addressOffset>0xB8</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VSSEL</name>
+     <description>GPIO Voltage Select.</description>
+     <addressOffset>0xC0</addressOffset>
+     <fields>
+      <field>
+       <name>ALL</name>
+       <description>Mask of all of the pins on the port.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--GPIO0 Individual I/O for each GPIO-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO1</name>
+   <description>Individual I/O for each GPIO 1</description>
+   <baseAddress>0x40009000</baseAddress>
+   <interrupt>
+    <name>GPIO1</name>
+    <description>GPIO1 IRQ</description>
+    <value>25</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO1 Individual I/O for each GPIO 1-->
+  <peripheral derivedFrom="GPIO0">
+   <name>GPIO2</name>
+   <description>Individual I/O for each GPIO 2</description>
+   <baseAddress>0x40080400</baseAddress>
+   <interrupt>
+    <name>GPIO2</name>
+    <description>GPIO2 IRQ</description>
+    <value>26</value>
+   </interrupt>
+  </peripheral>
+<!--GPIO2 Individual I/O for each GPIO 2-->
+  <peripheral>
+   <name>I2C0</name>
+   <description>Inter-Integrated Circuit.</description>
+   <groupName>I2C</groupName>
+   <baseAddress>0x4001D000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2C0</name>
+    <description>I2C0 IRQ</description>
+    <value>13</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control Register0.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>I2C Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable I2C.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable I2C.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>slave_mode</name>
+         <description>Slave Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>master_mode</name>
+         <description>Master Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_EN</name>
+       <description>General Call Address Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Ignore Gneral Call Address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Acknowledge general call address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_EN</name>
+       <description>Interactive Receive Mode.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Interactive Receive Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Interactive Receive Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM_ACK</name>
+       <description>Data Acknowledge. This bit defines the acknowledge bit returned by the I2C receiver while IRXM = 1 HW forces ACK to 0 when IRXM = 0.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ack</name>
+         <description>return ACK (pulling SDA LOW).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>nack</name>
+         <description>return NACK (leaving SDA HIGH).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL_OUT</name>
+       <description>SCL Output. This bits control SCL output when SWOE =1.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_scl_low</name>
+         <description>Drive SCL low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_scl</name>
+         <description>Release SCL.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDA_OUT</name>
+       <description>SDA Output. This bits control SDA output when SWOE = 1. </description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>drive_sda_low</name>
+         <description>Drive SDA low. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>release_sda</name>
+         <description>Release SDA.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCL</name>
+       <description>SCL status. This bit reflects the logic gate of SCL signal. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDA</name>
+       <description>SDA status. THis bit reflects the logic gate of SDA signal.</description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BB_MODE</name>
+       <description>Software Output Enable.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>outputs_disable</name>
+         <description>I2C Outputs SCLO and SDAO disabled. </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>outputs_enable</name>
+         <description>I2C Outputs SCLO and SDAO enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ</name>
+       <description>Read. This bit reflects the R/W bit of an address match (AMI = 1) or general call match (GCI = 1). This bit is valid 3 cycles after the relevant interrupt bit is set.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>write</name>
+         <description>Write.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>read</name>
+         <description>Read.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKSTR_DIS</name>
+       <description>This bit will disable slave clock stretching when set.</description>
+       <bitRange>[12:12]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Slave clock stretching enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Slave clock stretching disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ONE_MST_MODE</name>
+       <description>SCL Push-Pull Mode. This bit controls whether SCL is operated in a the I2C standard open-drain mode, or in a non-standard push-pull mode where the Hi-Z output isreplaced with Drive-1. The non-standard mode should only be used when operating as a master and communicating with slaves that are guaranteed to never drive SCL low. </description>
+       <bitRange>[13:13]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Standard open-drain operation:
+					drive low for 0, Hi-Z for 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Non-standard push-pull operation:
+					drive low for 0, drive high for 1</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HS_EN</name>
+       <description>High speed mode enable</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>Bus Status.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>I2C Bus Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>I2C Bus Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>RX empty.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX Full.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_full</name>
+         <description>Not Full.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>full</name>
+         <description>Full.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX Empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>TX Full.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_empty</name>
+         <description>Not Empty.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>empty</name>
+         <description>Empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_BUSY</name>
+       <description>Clock Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_actively_driving_scl_clock</name>
+         <description>Device not actively driving SCL clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>actively_driving_scl_clock</name>
+         <description>Device operating as master and actively driving SCL clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL0</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <name>INT_FL0_Done</name>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Interactive Receive Interrupt.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave General Call Address Match Interrupt.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave Address Match Interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Receive Threshold Interrupt. This bit is automaticcaly cleared when RX_FIFO is below the threshold level.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. RX_FIFO equal or more bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>Transmit Threshold Interrupt. This bit is automaticcaly cleared when TX_FIFO is above the threshold level.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>STOP Interrupt.</description>
+       <bitRange>[6:6]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending. TX_FIFO has equal or less bytes than the threshold.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Address Acknowledge Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Arbritation error Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>timeout Error Interrupt.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Address NACK Error Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Data NACK Error Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Do Not Respond Error Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Start Error Interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Stop Error Interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>Transmit Lock Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN0</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DONE</name>
+       <description>Transfer Done Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when DONE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>IRXM</name>
+       <description>Description not available.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when RX_MODE = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_MATCH</name>
+       <description>Slave mode general call address match received input enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when GEN_CTRL_ADDR = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_MATCH</name>
+       <description>Slave mode incoming address match interrupt.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when ADDR_MATCH = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Above Treshold Level Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Below Treshold Level Interrupt Enable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Stop Interrupt Enable</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled when STOP = 1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_ACK</name>
+       <description>Received Address ACK from Slave Interrupt.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ARB_ERR</name>
+       <description>Master Mode Arbitration Lost Interrupt.</description>
+       <bitRange>[8:8]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TO_ERR</name>
+       <description>Timeout Error Interrupt Enable.</description>
+       <bitRange>[9:9]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADDR_NACK_ERR</name>
+       <description>Master Mode Address NACK Received Interrupt.</description>
+       <bitRange>[10:10]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_ERR</name>
+       <description>Master Mode Data NACK Received Interrupt.</description>
+       <bitRange>[11:11]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DNR_ERR</name>
+       <description>Slave Mode Do Not Respond Interrupt.</description>
+       <bitRange>[12:12]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START_ERR</name>
+       <description>Out of Sequence START condition detected interrupt.</description>
+       <bitRange>[13:13]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOP_ERR</name>
+       <description>Out of Sequence STOP condition detected interrupt.</description>
+       <bitRange>[14:14]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LOCKOUT</name>
+       <description>TX FIFO Locked Out Interrupt.</description>
+       <bitRange>[15:15]</bitRange>
+      </field>
+      <field>
+       <name>MAMI</name>
+       <description>Multiple Address Match Interrupt</description>
+       <bitRange>[21:16]</bitRange>
+      </field>
+      <field>
+       <name>RD_ADDR_MATCH</name>
+       <description>Slave Read Address Match Interrupt</description>
+       <bitRange>[22:22]</bitRange>
+      </field>
+      <field>
+       <name>WR_ADDR_MATCH</name>
+       <description>Slave Write Address Match Interrupt</description>
+       <bitRange>[23:23]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL1</name>
+     <description>Interrupt Status Register 1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt. When operating as a slave receiver, this bit is set when you reach the first data bit and the RX FIFO and shift register are both full.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt. When operating as a slave transmitter, this bit is set when you reach the first data bit and the TX FIFO is empty and the master is still asking for more data (i.e the master hasn't sent a NACK yet).</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Status Flag.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN1</name>
+     <description>Interrupt Staus Register 1.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>RX_OV</name>
+       <description>Receiver Overflow Interrupt Enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit Underflow Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>No Interrupt is Pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>START Condition Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOLEN</name>
+     <description>FIFO Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>RX_DEPTH</name>
+       <description>Receive FIFO Length.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TX_DEPTH</name>
+       <description>Transmit FIFO Length.</description>
+       <bitRange>[15:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL0</name>
+     <description>Receive Control Register 0.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>DNR</name>
+       <description>Do Not Respond.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Always respond to address match.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>not_respond_rx_fifo_empty</name>
+         <description>Do not respond to address match when RX_FIFO is not empty.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Receive FIFO Flush. This bit is automatically cleared to 0 after the operation. Setting this bit to 1 will affect RX_FIFO status.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush RX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_LVL</name>
+       <description>Receive FIFO Threshold. These bits define the RX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXCTRL1</name>
+     <description>Receive Control Register 1.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>CNT</name>
+       <description>Receive Count Bits. These bits define the number of bytes to be received in a transaction, except for the case RXCNT = 0. RXCNT = 0 means 256 bytes to be received in a transaction.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Receive FIFO Count. These bits reflect the number of byte in the RX_FIFO. These bits are flushed when I2CEN = 0.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL0</name>
+     <description>Transmit Control Register 0.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_MODE</name>
+       <description>Transmit FIFO Preaload Mode. Setting this bit will allow for high speed application to preload the transmit FIFO prior to Slave Address Match.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>TX_READY_MODE</name>
+       <description>Transmit FIFO Ready Manual Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>HW control of I2CTXRDY enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>HW control of I2CTXRDY disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>GC_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO General Call Address Match Auto Flush Disable.</description>
+       <bitRange>[2:2]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WR_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Write Auto Flush Disable.</description>
+       <bitRange>[3:3]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_ADDR_FLUSH_DIS</name>
+       <description>TX FIFO Slave Address Match Read Auto Flush Disable.</description>
+       <bitRange>[4:4]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>NACK_FLUSH_DIS</name>
+       <description>TX FIFO received NACK Auto Flush Disable.</description>
+       <bitRange>[5:5]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Transmit FIFO Flush. This bit is automatically cleared to 0 after the operation.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not_flushed</name>
+         <description>FIFO not flushed.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>flush</name>
+         <description>Flush TX_FIFO.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THD_VAL</name>
+       <description>Transmit FIFO Threshold. These bits define the TX_FIFO interrupt threshold.</description>
+       <bitRange>[11:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXCTRL1</name>
+     <description>Transmit Control Register 1.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>PRELOAD_RDY</name>
+       <description>Transmit FIFO Preload Ready.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>LVL</name>
+       <description>Transmit FIFO Count. These bits reflect the number of bytes in the TX_FIFO.</description>
+       <bitRange>[11:8]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>Data Register.</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data is read from or written to this location. Transmit and receive FIFO are separate but both are addressed at this location.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MSTCTRL</name>
+     <description>Master Control Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>START</name>
+       <description>Setting this bit to 1 will start a master transfer.</description>
+       <bitRange>[0:0]</bitRange>
+      </field>
+      <field>
+       <name>RESTART</name>
+       <description>Setting this bit to 1 will generate a repeated START.</description>
+       <bitRange>[1:1]</bitRange>
+      </field>
+      <field>
+       <name>STOP</name>
+       <description>Setting this bit to 1 will generate a STOP condition.</description>
+       <bitRange>[2:2]</bitRange>
+      </field>
+      <field>
+       <name>EX_ADDR_EN</name>
+       <description>Slave Extend Address Select.</description>
+       <bitRange>[7:7]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKLO</name>
+     <description>Clock Low Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock low. In master mode, these bits define the SCL low period. In slave mode, these bits define the time SCL will be held low after data is outputted.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKHI</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>HI</name>
+       <description>Clock High. In master mode, these bits define the SCL high period.</description>
+       <bitRange>[8:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HSCLK</name>
+     <description>Clock high Register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Clock Low. This field sets the Hs-Mode clock low count. In Slave mode, this is the time SCL is held low after data is output on SDA.</description>
+       <bitRange>[7:0]</bitRange>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>Clock High. This field sets the Hs-Mode clock high count. In Slave mode, this is the time SCL is held high after data is output on SDA</description>
+       <bitRange>[15:8]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TIMEOUT</name>
+     <description>Timeout Register</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>SCL_TO_VAL</name>
+       <description>Timeout</description>
+       <bitRange>[15:0]</bitRange>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Register.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable.</description>
+       <bitRange>[0:0]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>SLAVE_MULTI[%s]</name>
+     <description>Slave Address Register.</description>
+     <alternateRegister>SLAVE0</alternateRegister>
+     <addressOffset>0x4C</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Slave Address.</description>
+       <bitRange>[9:0]</bitRange>
+      </field>
+      <field>
+       <name>DIS</name>
+       <description>Slave Disable.</description>
+       <bitRange>[10:10]</bitRange>
+      </field>
+      <field>
+       <name>EXT_ADDR_EN</name>
+       <description>Extended Address Select.</description>
+       <bitRange>[15:15]</bitRange>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>7_bits_address</name>
+         <description>7-bit address.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_bits_address</name>
+         <description>10-bit address.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SLAVE0</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE1</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x50</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE2</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x54</addressOffset>
+    </register>
+    <register>
+     <name>SLAVE3</name>
+     <description>Slave Address Register.</description>
+     <addressOffset>0x58</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2C0 Inter-Integrated Circuit.-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C1</name>
+   <description>Inter-Integrated Circuit. 1</description>
+   <baseAddress>0x4001E000</baseAddress>
+   <interrupt>
+    <name>I2C1</name>
+    <description>I2C1 IRQ</description>
+    <value>36</value>
+   </interrupt>
+  </peripheral>
+<!--I2C1 Inter-Integrated Circuit. 1-->
+  <peripheral derivedFrom="I2C0">
+   <name>I2C2</name>
+   <description>Inter-Integrated Circuit. 2</description>
+   <baseAddress>0x4001F000</baseAddress>
+   <interrupt>
+    <name>I2C2</name>
+    <description>I2C2 IRQ</description>
+    <value>62</value>
+   </interrupt>
+  </peripheral>
+<!--I2C2 Inter-Integrated Circuit. 2-->
+  <peripheral>
+   <name>I2S</name>
+   <description>Inter-IC Sound Interface.</description>
+   <groupName>I2S</groupName>
+   <baseAddress>0x40060000</baseAddress>
+   <size>32</size>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>I2S</name>
+    <description>I2S IRQ</description>
+    <value>99</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL0CH0</name>
+     <description>Global mode channel.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>LSB_FIRST</name>
+       <description>LSB Transmit Receive First.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_FILT</name>
+       <description>PDM Filter.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_EN</name>
+       <description>PDM Enable.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>USEDDR</name>
+       <description>DDR.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>PDM_INV</name>
+       <description>Invert PDM.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CH_MODE</name>
+       <description>SCK Select.</description>
+       <bitRange>[7:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>WS_POL</name>
+       <description>WS polarity select. </description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>MSB_LOC</name>
+       <description>MSB location. </description>
+       <bitRange>[9:9]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ALIGN</name>
+       <description>Align to MSB or LSB.</description>
+       <bitRange>[10:10]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EXT_SEL</name>
+       <description>External SCK/WS selection.</description>
+       <bitRange>[11:11]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>STEREO</name>
+       <description>Stereo mode of I2S.</description>
+       <bitRange>[13:12]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WSIZE</name>
+       <description>Data size when write to FIFO.</description>
+       <bitRange>[15:14]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX channel enable. </description>
+       <bitRange>[16:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX channel enable. </description>
+       <bitRange>[17:17]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FLUSH</name>
+       <description>Flushes the TX/RX FIFO buffer. </description>
+       <bitRange>[18:18]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RST</name>
+       <description>Write 1 to reset channel. </description>
+       <bitRange>[19:19]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFO_LSB</name>
+       <description>Bit Field Control. </description>
+       <bitRange>[20:20]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>depth of receive FIFO for threshold interrupt generation. </description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1CH0</name>
+     <description>Local channel Setup.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>BITS_WORD</name>
+       <description>I2S word length.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>I2S clock enable.</description>
+       <bitRange>[8:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SMP_SIZE</name>
+       <description>I2S sample size length.</description>
+       <bitRange>[13:9]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLKSEL</name>
+       <description>I2S clock select.</description>
+       <bitRange>[14:14]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ADJUST</name>
+       <description>LSB/MSB Justify.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>I2S clock frequency divisor.</description>
+       <bitRange>[31:16]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FILTCH0</name>
+     <description>Filter.</description>
+     <addressOffset>0x20</addressOffset>
+    </register>
+    <register>
+     <name>DMACH0</name>
+     <description>DMA Control.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>DMA_TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger.</description>
+       <bitRange>[6:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA channel enable.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_THD_VAL</name>
+       <description>RX FIFO Level DMA Trigger.</description>
+       <bitRange>[14:8]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA channel enable.</description>
+       <bitRange>[15:15]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Number of data word in the TX FIFO.</description>
+       <bitRange>[23:16]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Number of data word in the RX FIFO.</description>
+       <bitRange>[31:24]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFOCH0</name>
+     <description>I2S Fifo.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitRange>[31:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>ISR Status.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Status for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Status for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Status for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Status for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Interrupt Enable.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>RX_OV_CH0</name>
+       <description>Enable for RX FIFO Overrun interrupt.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RX_THD_CH0</name>
+       <description>Enable for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_OB_CH0</name>
+       <description>Enable for interrupt when TX FIFO has only one byte remaining.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TX_HE_CH0</name>
+       <description>Enable for interrupt when TX FIFO is half empty.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EXTSETUP</name>
+     <description>Ext Control.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>EXT_BITS_WORD</name>
+       <description>Word Length for ch_mode.</description>
+       <bitRange>[4:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wakeup Enable.</description>
+     <addressOffset>0x5C</addressOffset>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wakeup Flags.</description>
+     <addressOffset>0x60</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--I2S Inter-IC Sound Interface.-->
+  <peripheral>
+   <name>ICC0</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x4002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x800</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>INFO</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SZ</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCH</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEM</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ICC0 Instruction Cache Controller Registers-->
+  <peripheral derivedFrom="ICC0">
+   <name>ICC1</name>
+   <description>Instruction Cache Controller Registers 1</description>
+   <baseAddress>0x4002AC00</baseAddress>
+  </peripheral>
+<!--ICC1 Instruction Cache Controller Registers 1-->
+  <peripheral>
+   <name>LPCMP</name>
+   <description>Low Power Comparator</description>
+   <baseAddress>0x40088000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>LPCMP</name>
+    <description>Low Power Comparato</description>
+    <value>103</value>
+   </interrupt>
+   <registers>
+    <register>
+     <dim>3</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CTRL[%s]</name>
+     <description>Comparator Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Comparator Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>POL</name>
+       <description>Polarity Select</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTEN</name>
+       <description>IRQ Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUT</name>
+       <description>Raw Compartor Input.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTFL</name>
+       <description>IRQ Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--LPCMP Low Power Comparator-->
+  <peripheral>
+   <name>LPGCR</name>
+   <description>Low Power Global Control.</description>
+   <baseAddress>0x40080000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RST</name>
+     <description>Low Power Reset Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO2</name>
+       <description>Low Power GPIO 2 Reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>reset</name>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>reset_done</name>
+         <description>Reset complete.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Starts Reset or indicates reset in progress.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>WDT1</name>
+       <description>Low Power Watchdog Timer 1 Reset.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR4</name>
+       <description>Low Power Timer 4 Reset.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR5</name>
+       <description>Low Power Timer 5 Reset.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>UART3</name>
+       <description>Low Power UART 3 Reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>LPCOMP</name>
+       <description>Low Power Comparator Reset.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PCLKDIS</name>
+     <description>Low Power Peripheral Clock Disable Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>GPIO2</name>
+       <description>Low Power GPIO 2 Clock Disable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enable it.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disable it.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>WDT1</name>
+       <description>Low Power Watchdog 1 Clock Disable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR4</name>
+       <description>Low Power Timer 4 Clock Disable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>TMR5</name>
+       <description>Low Power Timer 5 Clock Disable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>UART3</name>
+       <description>Low Power UART 3 Clock Disable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="GPIO2">
+       <name>LPCOMP</name>
+       <description>Low Power Comparator Clock Disable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--LPGCR Low Power Global Control.-->
+  <peripheral>
+   <name>MCR</name>
+   <description>Misc Control.</description>
+   <baseAddress>0x40006C00</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>ECCEN</name>
+     <description>ECC Enable Register</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAM0</name>
+       <description>ECC System RAM0 Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPO_MTRIM</name>
+     <description>IPO Manual Register</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>MTRIM</name>
+       <description>Manual Trim Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>TRIM_RANGE</name>
+       <description>Trim Range Select.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTEN</name>
+     <description>Output Enable Register</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>SQWOUT_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PDOWN_OUT_EN</name>
+       <description>Power Down Output Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP_CTRL</name>
+     <description>Comparator Control Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Comparator Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>POL</name>
+       <description>Polarity Select</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INT_EN</name>
+       <description>IRQ Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUT</name>
+       <description>Comparator Output State.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INT_FL</name>
+       <description>IRQ Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Miscellaneous Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>CMPHYST</name>
+       <description>Comparator HYST.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>INRO_EN</name>
+       <description>INRO Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERTCO_EN</name>
+       <description>ERTCO Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBRO_EN</name>
+       <description>IBRO Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SIMO_CLKSCL_EN</name>
+       <description>SIMO Clock Scaling Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SIMO_RSTD</name>
+       <description>SIMO System Reset Disable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GPIO3_CTRL</name>
+     <description>GPIO3 Pin Control Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>P30_DO</name>
+       <description>GPIO3 Pin 0 Data Output.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P30_OE</name>
+       <description>GPIO3 Pin 0 Output Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P30_PE</name>
+       <description>GPIO3 Pin 0 Pull-up Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P30_IN</name>
+       <description>GPIO3 Pin 0 Input Status.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_DO</name>
+       <description>GPIO3 Pin 1 Data Output.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_OE</name>
+       <description>GPIO3 Pin 1 Output Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_PE</name>
+       <description>GPIO3 Pin 1 Pull-up Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>P31_IN</name>
+       <description>GPIO3 Pin 1 Input Status.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CWD0</name>
+     <description>Code Word Data0</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>data</name>
+       <description>Code word Data0 the register retains its value while vregi supply present</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CWD1</name>
+     <description>Code Word Data1</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>data</name>
+       <description>Code word Data0 the register retains its value while vregi supply present</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCCFG0</name>
+     <description>ADC Config 0</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>LP_5K_DIS</name>
+       <description>Disable 5K divider optionin low power modes</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LP_50K_DIS</name>
+       <description>Disable 50K divider optionin low power modes</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EXT_REF</name>
+       <description>External Reference Select Option</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>REF_SEL</name>
+       <description>Internal Reference Select Option</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCCFG1</name>
+     <description>ADC Config 1</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>CHX_PU_DYN</name>
+       <description>ADC PU dynamic control</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>13</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADCCFG2</name>
+     <description>ADC Config 2</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>CH0</name>
+       <description>Divider option for ADC input channel 0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>div1</name>
+         <description>div1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2_5k</name>
+         <description>5k ohom</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>div2_50k</name>
+         <description>50k ohom</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH1</name>
+       <description>Divider option for ADC input channel 1</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH2</name>
+       <description>Divider option for ADC input channel 2</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH3</name>
+       <description>Divider option for ADC input channel 3</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH4</name>
+       <description>Divider option for ADC input channel 4</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH5</name>
+       <description>Divider option for ADC input channel 5</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH6</name>
+       <description>Divider option for ADC input channel 6</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field derivedFrom="CH0">
+       <name>CH7</name>
+       <description>Divider option for ADC input channel 7</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LDOCTRL</name>
+     <description>LDO Control</description>
+     <addressOffset>0x60</addressOffset>
+     <fields>
+      <field>
+       <name>0P9EN</name>
+       <description>LDO 0.9V Enable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>2P5EN</name>
+       <description>LDO 2.5V Enable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--MCR Misc Control.-->
+  <peripheral>
+   <name>OWM</name>
+   <description>1-Wire Master Interface.</description>
+   <baseAddress>0x4003D000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>OneWire</name>
+    <value>67</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CFG</name>
+     <description>1-Wire Master Configuration.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>long_line_mode</name>
+       <description>Long Line Mode.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>force_pres_det</name>
+       <description>Force Line During Presence Detect.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_en</name>
+       <description>Bit Bang Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_mode</name>
+       <description>Provide an extra output control to control an external pullup.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ext_pullup_enable</name>
+       <description>Enable External Pullup.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>single_bit_mode</name>
+       <description>Enable Single Bit TX/RX Mode.</description>
+       <bitRange>[5:5]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>overdrive</name>
+       <description>Enables overdrive speed for 1-Wire operations.</description>
+       <bitRange>[6:6]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>int_pullup_enable</name>
+       <description>Enable intenral pullup.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_DIV_1US</name>
+     <description>1-Wire Master Clock Divisor.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>divisor</name>
+       <description>Clock Divisor for 1Mhz.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL_STAT</name>
+     <description>1-Wire Master Control/Status.</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>start_ow_reset</name>
+       <description>Start OW Reset.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>sra_mode</name>
+       <description>SRA Mode.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>bit_bang_oe</name>
+       <description>Bit Bang Output Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ow_input</name>
+       <description>OW Input State.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>od_spec_mode</name>
+       <description>Overdrive Spec Mode.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>presence_detect</name>
+       <description>Presence Pulse Detected.</description>
+       <bitRange>[7:7]</bitRange>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>1-Wire Master Data Buffer.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>tx_rx</name>
+       <description>TX/RX Buffer.</description>
+       <bitRange>[7:0]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>1-Wire Master Interrupt Flags.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>TX Data Empty Interrupt Flag.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>RX Data Ready Interrupt Flag</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Flag.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Flag.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>1-Wire Master Interrupt Enables.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>ow_reset_done</name>
+       <description>OW Reset Sequence Completed.</description>
+       <bitRange>[0:0]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>tx_data_empty</name>
+       <description>Tx Data Empty Interrupt Enable.</description>
+       <bitRange>[1:1]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>rx_data_ready</name>
+       <description>Rx Data Ready Interrupt Enable.</description>
+       <bitRange>[2:2]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_short</name>
+       <description>OW Line Short Detected Interrupt Enable.</description>
+       <bitRange>[3:3]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+      <field>
+       <name>line_low</name>
+       <description>OW Line Low Detected Interrupt Enable.</description>
+       <bitRange>[4:4]</bitRange>
+       <access>read-write</access>
+       <modifiedWriteValues>oneToClear</modifiedWriteValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--OWM 1-Wire Master Interface.-->
+  <peripheral>
+   <name>PT</name>
+   <description>Pulse Train</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C020</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0010</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RATE_LENGTH</name>
+     <description>Pulse Train Configuration</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>rate_control</name>
+       <description>Pulse Train Enable and Rate Control. Set to 0 to disable the Pulse Train.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>27</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>mode</name>
+       <description>Pulse Train Output Mode/Train Length</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>32_BIT</name>
+         <description>Pulse train, 32 bit pattern.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SQUARE_WAVE</name>
+         <description>Square wave mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>2_BIT</name>
+         <description>Pulse train, 2 bit pattern.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>3_BIT</name>
+         <description>Pulse train, 3 bit pattern.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>4_BIT</name>
+         <description>Pulse train, 4 bit pattern.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>5_BIT</name>
+         <description>Pulse train, 5 bit pattern.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6_BIT</name>
+         <description>Pulse train, 6 bit pattern.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7_BIT</name>
+         <description>Pulse train, 7 bit pattern.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8_BIT</name>
+         <description>Pulse train, 8 bit pattern.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>9_BIT</name>
+         <description>Pulse train, 9 bit pattern.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>10_BIT</name>
+         <description>Pulse train, 10 bit pattern.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>11_BIT</name>
+         <description>Pulse train, 11 bit pattern.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>12_BIT</name>
+         <description>Pulse train, 12 bit pattern.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>13_BIT</name>
+         <description>Pulse train, 13 bit pattern.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>14_BIT</name>
+         <description>Pulse train, 14 bit pattern.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>15_BIT</name>
+         <description>Pulse train, 15 bit pattern.</description>
+         <value>15</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16_BIT</name>
+         <description>Pulse train, 16 bit pattern.</description>
+         <value>16</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>17_BIT</name>
+         <description>Pulse train, 17 bit pattern.</description>
+         <value>17</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>18_BIT</name>
+         <description>Pulse train, 18 bit pattern.</description>
+         <value>18</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>19_BIT</name>
+         <description>Pulse train, 19 bit pattern.</description>
+         <value>19</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>20_BIT</name>
+         <description>Pulse train, 20 bit pattern.</description>
+         <value>20</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>21_BIT</name>
+         <description>Pulse train, 21 bit pattern.</description>
+         <value>21</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>22_BIT</name>
+         <description>Pulse train, 22 bit pattern.</description>
+         <value>22</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>23_BIT</name>
+         <description>Pulse train, 23 bit pattern.</description>
+         <value>23</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>24_BIT</name>
+         <description>Pulse train, 24 bit pattern.</description>
+         <value>24</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>25_BIT</name>
+         <description>Pulse train, 25 bit pattern.</description>
+         <value>25</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>26_BIT</name>
+         <description>Pulse train, 26 bit pattern.</description>
+         <value>26</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>27_BIT</name>
+         <description>Pulse train, 27 bit pattern.</description>
+         <value>27</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>28_BIT</name>
+         <description>Pulse train, 28 bit pattern.</description>
+         <value>28</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>29_BIT</name>
+         <description>Pulse train, 29 bit pattern.</description>
+         <value>29</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30_BIT</name>
+         <description>Pulse train, 30 bit pattern.</description>
+         <value>30</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>31_BIT</name>
+         <description>Pulse train, 31 bit pattern.</description>
+         <value>31</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRAIN</name>
+     <description>Write the repeating bit pattern that is shifted out, LSB first, when configured in Pulse Train mode. See PT_RATE_LENGTH.mode for setting the length.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+    </register>
+    <register>
+     <name>LOOP</name>
+     <description>Pulse Train Loop Count</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>count</name>
+       <description>Number of loops for this pulse train to repeat.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>delay</name>
+       <description>Delay between loops of the Pulse Train in PT Peripheral Clock cycles</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>12</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESTART</name>
+     <description> Pulse Train Auto-Restart Configuration.</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt_x_select</name>
+       <description>Auto-Restart PT X Select</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_x_loop_exit</name>
+       <description>Enable Auto-Restart on PT X Loop Exit</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt_y_select</name>
+       <description>Auto-Restart PT Y Select</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>5</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>on_pt_y_loop_exit</name>
+       <description>Enable Auto-Restart on PT Y Loop Exit</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PT Pulse Train-->
+  <peripheral derivedFrom="PT">
+   <name>PT1</name>
+   <description>Pulse Train 1</description>
+   <baseAddress>0x4003C030</baseAddress>
+  </peripheral>
+<!--PT1 Pulse Train 1-->
+  <peripheral derivedFrom="PT">
+   <name>PT2</name>
+   <description>Pulse Train 2</description>
+   <baseAddress>0x4003C040</baseAddress>
+  </peripheral>
+<!--PT2 Pulse Train 2-->
+  <peripheral derivedFrom="PT">
+   <name>PT3</name>
+   <description>Pulse Train 3</description>
+   <baseAddress>0x4003C050</baseAddress>
+  </peripheral>
+<!--PT3 Pulse Train 3-->
+  <peripheral>
+   <name>PTG</name>
+   <description>Pulse Train Generation</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0020</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>PT</name>
+    <description>Pulse Train IRQ</description>
+    <value>59</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ENABLE</name>
+     <description>Global Enable/Disable Controls for All Pulse Trains</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Enable/Disable control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Enable/Disable control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Enable/Disable control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Enable/Disable control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESYNC</name>
+     <description>Global Resync (All Pulse Trains) Control</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Resync control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Resync control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Resync control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Resync control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Pulse Train Interrupt Flags</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Pulse Train Interrupt Enable/Disable</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_EN</name>
+     <description>Pulse Train Global Safe Enable.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_DIS</name>
+     <description>Pulse Train Global Safe Disable.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PTG Pulse Train Generation-->
+  <peripheral>
+   <name>PWRSEQ</name>
+   <description>Power Sequencer / Low Power Control Register.</description>
+   <baseAddress>0x40006800</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>LPCN</name>
+     <description>Low Power Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>RAMRET0</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 0 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET1</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 1 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET2</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 2 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET3</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET4</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET5</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET6</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RAMRET7</name>
+       <description>System RAM retention in BACKUP mode. These two bits are used in conjuction with RREGEN bit. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Ram Retention.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable System RAM 3 retention.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ISOCLK_SELECT</name>
+       <description>0 = PCLK 1= ISO CLK use for RISV in Low power mode  </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FAST_ENTRY_DIS</name>
+       <description>Fast Low Power mode entry disable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BGOFF</name>
+       <description>Bandgap OFF. This controls the System Bandgap in DeepSleep mode.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>on</name>
+         <description>Bandgap is always ON.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>off</name>
+         <description>Bandgap is OFF in DeepSleep mode (default).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WKRST</name>
+       <description>Reset wakeup status registers</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST0</name>
+     <description>Low Power I/O Wakeup Status Register 0. This register indicates the low power wakeup status for GPIO0.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN0</name>
+     <description>Low Power I/O Wakeup Enable Register 0. This register enables low power wakeup functionality for GPIO0.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>31</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST1</name>
+     <description>Low Power I/O Wakeup Status Register 1. This register indicates the low power wakeup status for GPIO1.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN1</name>
+     <description>Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup functionality for GPIO1.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST2</name>
+     <description>Low Power I/O Wakeup Status Register 2. This register indicates the low power wakeup status for GPIO2.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN2</name>
+     <description>Low Power I/O Wakeup Enable Register 2. This register enables low power wakeup functionality for GPIO2.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKST3</name>
+     <description>Low Power I/O Wakeup Status Register 3. This register indicates the low power wakeup status for GPIO3.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEST</name>
+       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPWKEN3</name>
+     <description>Low Power I/O Wakeup Enable Register 3. This register enables low power wakeup functionality for GPIO3.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>WAKEEN</name>
+       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWST</name>
+     <description>Low Power Peripheral Wakeup Status Register.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>AINCOMP0</name>
+       <description>Analog Input Comparator Wakeup Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BACKUP</name>
+       <description>Backup Mode Wakeup Flag.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESET</name>
+       <description>Reset Detected Wakeup Flag.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>LPPWEN</name>
+     <description>Low Power Peripheral Wakeup Enable Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>USBLS</name>
+       <description> USB UTMI Linestate Detect Wakeup Enable. These bits allow wakeup from the corresponding USB linestate
+signal(s) on transition(s) from low to high or high to low when PM.USBWKEN is set.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>USBVBUS</name>
+       <description> USB VBUS Detect Wakeup Enable. This bit allows wakeup from the USB power supply on or off status.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AINCOMP0</name>
+       <description> AINCOMP0 Wakeup Enable. This bit allows wakeup from the AINCOMP0.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WDT0</name>
+       <description> WDT0 Wakeup Enable. This bit allows wakeup from the WDT0.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WDT1</name>
+       <description> WDT1 Wakeup Enable. This bit allows wakeup from the WDT1.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CPU1</name>
+       <description> CPU1 Wakeup Enable. This bit allows wakeup from the CPU1.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR0</name>
+       <description> TMR0 Wakeup Enable. This bit allows wakeup from the TMR0.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR1</name>
+       <description> TMR1 Wakeup Enable. This bit allows wakeup from the TMR1.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR2</name>
+       <description> TMR2 Wakeup Enable. This bit allows wakeup from the TMR2.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR3</name>
+       <description> TMR3 Wakeup Enable. This bit allows wakeup from the TMR3.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR4</name>
+       <description> TMR4 Wakeup Enable. This bit allows wakeup from the TMR4.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TMR5</name>
+       <description> TMR5 Wakeup Enable. This bit allows wakeup from the TMR5.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART0</name>
+       <description> UART0 Wakeup Enable. This bit allows wakeup from the UART0.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART1</name>
+       <description> UART1 Wakeup Enable. This bit allows wakeup from the UART1.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART2</name>
+       <description> UART2 Wakeup Enable. This bit allows wakeup from the UART2.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART3</name>
+       <description> UART3 Wakeup Enable. This bit allows wakeup from the UART3.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C0</name>
+       <description> I2C0 Wakeup Enable. This bit allows wakeup from the I2C0.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C1</name>
+       <description> I2C1 Wakeup Enable. This bit allows wakeup from the I2C1.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2C2</name>
+       <description> I2C2 Wakeup Enable. This bit allows wakeup from the I2C2.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>I2S</name>
+       <description> I2S Wakeup Enable. This bit allows wakeup from the I2S.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SPI1</name>
+       <description> SPI1 Wakeup Enable. This bit allows wakeup from the SPI0.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>LPCMP</name>
+       <description> LPCMP Wakeup Enable. This bit allows wakeup from the LPCMP.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GP0</name>
+     <description>General Purpose Register 0</description>
+     <addressOffset>0x48</addressOffset>
+    </register>
+    <register>
+     <name>GP1</name>
+     <description>General Purpose Register 1</description>
+     <addressOffset>0x4C</addressOffset>
+    </register>
+   </registers>
+  </peripheral>
+<!--PWRSEQ Power Sequencer / Low Power Control Register.-->
+  <peripheral>
+   <name>RTC</name>
+   <description>Real Time Clock and Alarm.</description>
+   <baseAddress>0x40006000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>RTC</name>
+    <description>RTC interrupt.</description>
+    <value>3</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SEC</name>
+     <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSEC</name>
+     <description>RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented when this register rolls over from 0xFF to 0x00.</description>
+     <addressOffset>0x04</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC</name>
+       <description>Sub-Seconds Counter (12-bit).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TODA</name>
+     <description>Time-of-day Alarm.</description>
+     <addressOffset>0x08</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-day Alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSECA</name>
+     <description>RTC sub-second alarm.  This register contains the reload value for the sub-second alarm.</description>
+     <addressOffset>0x0C</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>This register contains the reload value for the sub-second alarm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>RTC Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <resetValue>0x00000008</resetValue>
+     <resetMask>0xFFFFFF38</resetMask>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Real Time Clock Enable. This bit enables the Real Time Clock. This bit can only be written when WE=1 and BUSY =0. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM_IE</name>
+       <description>Alarm Time-of-Day Interrupt Enable. Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM_IE</name>
+       <description>Alarm Sub-second Interrupt Enable.  Change to this bit is effective only after BUSY is cleared from 1 to 0.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BUSY</name>
+       <description>RTC Busy. This bit is set to 1 by hardware when changes to RTC registers required a synchronized version of the register to be in place.  This bit is automatically cleared by hardware.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>idle</name>
+         <description>Idle.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Busy.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>RTC Ready. This bit is set to 1 by hardware when the RTC count registers update.  It can be cleared to 0 by software at any time. It will also be cleared to 0 by hardware just prior to an update of the RTC count register.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>busy</name>
+         <description>Register has not updated.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY_IE</name>
+       <description>RTC Ready Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TOD_ALARM</name>
+       <description>Time-of-Day Alarm Interrupt Flag.  This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSEC_ALARM</name>
+       <description>Sub-second Alarm Interrupt Flag. This alarm is qualified as wake-up source to the processor.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_EN</name>
+       <description>Square Wave Output Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SQW_SEL</name>
+       <description>Frequency Output Selection. When SQE=1, these bits specify the output frequency on the SQW pin.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>freq1Hz</name>
+         <description>1 Hz (Compensated).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq512Hz</name>
+         <description>512 Hz (Compensated).</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>freq4KHz</name>
+         <description>4 KHz.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>clkDiv8</name>
+         <description>RTC Input Clock / 8.</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RD_EN</name>
+       <description>Asynchronous Counter Read Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_EN</name>
+       <description>Write Enable. This register bit serves as a protection mechanism against unintentional writes to critical RTC bits.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>Not active</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Pending</name>
+         <description>Active</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRIM</name>
+     <description>RTC Trim Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>TRIM</name>
+       <description>RTC Trim. This register contains the 2's complement value that specifies the trim resolution. Each increment or decrement of the bit adds or subtracts 1ppm at each 4KHz clock value, with a maximum correction of +/- 127ppm.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VRTC_TMR</name>
+       <description>VBAT Timer Value. When RTC is running off of VBAT, this field is incremented every 32 seconds.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSCCTRL</name>
+     <description>RTC Oscillator Control Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>FILTER_EN</name>
+       <description>Enables analog deglitch filter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_SEL</name>
+       <description>If IBIAS_EN is 1, selects 4x,2x mode.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HYST_EN</name>
+       <description>Enables high current hysteresis buffer.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IBIAS_EN</name>
+       <description>Enables higher 4x,2x current modes.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BYPASS</name>
+       <description>RTC Crystal Bypass</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SQW_32K</name>
+       <description>RTC 32kHz Square Wave Output</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--RTC Real Time Clock and Alarm.-->
+  <peripheral>
+   <name>SDHC</name>
+   <description>SDHC/SDIO Controller</description>
+   <baseAddress>0x40037000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SDHC</name>
+    <value>66</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>SDMA</name>
+     <description>SDMA System Address / Argument 2.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>SDMA System Address / Argument 2  of Auto CMD23.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_SIZE</name>
+     <description>Block Size.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>TRANS</name>
+       <description>Transfer Block Size.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>12</bitWidth>
+      </field>
+      <field>
+       <name>HOST_BUFF</name>
+       <description>Host SDMA Buffer Boundary.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_CNT</name>
+     <description>Block Count.</description>
+     <addressOffset>0x06</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Blocks Count For Current Transfer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ARG_1</name>
+     <description>Argument 1.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>CMD</name>
+       <description>Command Argument 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TRANS</name>
+     <description>Transfer Mode.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>DMA_EN</name>
+       <description>DMA Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>enable</name>
+        <enumeratedValue>
+         <name>dma_transfer</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>non_dma_transfer</name>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>BLK_CNT_EN</name>
+       <description>Block Count Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>count</name>
+        <enumeratedValue>
+         <name>enable</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AUTO_CMD_EN</name>
+       <description>Auto CMD Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <name>CMD</name>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cmd12</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>cmd23</name>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>READ_WRITE</name>
+       <description>Data Transfer Direction Select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>read</name>
+        <enumeratedValue>
+         <name>read</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>write</name>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MULTI</name>
+       <description>Multi / Single Block Select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <name>multi</name>
+        <enumeratedValue>
+         <name>enable</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>disable</name>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMD</name>
+     <description>Command.</description>
+     <addressOffset>0x0E</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>RESP_TYPE</name>
+       <description>Response Type Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CRC_CHK_EN</name>
+       <description>Command CRC Check Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IDX_CHK_EN</name>
+       <description>Command Index Check Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_PRES_SEL</name>
+       <description>Data Present Select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TYPE</name>
+       <description>Command Type.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>IDX</name>
+       <description>Command Index.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>RESP[%s]</name>
+     <description>Response 0 Register 0-15.</description>
+     <addressOffset>0x010</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>CMD_RESP</name>
+       <description>Command Response.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUFFER</name>
+     <description>Buffer Data Port.</description>
+     <addressOffset>0x20</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Buffer Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESENT</name>
+     <description>Present State.</description>
+     <addressOffset>0x024</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CMD</name>
+       <description>Command Inhibit (CMD).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DAT</name>
+       <description>Command Inhibit (DAT).</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DAT_LINE_ACTIVE</name>
+       <description>DAT Line Active.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Request.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WRITE_TRANSFER</name>
+       <description>Write Transfer Active.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>READ_TRANSFER</name>
+       <description>Read Transfer Active.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BUFFER_WRITE</name>
+       <description>Buffer Write Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BUFFER_READ</name>
+       <description>Buffer Read Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CARD_INSERTED</name>
+       <description>Card Inserted.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CARD_STATE</name>
+       <description>Card State Stable.</description>
+       <bitOffset>17</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CARD_DETECT</name>
+       <description>Card Detect Pin Level.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>WP</name>
+       <description>Write Protect Switch Pin Level.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DAT_SIGNAL_LEVEL</name>
+       <description>DAT[3:0] Line Signal Level.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>CMD_SIGNAL_LEVEL</name>
+       <description>CMD Line Signal Level.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HOST_CN_1</name>
+     <description>Host Control 1.</description>
+     <addressOffset>0x028</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>LED_CN</name>
+       <description>LED Control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TRANSFER_WIDTH</name>
+       <description>Data Transfer Width.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HS_EN</name>
+       <description>High Speed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA_SELECT</name>
+       <description>DMA Select.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>EXT_DATA_TRANSFER_WIDTH</name>
+       <description>Extended Data Transfer Width.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_DETECT_TEST</name>
+       <description>Card Detect Test Level.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_DETECT_SIGNAL</name>
+       <description>Card Detect Signal Selection.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWR</name>
+     <description>Power Control.</description>
+     <addressOffset>0x029</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>BUS_POWER</name>
+       <description>SD Bus Power.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUS_VOLT_SEL</name>
+       <description>SD Bus Voltage Select.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BLK_GAP</name>
+     <description>Block Gap Control.</description>
+     <addressOffset>0x02A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>STOP</name>
+       <description>Stop At Block Gap Request.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CONT</name>
+       <description>Continue Request.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>READ_WAIT</name>
+       <description>Read Wait Control.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTR</name>
+       <description>Interrupt At Block Gap.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WAKEUP</name>
+     <description>Wakeup Control.</description>
+     <addressOffset>0x02B</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>CARD_INT</name>
+       <description>Wakeup Event Enable On Card Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INS</name>
+       <description>Wakeup Event Enable On SD Card Insertion.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REM</name>
+       <description>Wakeup Event Enable On SD Card Removal.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLK_CN</name>
+     <description>Clock Control.</description>
+     <addressOffset>0x02C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>INTERNAL_CLK_EN</name>
+       <description>Internal Clock Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INTERNAL_CLK_STABLE</name>
+       <description>Internal Clock Stable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SD_CLK_EN</name>
+       <description>SD Clock Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLK_GEN_SEL</name>
+       <description>Clock Generator Select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>UPPER_SDCLK_FREQ_SEL</name>
+       <description>Upper Bits of SDCLK Frequency Select.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SDCLK_FREQ_SEL</name>
+       <description>SDCLK Frequency Select.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TO</name>
+     <description>Timeout Control.</description>
+     <addressOffset>0x02E</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>DATA_COUNT_VALUE</name>
+       <description>Data Timeout Counter Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SW_RESET</name>
+     <description>Software Reset.</description>
+     <addressOffset>0x02F</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RESET_ALL</name>
+       <description>Software Reset For All.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESET_CMD</name>
+       <description>Software Reset For CMD Line.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RESET_DAT</name>
+       <description>Software Reset For DAT Line.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_STAT</name>
+     <description>Normal Interrupt Status.</description>
+     <addressOffset>0x030</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_COMP</name>
+       <description>Command Complete.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRANS_COMP</name>
+       <description>Transfer Complete.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BLK_GAP_EVENT</name>
+       <description>Block Gap Event.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFF_WR_READY</name>
+       <description>Buffer Write Ready.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFF_RD_READY</name>
+       <description>Buffer Read Ready.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INSERTION</name>
+       <description>Card Insertion.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REMOVAL</name>
+       <description>Card Removal.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INTR</name>
+       <description>Card Interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Event.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ERR_INTR</name>
+       <description>Error Interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ER_INT_STAT</name>
+     <description>Error Interrupt Status.</description>
+     <addressOffset>0x032</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Command Timeout Error.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Command CRC Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Command End Bit Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_IDX</name>
+       <description>Command Index Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Data Timeout Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Data CRC Error.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Data End Bit Error.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CURRENT_LIMIT</name>
+       <description>Current Limit Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AUTO_CMD_12</name>
+       <description>Auto CMD Error.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>ADMA Error.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Error.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Normal Interrupt Status Enable.</description>
+     <addressOffset>0x034</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_COMP</name>
+       <description>Command Complete Status Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRANS_COMP</name>
+       <description>Transfer Complete Status Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BLK_GAP</name>
+       <description>Block Gap Event Status Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Interrupt Status Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_WR</name>
+       <description>Buffer Write Ready Status Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_RD</name>
+       <description>Buffer Read Ready Status Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INSERT</name>
+       <description>Card Insertion Status Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REMOVAL</name>
+       <description>Card Removal Status Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INT</name>
+       <description>Card Interrupt Status Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Event Status Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ER_INT_EN</name>
+     <description>Error Interrupt Status Enable.</description>
+     <addressOffset>0x36</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Command Timeout Error Status Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Command CRC Error Status Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Command End Bit Error Status Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_IDX</name>
+       <description>Command Index Error Status Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Data Timeout Error Status Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Data CRC Error Status Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Data End Bit Error Status Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AUTO_CMD</name>
+       <description>Auto CMD Error Status Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>ADMA Error Status Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TUNING</name>
+       <description>Tuning Error Status Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VENDOR</name>
+       <description>Vendor Specific Error Status Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_SIGNAL</name>
+     <description>Normal Interrupt Signal Enable.</description>
+     <addressOffset>0x038</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_COMP</name>
+       <description>Command Complete Signal Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TRANS_COMP</name>
+       <description>Transfer Complete Signal Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BLK_GAP</name>
+       <description>Block Gap Event Signal Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DMA</name>
+       <description>DMA Interrupt Signal Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_WR</name>
+       <description>Buffer Write Ready Signal Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BUFFER_RD</name>
+       <description>Buffer Read Ready Signal Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INSERT</name>
+       <description>Card Insertion Signal Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_REMOVAL</name>
+       <description>Card Removal Signal Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CARD_INT</name>
+       <description>Card Interrupt Signal Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Event Signal Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ER_INT_SIGNAL</name>
+     <description>Error Interrupt Signal Enable.</description>
+     <addressOffset>0x03A</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Command Timeout Error Signal Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Command CRC Error Signal Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Command End Bit Error Signal Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CMD_IDX</name>
+       <description>Command Index Error Signal Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Data Timeout Error Signal Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Data CRC Error Signal Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Data End Bit Error Signal Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CURR_LIM</name>
+       <description>Current Limit Error Signal Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>AUTO_CMD</name>
+       <description>Auto CMD Error Signal Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>ADMA Error Signal Enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TUNING</name>
+       <description>Tuning Error Signal Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TAR_RESP</name>
+       <description>Target Response Error Signal Enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>AUTO_CMD_ER</name>
+     <description>Auto CMD Error Status.</description>
+     <addressOffset>0x03C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>NOT_EXCUTED</name>
+       <description>Auto CMD12 Not Executed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TO</name>
+       <description>Auto CMD Timeout Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRC</name>
+       <description>Auto CMD CRC Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>END_BIT</name>
+       <description>Auto CMD End Bit Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INDEX</name>
+       <description>Auto CMD Index Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOT_ISSUED</name>
+       <description>Command Not Issued By Auto CMD12 Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HOST_CN_2</name>
+     <description>Host Control 2.</description>
+     <addressOffset>0x03E</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>UHS</name>
+       <description>UHS Mode Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SIGNAL_V1_8</name>
+       <description>1.8V Signaling Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>EXCUTE</name>
+       <description>Execute Tuning.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>SAMPLING_CLK</name>
+       <description>Sampling Clock Select.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ASYNCH_INT</name>
+       <description>Asynchronous Interrupt Enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PRESET_VAL_EN</name>
+       <description>Preset Value Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_0</name>
+     <description>Capabilities 0-31.</description>
+     <addressOffset>0x040</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TO_CLK_FREQ</name>
+       <description>Timeout Clock Frequency.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TO_CLK_UNIT</name>
+       <description>Timeout Clock Unit.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_FREQ</name>
+       <description>Base Clock Frequency For SD Clock.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>MAX_BLK_LEN</name>
+       <description>Max Block Length.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BIT_8</name>
+       <description>8-bit Support for Embedded Device.</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ADMA2</name>
+       <description>ADMA2 Support.</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS</name>
+       <description>High Speed Support.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDMA</name>
+       <description>SDMA Support.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SUSPEND</name>
+       <description>Suspend/Resume Support.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>V3_3</name>
+       <description>Voltage Support 3.3V.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>V3_0</name>
+       <description>Voltage Support 3.0V.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>V1_8</name>
+       <description>Voltage Support 1.8V.</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>BIT_64_SYS_BUS</name>
+       <description>64-bit System Bus Support.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ASYNC_INT</name>
+       <description>Asynchronous Interrupt Support.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SLOT_TYPE</name>
+       <description>Slot Type.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CFG_1</name>
+     <description>Capabilities 32-63.</description>
+     <addressOffset>0x044</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDR50</name>
+       <description>SDR50 Support.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SDR104</name>
+       <description>SDR104 Support.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>0</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DDR50</name>
+       <description>DDR50 Support.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_A</name>
+       <description>Driver Type A Support.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_C</name>
+       <description>Driver Type C Support.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_D</name>
+       <description>Driver Type D Support.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TIMER_CNT_TUNING</name>
+       <description>Timer Count for Re-Tuning.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>TUNING_SDR50</name>
+       <description>Use Tuning for SDR50.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RETUNING</name>
+       <description>Re-Tuning Modes.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_MULTI</name>
+       <description>Clock Multiplier.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAX_CURR_CFG</name>
+     <description>Maximum Current Capabilities.</description>
+     <addressOffset>0x048</addressOffset>
+     <size>32</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>V3_3</name>
+       <description>Maximum Current for 3.3V.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>V3_0</name>
+       <description>Maximum Current for 3.0V.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>V1_8</name>
+       <description>Maximum Current for 1.8V.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FORCE_CMD</name>
+     <description>Force Event for Auto CMD Error Status.</description>
+     <addressOffset>0x050</addressOffset>
+     <size>16</size>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>NOT_EXCU</name>
+       <description>Force Event for Auto CMD12 Not Executed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>TO</name>
+       <description>Force Event for Auto CMD Timeout Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>CRC</name>
+       <description>Force Event for Auto CMD CRC Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>END_BIT</name>
+       <description>Force Event for Auto CMD End Bit Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>INDEX</name>
+       <description>Force Event for Auto CMD Index Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>NOT_ISSUED</name>
+       <description>Force Event for Command Not Issued By Auto CMD12 Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FORCE_EVENT_INT_STAT</name>
+     <description>Force Event for Error Interrupt Status.</description>
+     <addressOffset>0x052</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>CMD_TO</name>
+       <description>Force Event for Command Timeout Error.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CMD_CRC</name>
+       <description>Force Event for Command CRC Error.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CMD_END_BIT</name>
+       <description>Force Event for Command End Bit Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CMD_INDEX</name>
+       <description>Force Event for Command Index Error.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_TO</name>
+       <description>Force Event for Data Timeout Error.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_CRC</name>
+       <description>Force Event for Data CRC Error.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_END_BIT</name>
+       <description>Force Event for Data End Bit Error.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CURR_LIMIT</name>
+       <description>Force Event for Current Limit Error.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>AUTO_CMD</name>
+       <description>Force Event for Auto CMD Error.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>ADMA</name>
+       <description>Force Event for ADMA Error.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>VENDOR</name>
+       <description>Force Event for Vendor Specific Error Status.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>3</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADMA_ER</name>
+     <description>ADMA Error Status.</description>
+     <addressOffset>0x054</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>STATE</name>
+       <description>ADMA Error State.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>LEN_MISMATCH</name>
+       <description>ADMA Length Mismatch Error.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADMA_ADDR_0</name>
+     <description>ADMA System Address 0-31.</description>
+     <addressOffset>0x058</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>ADMA System Address  Part 1 (part 2 is ADMA_ADDR_1).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ADMA_ADDR_1</name>
+     <description>ADMA System Address 32-63.</description>
+     <addressOffset>0x05C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>ADMA System Address  Part 1 (part 2 is ADMA_ADDR_1).</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_0</name>
+     <description>Preset Value for Initialization.</description>
+     <addressOffset>0x060</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_1</name>
+     <description>Preset Value for Default Speed.</description>
+     <addressOffset>0x062</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_2</name>
+     <description>Preset Value for High Speed.</description>
+     <addressOffset>0x064</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_3</name>
+     <description>Preset Value for SDR12.</description>
+     <addressOffset>0x066</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_4</name>
+     <description>Preset Value for SDR25.</description>
+     <addressOffset>0x068</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_5</name>
+     <description>Preset Value for SDR50.</description>
+     <addressOffset>0x06A</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_6</name>
+     <description>Preset Value for SDR104.</description>
+     <addressOffset>0x06C</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET_7</name>
+     <description>Preset Value for DDR50.</description>
+     <addressOffset>0x06E</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>SDCLK_FREQ</name>
+       <description>SDCLK Frequency Select Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>10</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>CLK_GEN</name>
+       <description>Clock Generator Select Value.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DRIVER_STRENGTH</name>
+       <description>Driver Strength Select Value.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>2</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SHARED_BUS</name>
+     <description>SHARED_BUS.</description>
+     <addressOffset>0x0E0</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>SLOT_INT</name>
+     <description>Slot Interrupt Status.</description>
+     <addressOffset>0x0FC</addressOffset>
+     <size>16</size>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>INT_SIGNALS</name>
+       <description>Interrupt Signal For Each Slot.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HOST_CN_VER</name>
+     <description>Host Controller Version.</description>
+     <addressOffset>0x0FE</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>SPEC_VER</name>
+       <description>Specification Version Number.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>VEND_VER</name>
+       <description>Vendor Version Number.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SDHC SDHC/SDIO Controller-->
+  <peripheral>
+   <name>SEMA</name>
+   <description>The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.</description>
+   <baseAddress>0x4003E000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <dim>8</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>SEMAPHORES[%s]</name>
+     <description>Read to test and set, returns prior value. Write 0 to clear semaphore.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>sema</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>irq0</name>
+     <description>Semaphore IRQ0 register.</description>
+     <addressOffset>0x40</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>en</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>cm4_irq</name>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>mail0</name>
+     <description>Semaphore Mailbox 0 register.</description>
+     <addressOffset>0x44</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>data</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>irq1</name>
+     <description>Semaphore IRQ1 register.</description>
+     <addressOffset>0x48</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>en</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>rv32_irq</name>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>mail1</name>
+     <description>Semaphore Mailbox 1 register.</description>
+     <addressOffset>0x4C</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>data</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>status</name>
+     <description>Semaphore status bits. 0 indicates the semaphore is free, 1 indicates taken.</description>
+     <addressOffset>0x100</addressOffset>
+     <size>32</size>
+     <fields>
+      <field>
+       <name>status0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>status7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SEMA The Semaphore peripheral allows multiple cores in a system to cooperate when accessing shred resources.
+                                     The peripheral contains eight semaphores that can be atomically set and cleared. It is left to the discretion of the software
+                                     architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
+                                     
+                                     modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.-->
+  <peripheral>
+   <name>SIMO</name>
+   <description>Single Inductor Multiple Output Switching Converter</description>
+   <baseAddress>0x40004400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>VREGO_A</name>
+     <description>Buck Voltage Regulator A Control Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETA</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGEA</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGO_B</name>
+     <description>Buck Voltage Regulator B Control Register</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETB</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGEB</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGO_C</name>
+     <description>Buck Voltage Regulator C Control Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETC</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGEC</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>VREGO_D</name>
+     <description>Buck Voltage Regulator D Control Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>VSETD</name>
+       <description>Regulator Output Voltage Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>RANGED</name>
+       <description>Regulator Output Range Set</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>low</name>
+         <description>Low output voltage range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>high</name>
+         <description>High output voltage range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPKA</name>
+     <description>High Side FET Peak Current VREGO_A/VREGO_B Register</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IPKSETA</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IPKSETB</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPKB</name>
+     <description>High Side FET Peak Current VREGO_C/VREGO_D Register</description>
+     <addressOffset>0x0018</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IPKSETC</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>IPKSETD</name>
+       <description>Voltage Regulator Peak Current Setting</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MAXTON</name>
+     <description>Maximum High Side FET Time On Register</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TONSET</name>
+       <description>Sets the maximum on time for the high side FET, each increment represents 500ns</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_A</name>
+     <description>Buck Cycle Count VREGO_A Register</description>
+     <addressOffset>0x0020</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADA</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_B</name>
+     <description>Buck Cycle Count VREGO_B Register</description>
+     <addressOffset>0x0024</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADB</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_C</name>
+     <description>Buck Cycle Count VREGO_C Register</description>
+     <addressOffset>0x0028</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADC</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ILOAD_D</name>
+     <description>Buck Cycle Count VREGO_D Register</description>
+     <addressOffset>0x002C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ILOADD</name>
+       <description>Number of buck cycles that occur within the cycle clock</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_A</name>
+     <description>Buck Cycle Count Alert VERGO_A Register</description>
+     <addressOffset>0x0030</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRA</name>
+       <description>Threshold for ILOADA to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_B</name>
+     <description>Buck Cycle Count Alert VERGO_B Register</description>
+     <addressOffset>0x0034</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRB</name>
+       <description>Threshold for ILOADB to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_C</name>
+     <description>Buck Cycle Count Alert VERGO_C Register</description>
+     <addressOffset>0x0038</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRC</name>
+       <description>Threshold for ILOADC to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_ALERT_THR_D</name>
+     <description>Buck Cycle Count Alert VERGO_D Register</description>
+     <addressOffset>0x003C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>BUCKTHRD</name>
+       <description>Threshold for ILOADD to generate the BUCK_ALERT</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>BUCK_OUT_READY</name>
+     <description>Buck Regulator Output Ready Register</description>
+     <addressOffset>0x0040</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUCKOUTRDYA</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notrdy</name>
+         <description>Output voltage not in range</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>rdy</name>
+         <description>Output voltage in range</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field derivedFrom="BUCKOUTRDYA">
+       <name>BUCKOUTRDYB</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BUCKOUTRDYA">
+       <name>BUCKOUTRDYC</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field derivedFrom="BUCKOUTRDYA">
+       <name>BUCKOUTRDYD</name>
+       <description>When set, indicates that the output voltage has reached its regulated value</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_A</name>
+     <description>Zero Cross Calibration VERGO_A Register</description>
+     <addressOffset>0x0044</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALA</name>
+       <description>Zero Cross Calibrartion Value VREGO_A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_B</name>
+     <description>Zero Cross Calibration VERGO_B Register</description>
+     <addressOffset>0x0048</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALB</name>
+       <description>Zero Cross Calibrartion Value VREGO_B</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_C</name>
+     <description>Zero Cross Calibration VERGO_C Register</description>
+     <addressOffset>0x004C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALC</name>
+       <description>Zero Cross Calibrartion Value VREGO_C</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ZERO_CROSS_CAL_D</name>
+     <description>Zero Cross Calibration VERGO_D Register</description>
+     <addressOffset>0x0050</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ZXCALD</name>
+       <description>Zero Cross Calibrartion Value VREGO_D</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIMO Single Inductor Multiple Output Switching Converter-->
+  <peripheral>
+   <name>SIR</name>
+   <description>System Initialization Registers.</description>
+   <baseAddress>0x40000400</baseAddress>
+   <access>read-only</access>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>SISTAT</name>
+     <description>System Initialization Status Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>MAGIC</name>
+       <description>Magic Word Validation.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>magicNotSet</name>
+         <description>Magic word was not set (OTP has not been initialized properly).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>magicSet</name>
+         <description>Magic word was set (OTP contains valid settings).</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CRCERR</name>
+       <description>CRC Error Status.  This bit is set by the system initialization block following power-up.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <usage>read</usage>
+        <enumeratedValue>
+         <name>noError</name>
+         <description>No CRC errors occurred during the read of the OTP memory block.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>error</name>
+         <description>A CRC error occurred while reading the OTP. The address of the failure location in the OTP memory is stored in the ERRADDR register.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SIADDR</name>
+     <description>Read-only field set by the SIB block if a CRC error occurs during the read of the OTP memory. Contains the failing address in OTP memory (when CRCERR equals 1).</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>ERRADDR</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FSTAT</name>
+     <description>funcstat register.</description>
+     <addressOffset>0x100</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>FPU</name>
+       <description>FPU Function.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>USB</name>
+       <description>USB Function.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ADC</name>
+       <description>ADC Function.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SDIO</name>
+       <description>SDIO Function.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SMPHR</name>
+       <description>SMPHR function.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SFSTAT</name>
+     <description>Security function status register.</description>
+     <addressOffset>0x104</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TRNG</name>
+       <description> TRNG Function.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>AES</name>
+       <description>AES Block.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>no</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>yes</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SIR System Initialization Registers.-->
+  <peripheral>
+   <name>SPI0</name>
+   <description>SPI peripheral.</description>
+   <baseAddress>0x400BE000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SPI0</name>
+    <value>56</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FIFO32</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>2</dim>
+     <dimIncrement>2</dimIncrement>
+     <name>FIFO16[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>16</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <dim>4</dim>
+     <dimIncrement>1</dimIncrement>
+     <name>FIFO8[%s]</name>
+     <description>Register for reading and writing the FIFO.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read to pull from RX FIFO, write to put into TX FIFO.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>SPI Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_MODE</name>
+       <description>Master Mode Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>SPI is Slave mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>SPI is  Master mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_IO</name>
+       <description>Slave Select 0, IO direction, to support Multi-Master mode,Slave Select 0 can be input in Master mode. This bit has no effect in slave mode.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>output</name>
+         <description>Slave select 0 is output.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>input</name>
+         <description>Slave Select 0 is input, only valid if MMEN=1.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>START</name>
+       <description>Start Transmit.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>start</name>
+         <description>Master Initiates a transaction, this bit is self clearing when transactions are done. If a transaction cimpletes, and the TX FIFO is empty, the Master halts, if a transaction completes, and the TX FIFO is not empty, the Master initiates another transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_CTRL</name>
+       <description>Start Select Control. Used in Master mode to control the behavior of the Slave Select signal at the end of a transaction.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DEASSERT</name>
+         <description>SPI De-asserts Slave Select at the end of a transaction.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ASSERT</name>
+         <description>SPI leaves Slave Select asserted at the end of a transaction.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_ACTIVE</name>
+       <description>Slave Select, when in Master mode selects which Slave devices are selected. More than one Slave device can be selected.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0</name>
+         <description>SS0 is selected.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1</name>
+         <description>SS1 is selected.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2</name>
+         <description>SS2 is selected.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3</name>
+         <description>SS3 is selected.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_NUM_CHAR</name>
+       <description>Nubmer of Characters to transmit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>RX_NUM_CHAR</name>
+       <description>Nubmer of Characters to receive.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL2</name>
+     <description>Register for controlling SPI peripheral.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKPHA</name>
+       <description>Clock Phase.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Rising_Edge</name>
+         <description>Data Sampled on clock rising edge. Use when in SPI Mode 0 and Mode 2 </description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Falling_Edge</name>
+         <description>Data Sampled on clock falling edge. Use when in SPI Mode 1 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKPOL</name>
+       <description>Clock Polarity.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Normal</name>
+         <description>Normal Clock. Use when in SPI Mode 0 and Mode 1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Inverted</name>
+         <description>Inverted Clock. Use when in SPI Mode 2 and Mode 3</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SCLK_FB_INV</name>
+       <description>SCLK_FB_INV.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NUMBITS</name>
+       <description>Number of Bits per character.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>0</name>
+         <description>16 bits per character.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DATA_WIDTH</name>
+       <description>SPI Data width.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Mono</name>
+         <description>1 data pin.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Dual</name>
+         <description>2 data pins.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Quad</name>
+         <description>4 data pins.</description>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>THREE_WIRE</name>
+       <description>Three Wire mode. MOSI/MISO pin (s) shared. Only Mono mode suports Four-Wire.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Use four wire mode (Mono only).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Use three wire mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SS_POL</name>
+       <description>Slave Select Polarity, each Slave Select can have unique polarity.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>SS0_high</name>
+         <description>SS0 active high.</description>
+         <value>0x1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS1_high</name>
+         <description>SS1 active high.</description>
+         <value>0x2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS2_high</name>
+         <description>SS2 active high.</description>
+         <value>0x4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>SS3_high</name>
+         <description>SS3 active high.</description>
+         <value>0x8</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SSTIME</name>
+     <description>Register for controlling SPI peripheral/Slave Select Timing.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PRE</name>
+       <description>Slave Select Pre delay 1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between SS active and first serial clock edge.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POST</name>
+       <description>Slave Select Post delay 2.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between last serial clock edge and SS inactive.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INACT</name>
+       <description>Slave Select Inactive delay.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>256</name>
+         <description>256 system clocks between transactions.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKCTRL</name>
+     <description>Register for controlling SPI clock rate.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO</name>
+       <description>Low duty cycle control. In timer mode, reload[7:0].</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>HI</name>
+       <description>High duty cycle control. In timer mode, reload[15:8].</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Dis</name>
+         <description>Duty cycle control of serial clock generation is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV</name>
+       <description>System Clock scale factor. Scales the AMBA clock by 2^SCALE before generating serial clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>AFP_FCD</name>
+       <description>Automatic frequency prescalar.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>Register for controlling DMA.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>Transmit FIFO level that will trigger a DMA request, also level for threshold status. When TX FIFO has fewer than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>TX_FIFO_EN</name>
+       <description>Transmit FIFO enabled for SPI transactions.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Transmit FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Transmit FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Clear TX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Transmit FIFO, clears any pending TX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Count of entries in TX FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_TX_EN</name>
+       <description>TX DMA Enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>TX DMA requests are disabled, andy pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>TX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Receive FIFO level that will trigger a DMA request, also level for threshold status. When RX FIFO has more than this many bytes, the associated events and conditions are triggered.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>RX_FIFO_EN</name>
+       <description>Receive FIFO enabled for SPI transactions.</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIS</name>
+         <description>Receive FIFO is not enabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Receive FIFO is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Clear RX FIFO, clear is accomplished by resetting the read and write pointers. This should be done when FIFO is not being accessed on the SPI side.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>CLEAR</name>
+         <description>Clear the Receive FIFO, clears any pending RX FIFO status.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Count of entries in RX FIFO.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>6</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DMA_RX_EN</name>
+       <description>RX DMA Enable.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>RX DMA requests are disabled, any pending DMA requests are cleared.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>RX DMA requests are enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Register for reading and clearing interrupt flags. All bits are write 1 to clear.</description>
+     <addressOffset>0x20</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done, set when SPI Master has completed any transactions.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun, set when the AMBA side attempts to write data to a full transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun, set when the SPI side attempts to read data from an empty transmit FIFO.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun, set when the SPI side attempts to write to a full receive FIFO.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun, set when the AMBA side attempts to read data from an empty receive FIFO.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTEN</name>
+     <description>Register for enabling interrupts.</description>
+     <addressOffset>0x24</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>TX FIFO Threshold interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>TX FIFO Empty interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>RX FIFO Threshold Crossed interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>RX FIFO FULL interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSA</name>
+       <description>Slave Select Asserted interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>SSD</name>
+       <description>Slave Select Deasserted interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FAULT</name>
+       <description>Multi-Master Mode Fault interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ABORT</name>
+       <description>Slave Abort Detected interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MST_DONE</name>
+       <description>Master Done interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_OV</name>
+       <description>Transmit FIFO Overrun interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_UN</name>
+       <description>Transmit FIFO Underrun interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Receive FIFO Overrun interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_UN</name>
+       <description>Receive FIFO Underrun interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Interrupt is disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Interrupt is enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Register for wake up flags. All bits in this register are write 1 to clear.</description>
+     <addressOffset>0x28</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>clear</name>
+         <description>Flag is set when value read is 1. Write 1 to clear this flag.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Register for wake up enable.</description>
+     <addressOffset>0x2C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TX_THD</name>
+       <description>Wake on TX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Wake on TX FIFO Empty Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake on RX FIFO Threshold Crossed Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake on RX FIFO Full Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Wakeup source disabled.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Wakeup source enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STAT</name>
+     <description>SPI Status register.</description>
+     <addressOffset>0x30</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>BUSY</name>
+       <description>SPI active status. In Master mode, set when transaction starts, cleared when last bit of last character is acted upon and Slave Select de-assertion would occur. In Slave mode, set when Slave Select is asserted, cleared when Slave Select is de-asserted. Not used in Timer mode. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>not</name>
+         <description>SPI not active.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>active</name>
+         <description>SPI active.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SPI0 SPI peripheral.-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI1</name>
+   <description>SPI peripheral. 1</description>
+   <baseAddress>0x40046000</baseAddress>
+   <interrupt>
+    <name>SPI1</name>
+    <description>SPI1 IRQ</description>
+    <value>16</value>
+   </interrupt>
+  </peripheral>
+<!--SPI1 SPI peripheral. 1-->
+  <peripheral>
+   <name>TMR</name>
+   <description>Low-Power Configurable Timer</description>
+   <baseAddress>0x40010000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TMR</name>
+    <value>5</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Timer Counter Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>The current count value for the timer. This field increments as the timer counts.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Timer Compare Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>The value in this register is used as the compare value for the timer's count value. The compare field meaning is determined by the specific mode of the timer.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PWM</name>
+     <description>Timer PWM Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>PWM</name>
+       <description>Timer PWM Match:
+                In PWM Mode, this field sets the count value for the first transition period of the PWM cycle. At the end of the cycle where CNT equals PWM, the PWM output transitions to the second period of the PWM cycle. The second PWM period count is stored in the CMP register. The value set for PWM must me less than the value set in CMP for PWM mode operation. Timer Capture Value:
+                In Capture, Compare, and Capture/Compare modes, this field is used to store the CNT value when a Capture, Compare, or Capture/Compare event occurs.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Timer Interrupt Status Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ_A</name>
+       <description>Interrupt Flag for Timer A.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_A</name>
+       <description>Write Done Flag for Timer A indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_A</name>
+       <description>Write Disable to CNT/PWM for Timer A in the non-cascaded dual timer configuration.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IRQ_B</name>
+       <description>Interrupt Flag for Timer B.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WRDONE_B</name>
+       <description>Write Done Flag for Timer B indicating the write is complete from APB to CLK_TMR domain.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WR_DIS_B</name>
+       <description>Write Disable to CNT/PWM for Timer B in the non-cascaded dual timer configuration.</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL0</name>
+     <description>Timer Control Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>MODE_A</name>
+       <description>Mode Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_A</name>
+       <description>Clock Divider Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_A</name>
+       <description>Timer Polarity for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_A</name>
+       <description>PWM Synchronization Mode for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_A</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer A</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_A</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_A</name>
+       <description>PWM Phase A-Prime Output Disable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_A</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer A. Self-clears.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Write 1 to Enable CLK_TMR for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_A</name>
+       <description>Enable for Timer A</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>MODE_B</name>
+       <description>Mode Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>ONE_SHOT</name>
+         <description>One-Shot Mode</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CONTINUOUS</name>
+         <description>Continuous Mode</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COUNTER</name>
+         <description>Counter Mode</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>PWM</name>
+         <description>PWM Mode</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPTURE</name>
+         <description>Capture Mode</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>COMPARE</name>
+         <description>Compare Mode</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>GATED</name>
+         <description>Gated Mode</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CAPCOMP</name>
+         <description>Capture/Compare Mode</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DUAL_EDGE</name>
+         <description>Dual Edge Capture Mode</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>IGATED</name>
+         <description>Inactive Gated Mode</description>
+         <value>14</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKDIV_B</name>
+       <description>Clock Divider Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV_BY_1</name>
+         <description>Prescaler Divide-By-1</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2</name>
+         <description>Prescaler Divide-By-2</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4</name>
+         <description>Prescaler Divide-By-4</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_8</name>
+         <description>Prescaler Divide-By-8</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_16</name>
+         <description>Prescaler Divide-By-16</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_32</name>
+         <description>Prescaler Divide-By-32</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_64</name>
+         <description>Prescaler Divide-By-64</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_128</name>
+         <description>Prescaler Divide-By-128</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_256</name>
+         <description>Prescaler Divide-By-256</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_512</name>
+         <description>Prescaler Divide-By-512</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_1024</name>
+         <description>Prescaler Divide-By-1024</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_2048</name>
+         <description>Prescaler Divide-By-2048</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV_BY_4096</name>
+         <description>TBD</description>
+         <value>12</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>POL_B</name>
+       <description>Timer Polarity for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMSYNC_B</name>
+       <description>PWM Synchronization Mode for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLHPOL_B</name>
+       <description>PWM Phase A (Non-Overlapping High) Polarity for Timer B</description>
+       <bitOffset>26</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOLLPOL_B</name>
+       <description>PWM Phase A-Prime (Non-Overlapping Low) Polarity for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PWMCKBD_B</name>
+       <description>PWM Phase A-Prime Output Disable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RST_B</name>
+       <description>Resets all flip flops in the CLK_TMR domain for Timer B. Self-clears.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Write 1 to Enable CLK_TMR for Timer B</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EN_B</name>
+       <description>Enable for Timer B</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Timer Non-Overlapping Compare Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>LO_A</name>
+       <description>Non-Overlapping Low Compare value for Timer A controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_A</name>
+       <description>Non-Overlapping High Compare value for Timer A controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>LO_B</name>
+       <description>Non-Overlapping Low Compare value for Timer B controls the time between the falling edge of PWM Phase A and the next rising edge of PWM Phase A-Prime.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>HI_B</name>
+       <description>Non-Overlapping High Compare value for Timer B controls the time between the falling edge of PWM Phase A-Prime and the next rising edge of PWM Phase A.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL1</name>
+     <description>Timer Configuration Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>CLKSEL_A</name>
+       <description>Timer Clock Select for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_A</name>
+       <description>Timer A Enable Status</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_A</name>
+       <description>CLK_TMR Ready Flag for Timer A</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_A</name>
+       <description>Event Select for Timer A</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_A</name>
+       <description>Negative Edge Trigger for Event for Timer A</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_A</name>
+       <description>Interrupt Enable for Timer A</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_A</name>
+       <description>Capture Event Select for Timer A</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_A</name>
+       <description>Software Capture Event for Timer A</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_A</name>
+       <description>Wake-Up Enable for Timer A</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTEN_A</name>
+       <description>OUT_OE_O Enable for Modes 0, 1,and 5 for Timer A</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUTBEN_A</name>
+       <description>PWM_CKB_EN_O Enable for Modes other than Mode 3 for Timer A</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>ASYNC</name>
+       <description>Allows asynchronous reads of the PWM and CNT registers.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKSEL_B</name>
+       <description>Timer Clock Select for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>CLKEN_B</name>
+       <description>Timer B Enable Status</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY_B</name>
+       <description>CLK_TMR Ready Flag for Timer B</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>EVENT_SEL_B</name>
+       <description>Event Select for Timer B</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>NEGTRIG_B</name>
+       <description>Negative Edge Trigger for Event for Timer B</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IE_B</name>
+       <description>Interrupt Enable for Timer B</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CAPEVENT_SEL_B</name>
+       <description>Capture Event Select for Timer B</description>
+       <bitOffset>25</bitOffset>
+       <bitWidth>2</bitWidth>
+      </field>
+      <field>
+       <name>SW_CAPEVENT_B</name>
+       <description>Software Capture Event for Timer B</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WE_B</name>
+       <description>Wake-Up Enable for Timer B</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CASCADE</name>
+       <description>Cascade two 16-bit timers into one 32-bit timer. Only available when C_TMR16=0 adn C_DUALTMR16=1.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Timer Wakeup Status Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>A</name>
+       <description>Wake-Up Flag for Timer A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>B</name>
+       <description>Wake-Up Flag for Timer B</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TMR Low-Power Configurable Timer-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR1</name>
+   <description>Low-Power Configurable Timer 1</description>
+   <baseAddress>0x40011000</baseAddress>
+   <interrupt>
+    <name>TMR1</name>
+    <description>TMR1 IRQ</description>
+    <value>6</value>
+   </interrupt>
+  </peripheral>
+<!--TMR1 Low-Power Configurable Timer 1-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR2</name>
+   <description>Low-Power Configurable Timer 2</description>
+   <baseAddress>0x40012000</baseAddress>
+   <interrupt>
+    <name>TMR2</name>
+    <description>TMR2 IRQ</description>
+    <value>7</value>
+   </interrupt>
+  </peripheral>
+<!--TMR2 Low-Power Configurable Timer 2-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR3</name>
+   <description>Low-Power Configurable Timer 3</description>
+   <baseAddress>0x40013000</baseAddress>
+   <interrupt>
+    <name>TMR3</name>
+    <description>TMR3 IRQ</description>
+    <value>8</value>
+   </interrupt>
+  </peripheral>
+<!--TMR3 Low-Power Configurable Timer 3-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR4</name>
+   <description>Low-Power Configurable Timer 4</description>
+   <baseAddress>0x40080C00</baseAddress>
+   <interrupt>
+    <name>TMR4</name>
+    <description>TMR4 IRQ</description>
+    <value>9</value>
+   </interrupt>
+  </peripheral>
+<!--TMR4 Low-Power Configurable Timer 4-->
+  <peripheral derivedFrom="TMR">
+   <name>TMR5</name>
+   <description>Low-Power Configurable Timer 5</description>
+   <baseAddress>0x40081000</baseAddress>
+   <interrupt>
+    <name>TMR5</name>
+    <description>TMR5 IRQ</description>
+    <value>10</value>
+   </interrupt>
+  </peripheral>
+<!--TMR5 Low-Power Configurable Timer 5-->
+  <peripheral>
+   <name>TRNG</name>
+   <description>Random Number Generator.</description>
+   <baseAddress>0x4004D000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>TRNG</name>
+    <description>TRNG interrupt.</description>
+    <value>4</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>TRNG Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <resetValue>0x00000003</resetValue>
+     <fields>
+      <field>
+       <name>RND_IE</name>
+       <description>To enable IRQ generation when a new 32-bit Random number is ready.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>disable</name>
+         <description>Disable</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>enable</name>
+         <description>Enable</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>KEYGEN</name>
+       <description>AES Key Generate. When enabled, the key for securing NVSRAM is generated and transferred to the secure key register automatically without user visibility or intervention. This bit is cleared by hardware once the key has been transferred to the secure key register.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>KEYWIPE</name>
+       <description>To wipe the Battery Backed key.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>RDY</name>
+       <description>32-bit random data is ready to read from TRNG_DATA register. Reading TRNG_DATA when RND_RDY=0 will return all 0's. IRQ is generated when RND_RDY=1 if TRNG_CN.RND_IRQ_EN=1.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Busy</name>
+         <description>TRNG Busy</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>Ready</name>
+         <description>32 bit random data is ready</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DATA</name>
+     <description>Data. The content of this register is valid only when RNG_IS = 1. When TRNG is disabled, read returns 0x0000 0000.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Data. The content of this register is valid only when RNG_IS =1. When TNRG is disabled, read returns 0x0000 0000.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRNG Random Number Generator.-->
+  <peripheral>
+   <name>TRIMSIR</name>
+   <description>Trim System Initilazation Registers</description>
+   <baseAddress>0x40005400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>RTC</name>
+     <description>RTC Trim System Initialization Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>X1TRIM</name>
+       <description>RTC X1 Trim.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>X2TRIM</name>
+       <description>RTC X2 Trim.</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>LOCK</name>
+       <description>Lock.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SIMO</name>
+     <description>SIMO Trim System Initialization Register.</description>
+     <addressOffset>0x34</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>SIMO Clock Divide.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV16</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV32</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV64</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV128</name>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IPOLO</name>
+     <description>IPO Low Trim System Initialization Register.</description>
+     <addressOffset>0x3C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>IPO_LIMITLO</name>
+       <description>IPO Low Limit Trim.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Control Trim System Initialization Register.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>VDDA_LIMITLO</name>
+       <description>VDDA Low Trim Limit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>VDDA_LIMITHI</name>
+       <description>VDDA High Trim Limit.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>7</bitWidth>
+      </field>
+      <field>
+       <name>IPO_LIMITHI</name>
+       <description>IPO High Trim Limit.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>9</bitWidth>
+      </field>
+      <field>
+       <name>INRO_SEL</name>
+       <description>INRO Clock Select.</description>
+       <bitOffset>24</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>8KHZ</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16KHZ</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30KHZ</name>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INRO_TRIM</name>
+       <description>INRO Clock Trim.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INRO</name>
+     <description>RTC Trim System Initialization Register.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>TRIM16K</name>
+       <description>INRO 16KHz Trim.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>TRIM30K</name>
+       <description>INRO 30KHz Trim.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+      <field>
+       <name>LPCLKSEL</name>
+       <description>INRO Low Power Mode Clock Select.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>8KHZ</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>16KHZ</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>30KHZ</name>
+         <value>2</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--TRIMSIR Trim System Initilazation Registers-->
+  <peripheral>
+   <name>UART</name>
+   <description>UART Low Power Registers</description>
+   <baseAddress>0x40042000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Control register</description>
+     <addressOffset>0x0000</addressOffset>
+     <fields>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>This field specifies the depth of receive FIFO for interrupt generation (value 0 and &gt; 16 are ignored) </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EN</name>
+       <description>Parity Enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_EO</name>
+       <description>when PAREN=1 selects odd or even parity odd is 1 even is 0</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>PAR_MD</name>
+       <description>Selects parity based on 1s or 0s count (when PAREN=1) </description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_DIS</name>
+       <description>CTS Sampling Disable </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FLUSH</name>
+       <description>Flushes the TX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FLUSH</name>
+       <description>Flushes the RX FIFO buffer. This bit is automatically cleared by hardware when flush is completed.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CHAR_SIZE</name>
+       <description>Selects UART character size</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>5bits</name>
+         <description>5 bits</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>6bits</name>
+         <description>6 bits</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>7bits</name>
+         <description>7 bits</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>8bits</name>
+         <description>8 bits</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>STOPBITS</name>
+       <description>Selects the number of stop bits that will be generated</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HFC_EN</name>
+       <description>Enables/disables hardware flow control</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RTSDC</name>
+       <description>Hardware Flow Control RTS Mode</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKEN</name>
+       <description>Baud clock enable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKSRC</name>
+       <description>To select the UART clock source for the UART engine (except APB registers). Secondary clock (used for baud rate generator) can be asynchronous from APB clock.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>2</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>Peripheral_Clock</name>
+         <description>apb clock</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK1</name>
+         <description>Clock 1</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK2</name>
+         <description>Clock 2</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>CLK3</name>
+         <description>Clock 3</description>
+         <value>3</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPFE_EN</name>
+       <description>Data/Parity bit frame error detection enable</description>
+       <bitOffset>18</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>BCLKRDY</name>
+       <description>Baud clock Ready read only bit</description>
+       <bitOffset>19</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UCAGM</name>
+       <description>UART Clock Auto Gating mode</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>FDM</name>
+       <description>Fractional Division Mode</description>
+       <bitOffset>21</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>DESM</name>
+       <description>RX Dual Edge Sampling Mode</description>
+       <bitOffset>22</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STATUS</name>
+     <description>Status register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>TX_BUSY</name>
+       <description>Read-only flag indicating the UART transmit status</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_BUSY</name>
+       <description>Read-only flag indicating the UART receiver status</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_EM</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Read-only flag indicating the RX FIFO state</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_EM</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_FULL</name>
+       <description>Read-only flag indicating the TX FIFO state</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_LVL</name>
+       <description>Indicates the number of bytes currently in the RX FIFO (0-RX FIFO_ELTS) </description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_LVL</name>
+       <description>Indicates the number of bytes currently in the TX FIFO (0-TX FIFO_ELTS) </description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_EN</name>
+     <description>Interrupt Enable control register</description>
+     <addressOffset>0x0008</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Enable Interrupt For RX Frame Error</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Enable Interrupt For RX Parity Error</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Enable Interrupt For CTS signal change Error</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Enable Interrupt For RX FIFO Overrun Error</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Enable Interrupt For RX FIFO reaches the number of bytes configured by RXTHD</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Enable Interrupt For TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Enable Interrupt For TX FIFO has half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INT_FL</name>
+     <description>Interrupt status flags Control register</description>
+     <addressOffset>0x000C</addressOffset>
+     <fields>
+      <field>
+       <name>RX_FERR</name>
+       <description>Flag for RX Frame Error Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Flag for RX Parity Error interrupt</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTS_EV</name>
+       <description>Flag for CTS signal change interrupt (hardware flow control disabled) </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_OV</name>
+       <description>Flag for RX FIFO Overrun interrupt</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Flag for interrupt when RX FIFO reaches the number of bytes configured by the RXTHD field</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_OB</name>
+       <description>Flag for interrupt when TX FIFO has one byte remaining</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TX_HE</name>
+       <description>Flag for interrupt when TX FIFO is half empty</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKDIV</name>
+     <description>Clock Divider register</description>
+     <addressOffset>0x0010</addressOffset>
+     <fields>
+      <field>
+       <name>CLKDIV</name>
+       <description>Baud rate divisor value</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>20</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OSR</name>
+     <description>Over Sampling Rate register</description>
+     <addressOffset>0x0014</addressOffset>
+     <fields>
+      <field>
+       <name>OSR</name>
+       <description>OSR</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXPEEK</name>
+     <description>TX FIFO Output Peek register</description>
+     <addressOffset>0x0018</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Read TX FIFO next data. Reading from this field does not affect the contents of TX FIFO. Note that the parity bit is available from this field.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PNR</name>
+     <description> Pin register</description>
+     <addressOffset>0x001C</addressOffset>
+     <fields>
+      <field>
+       <name>CTS</name>
+       <description>Current sampled value of CTS IO</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RTS</name>
+       <description>This bit controls the value to apply on the RTS IO. If set to 1, the RTS IO is set to high level. If set to 0, the RTS IO is set to low level.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO</name>
+     <description>FIFO Read/Write register</description>
+     <addressOffset>0x0020</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Load/unload location for TX and RX FIFO buffers.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>RX_PAR</name>
+       <description>Parity error flag for next byte to be read from FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>DMA</name>
+     <description>DMA Configuration register</description>
+     <addressOffset>0x0030</addressOffset>
+     <fields>
+      <field>
+       <name>TX_THD_VAL</name>
+       <description>TX FIFO Level DMA Trigger If the TX FIFO level is less than this value, then the TX FIFO DMA interface will send a signal to system DMA to notify that TX FIFO is ready to receive data from memory.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TX_EN</name>
+       <description>TX DMA channel enable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD_VAL</name>
+       <description>Rx FIFO Level DMA Trigger If the RX FIFO level is greater than this value, then the RX FIFO DMA interface will send a signal to the system DMA to notify that RX FIFO has characters to transfer to memory.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>RX_EN</name>
+       <description>RX DMA channel enable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKEN</name>
+     <description>Wake up enable Control register</description>
+     <addressOffset>0x0034</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Enable for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Enable for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Enable for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WKFL</name>
+     <description>Wake up Flags register</description>
+     <addressOffset>0x0038</addressOffset>
+     <fields>
+      <field>
+       <name>RX_NE</name>
+       <description>Wake-Up Flag for RX FIFO Not Empty</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_FULL</name>
+       <description>Wake-Up Flag for RX FIFO Full</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RX_THD</name>
+       <description>Wake-Up Flag for RX FIFO Threshold Met</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--UART UART Low Power Registers-->
+  <peripheral derivedFrom="UART">
+   <name>UART1</name>
+   <description>UART Low Power Registers 1</description>
+   <baseAddress>0x40043000</baseAddress>
+  </peripheral>
+<!--UART1 UART Low Power Registers 1-->
+  <peripheral derivedFrom="UART">
+   <name>UART2</name>
+   <description>UART Low Power Registers 2</description>
+   <baseAddress>0x40044000</baseAddress>
+  </peripheral>
+<!--UART2 UART Low Power Registers 2-->
+  <peripheral derivedFrom="UART">
+   <name>UART3</name>
+   <description>UART Low Power Registers 3</description>
+   <baseAddress>0x40081400</baseAddress>
+  </peripheral>
+<!--UART3 UART Low Power Registers 3-->
+  <peripheral>
+   <name>USBHS</name>
+   <description>USB 2.0 High-speed Controller.</description>
+   <baseAddress>0x400B1000</baseAddress>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>USB</name>
+    <value>2</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>FADDR</name>
+     <description>Function address register.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>8</size>
+     <resetMask>0x00</resetMask>
+     <fields>
+      <field>
+       <name>ADDR</name>
+       <description>Function address for this controller.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>UPDATE</name>
+       <description>Set when ADDR is written, cleared when new address takes effect.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>POWER</name>
+     <description>Power management register.</description>
+     <addressOffset>0x01</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>EN_SUSPENDM</name>
+       <description>Enable SUSPENDM signal.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SUSPEND</name>
+       <description>Suspend mode detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESUME</name>
+       <description>Generate resume signaling.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESET</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS_MODE</name>
+       <description>High-speed mode detected.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>HS_ENABLE</name>
+       <description>High-speed mode enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SOFTCONN</name>
+       <description>Softconn.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ISO_UPDATE</name>
+       <description>Wait for SOF during Isochronous xfers.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRIN</name>
+     <description>Interrupt register for EP0 and IN EP1-15.</description>
+     <addressOffset>0x02</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_IN_INT</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP14_IN_INT</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP13_IN_INT</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP12_IN_INT</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP11_IN_INT</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP10_IN_INT</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP9_IN_INT</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP8_IN_INT</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP7_IN_INT</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP6_IN_INT</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP5_IN_INT</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP4_IN_INT</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP3_IN_INT</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP2_IN_INT</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP1_IN_INT</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP0_IN_INT</name>
+       <description>Endpoint 0 interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTROUT</name>
+     <description>Interrupt register for OUT EP 1-15.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_OUT_INT</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP14_OUT_INT</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP13_OUT_INT</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP12_OUT_INT</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP11_OUT_INT</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP10_OUT_INT</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP9_OUT_INT</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP8_OUT_INT</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP7_OUT_INT</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP6_OUT_INT</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP5_OUT_INT</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP4_OUT_INT</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP3_OUT_INT</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP2_OUT_INT</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>EP1_OUT_INT</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRINEN</name>
+     <description>Interrupt enable for EP 0 and IN EP 1-15.</description>
+     <addressOffset>0x06</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_IN_INT_EN</name>
+       <description>Endpoint 15 interrupt enable.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP14_IN_INT_EN</name>
+       <description>Endpoint 14 interrupt enable.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP13_IN_INT_EN</name>
+       <description>Endpoint 13 interrupt enable.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP12_IN_INT_EN</name>
+       <description>Endpoint 12 interrupt enable.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP11_IN_INT_EN</name>
+       <description>Endpoint 11 interrupt enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP10_IN_INT_EN</name>
+       <description>Endpoint 10 interrupt enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP9_IN_INT_EN</name>
+       <description>Endpoint 9 interrupt enable.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP8_IN_INT_EN</name>
+       <description>Endpoint 8 interrupt enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP7_IN_INT_EN</name>
+       <description>Endpoint 7 interrupt enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP6_IN_INT_EN</name>
+       <description>Endpoint 6 interrupt enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP5_IN_INT_EN</name>
+       <description>Endpoint 5 interrupt enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP4_IN_INT_EN</name>
+       <description>Endpoint 4 interrupt enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP3_IN_INT_EN</name>
+       <description>Endpoint 3 interrupt enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP2_IN_INT_EN</name>
+       <description>Endpoint 2 interrupt enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP1_IN_INT_EN</name>
+       <description>Endpoint 1 interrupt enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP0_INT_EN</name>
+       <description>Endpoint 0 interrupt enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTROUTEN</name>
+     <description>Interrupt enable for OUT EP 1-15.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>EP15_OUT_INT_EN</name>
+       <description>Endpoint 15 interrupt.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP14_OUT_INT_EN</name>
+       <description>Endpoint 14 interrupt.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP13_OUT_INT_EN</name>
+       <description>Endpoint 13 interrupt.</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP12_OUT_INT_EN</name>
+       <description>Endpoint 12 interrupt.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP11_OUT_INT_EN</name>
+       <description>Endpoint 11 interrupt.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP10_OUT_INT_EN</name>
+       <description>Endpoint 10 interrupt.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP9_OUT_INT_EN</name>
+       <description>Endpoint 9 interrupt.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP8_OUT_INT_EN</name>
+       <description>Endpoint 8 interrupt.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP7_OUT_INT_EN</name>
+       <description>Endpoint 7 interrupt.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP6_OUT_INT_EN</name>
+       <description>Endpoint 6 interrupt.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP5_OUT_INT_EN</name>
+       <description>Endpoint 5 interrupt.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP4_OUT_INT_EN</name>
+       <description>Endpoint 4 interrupt.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP3_OUT_INT_EN</name>
+       <description>Endpoint 3 interrupt.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP2_OUT_INT_EN</name>
+       <description>Endpoint 2 interrupt.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>EP1_OUT_INT_EN</name>
+       <description>Endpoint 1 interrupt.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRUSB</name>
+     <description>Interrupt register for common USB interrupts.</description>
+     <addressOffset>0x0A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SOF_INT</name>
+       <description>Start of Frame.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESET_INT</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>RESUME_INT</name>
+       <description>Resume detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>SUSPEND_INT</name>
+       <description>Suspend detected.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTRUSBEN</name>
+     <description>Interrupt enable for common USB interrupts.</description>
+     <addressOffset>0x0B</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SOF_INT_EN</name>
+       <description>Start of Frame.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESET_INT_EN</name>
+       <description>Bus reset detected.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RESUME_INT_EN</name>
+       <description>Resume detected.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SUSPEND_INT_EN</name>
+       <description>Suspend detected.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FRAME</name>
+     <description>Frame number.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>FRAMENUM</name>
+       <description>Read the last received frame number, that is the 11-bit frame number received in the SOF packet.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INDEX</name>
+     <description>Index for banked registers.</description>
+     <addressOffset>0x0E</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>INDEX</name>
+       <description>Index Register Access Selector. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TESTMODE</name>
+     <description>USB 2.0 test mode enable register.</description>
+     <addressOffset>0x0F</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>FORCE_FS</name>
+       <description>Force USB to Full-speed after reset.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FORCE_HS</name>
+       <description>Force USB to High-speed after reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_PKT</name>
+       <description>Transmit fixed test packet.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_K</name>
+       <description>Force USB to continuous K state.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_J</name>
+       <description>Force USB to continuous J state.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>TEST_SE0_NAK</name>
+       <description>Respond to any valid IN token with NAK.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INMAXP</name>
+     <description>Maximum packet size for INx endpoint (x == INDEX).</description>
+     <addressOffset>0x10</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>MAXPACKETSIZE</name>
+       <description>Maximum Packet Size in a Single Transaction. That is the maximum packet size in bytes, that is transmitted for each microframe. The maximum value is 1024, subject to the limitations of the endpoint type set in USB 2.0 Specification, Chapter 9</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+      <field>
+       <name>NUMPACKMINUS1</name>
+       <description>Number of Split Packets - 1. Defines the maximum number of packets minus 1 that a USB payload can be split into. THis must be an exact multiple of maxpacketsize. Only applicable for HS High-Bandwidth isochronous endpoints and Bulk endpoints. Ignored in all other cases. </description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CSR0</name>
+     <description>Control status register for EP 0 (when INDEX == 0).</description>
+     <addressOffset>0x12</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>SERV_SETUP_END</name>
+       <description>Clear EP0 Setup End Bit. Write a 1 to clear the setupend bit. Automatically cleared after being set </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SERV_OUTPKTRDY</name>
+       <description>Clear EP0 Out Packet Ready Bit. Write a 1 to clear the outpktrdy bit. Automatically cleared after being set.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SEND_STALL</name>
+       <description>Send EP0 STALL Handshake. Write a 1 to this bit to terminate the current control transaction by sneding a STALL handshake. Automatically cleared after being set. </description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SETUP_END</name>
+       <description>Read Setup End Status. Automatically set when a contorl transaction ends before the dataend bit has been set by fimrware. An interrupt is generated when this bit is set. Write 1 to servicedsetupend to clear.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>DATA_END</name>
+       <description>Control Transaction Data End. Write a 1 to this bit after firmware completes any of the following three transactions: 1. set inpktrdy = 1 for the last data packet. 2. Set inpktrdy =1 for a zero-length data packet. 3. Clear outpktrdy = 0 after unloading the last data packet. </description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENT_STALL</name>
+       <description> Read EP0 STALL Handshake Sent Status Automatically set when a STALL handshake is transmitted. Write a 0 to clear. </description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPKTRDY</name>
+       <description>EP0 IN Packet Ready 1: Write a 1 after writing a data packet to the IN FIFO. Automatically cleared when the data packet is transmitted. An interrupt is generated when this bit is cleared. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>OUTPKTRDY</name>
+       <description>EP0 OUT Packet Ready Status Automatically set when a data packet is received in the OUT FIFO. An interrupt is generated when this bit is set. Write a 1 to the servicedoutpktrdy bit (above) to clear after the packet is unloaded from the OUT FIFO. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INCSRL</name>
+     <description>Control status lower register for INx endpoint (x == INDEX).</description>
+     <alternateRegister>CSR0</alternateRegister>
+     <addressOffset>0x12</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>INCOMPTX</name>
+       <description>Read Incomplete Split Transfer Error Status High-bandwidth isochronous transfers: Automatically set when a payload is split into multiple packets but insufficient IN tokens were received to send all packets. The current packets is flushed from the IN FIFO. Write 0 to clear.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>CLRDATATOG</name>
+       <description>Write 1 to clear IN endpoint data-toggle to 0.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENTSTALL</name>
+       <description>Read STALL Handshake Sent Status Automatically set when a STALL handshake is transmitted, at which time the IN FIFO is flushed, and inpktrdy is cleared. Write 0 to clear.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENDSTALL</name>
+       <description>Send STALL Handshake.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>terminate</name>
+         <description>Terminate STALL handhsake</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>respond</name>
+         <description>Respond to an IN token with a STALL handshake</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FLUSHFIFO</name>
+       <description>Flush Next Packet from IN FIFO. Write 1 to clear</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>UNDERRUN</name>
+       <description>Read IN FIFO Underrun Error Status Isochronous Mode: Automatically set if the IN FIFO is empty. Write 0 to clear</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFONOTEMPTY</name>
+       <description>Read FIFO Not Empty Status. Automatically set when there is at least one packet in the IN FIFO. Write a 0 to clear. </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INPKTRDY</name>
+       <description>IN Packet Ready. Write a 1 to clear </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INCSRU</name>
+     <description>Control status upper register for INx endpoint (x == INDEX).</description>
+     <addressOffset>0x13</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>AUTOSET</name>
+       <description>Auto Set inpktrdy. </description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>set</name>
+         <description>USBHS_INCSRL_inpktrdy must be set by firmware.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>auto</name>
+         <description>USBHS_INCSRL_inpktrdy is automatically set. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>ISO</name>
+       <description>Isochronous Transfer Enable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>interrupt</name>
+         <description>Enable IN Bulk and IN interrupt transfers.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>isochronous</name>
+         <description>Enable IN Isochronous transfers. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>MODE</name>
+       <description> Endpoint Direction Mode.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>out</name>
+         <description>Endpoint direction is OUT.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>in</name>
+         <description>Endpoint direction is IN. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>FRCDATATOG</name>
+       <description> Force In Data - Toggle</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>received</name>
+         <description>Toggle data-toglge only when an ACK is received.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dontcare</name>
+         <description>Toggle data-toggle regardless of ACK. </description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>DPKTBUFDIS</name>
+       <description> Double Packet Buffering Disable </description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable Double packet buffering.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable Double Packet Buffering.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTMAXP</name>
+     <description>Maximum packet size for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x14</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>NUMPACKMINUS1</name>
+       <description>Number of Split Packets -1. Defines the maximum number of packets - 1 that a usb payload is combined into. The value must be exact multiple of maxpacketsize. </description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>5</bitWidth>
+      </field>
+      <field>
+       <name>MAXPACKETSIZE</name>
+       <description>Maximum Packet in a Single Transaction. This is the maximum packet size, in bytes, that is transmitted for each microframe. The maximum value is 1024, subject to the limitations for the endpoint type set in USB2.0 spesification, chapter 9.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>11</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCSRL</name>
+     <description>Control status lower register for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x16</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>CLRDATATOG</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENTSTALL</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>SENDSTALL</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FLUSHFIFO</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DATAERROR</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>OVERRUN</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>FIFOFULL</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>OUTPKTRDY</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCSRU</name>
+     <description>Control status upper register for OUTx endpoint (x == INDEX).</description>
+     <addressOffset>0x17</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>AUTOCLEAR</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>ISO</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DISNYET</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>DPKTBUFDIS</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>INCOMPRX</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>COUNT0</name>
+     <description>Number of received bytes in EP 0 FIFO (INDEX == 0).</description>
+     <addressOffset>0x18</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>COUNT0</name>
+       <description>Read Number of Data Bytes in the Endpoint 0 FIFO. Returns the number of data bytes in the endpoint 0 FIFO. This value changes as contents of the FIFO change. The value is only valued when USBHS_OUTSCRL_outpktrdy = 1 </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>7</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>OUTCOUNT</name>
+     <description>Number of received bytes in OUT EPx FIFO (x == INDEX).</description>
+     <alternateRegister>COUNT0</alternateRegister>
+     <addressOffset>0x18</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>OUTCOUNT</name>
+       <description>Read Number of Data Bytes in OUT FIFO. Returns the number of data bytes in the packet that are read next in the OUT FIFO. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>13</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO0</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO0</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO1</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO1</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO2</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO2</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO3</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x2c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO3</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO4</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x30</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO4</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO5</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x34</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO5</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO6</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x38</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO6</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO7</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x3c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO7</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO8</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x40</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO8</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO9</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x44</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO9</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO10</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x48</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO10</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO11</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x4c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO11</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO12</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x50</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO12</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO13</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x54</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO13</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO14</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x58</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO14</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>FIFO15</name>
+     <description>Read for OUT data FIFO, write for IN data FIFO.</description>
+     <addressOffset>0x5c</addressOffset>
+     <fields>
+      <field>
+       <name>USBHS_FIFO15</name>
+       <description>USBHS Endpoint FIFO Read/Write Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>HWVERS</name>
+     <description>HWVERS</description>
+     <addressOffset>0x6c</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>USBHS_HWVERS</name>
+       <description>USBHS Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>EPINFO</name>
+     <description>Endpoint hardware information.</description>
+     <addressOffset>0x78</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>OUTENDPOINTS</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+      <field>
+       <name>INTENDPOINTS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RAMINFO</name>
+     <description>RAM width information.</description>
+     <addressOffset>0x79</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RAMBITS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <access>read-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SOFTRESET</name>
+     <description>Software reset register.</description>
+     <addressOffset>0x7A</addressOffset>
+     <size>8</size>
+     <fields>
+      <field>
+       <name>RSTXS</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>RSTS</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTUCH</name>
+     <description>Chirp timeout timer setting.</description>
+     <addressOffset>0x80</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>C_T_UCH</name>
+       <description>HS Chirp Timeout Clock Cycles. This configures the chirp timeout used by this device to negotiate a HS connection with a FS Host. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTHSRTN</name>
+     <description>Sets delay between HS resume to UTM normal operating mode.</description>
+     <addressOffset>0x82</addressOffset>
+     <size>16</size>
+     <fields>
+      <field>
+       <name>C_T_HSTRN</name>
+       <description>High Speed Resume Delay Clock Cycles. This configures the delay from when the RESUME state on the bus ends, the when the USBHS resumes normal operation.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_USB_REG_00</name>
+     <description>MXM_USB_REG_00</description>
+     <addressOffset>0x400</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_UTMI_RESET</name>
+     <description>M31_PHY_UTMI_RESET</description>
+     <addressOffset>0x404</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_UTMI_VCONTROL</name>
+     <description>M31_PHY_UTMI_VCONTROL</description>
+     <addressOffset>0x408</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CLK_EN</name>
+     <description>M31_PHY_CLK_EN</description>
+     <addressOffset>0x40C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_PONRST</name>
+     <description>M31_PHY_PONRST</description>
+     <addressOffset>0x410</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_NONCRY_RSTB</name>
+     <description>M31_PHY_NONCRY_RSTB</description>
+     <addressOffset>0x414</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_NONCRY_EN</name>
+     <description>M31_PHY_NONCRY_EN</description>
+     <addressOffset>0x418</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_EN</name>
+     <description>M31_PHY_U2_COMPLIANCE_EN</description>
+     <addressOffset>0x420</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_DAC_ADJ</name>
+     <description>M31_PHY_U2_COMPLIANCE_DAC_ADJ</description>
+     <addressOffset>0x424</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_U2_COMPLIANCE_DAC_ADJ_EN</name>
+     <description>M31_PHY_U2_COMPLIANCE_DAC_ADJ_EN</description>
+     <addressOffset>0x428</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CLK_RDY</name>
+     <description>M31_PHY_CLK_RDY</description>
+     <addressOffset>0x42C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_PLL_EN</name>
+     <description>M31_PHY_PLL_EN</description>
+     <addressOffset>0x430</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_BIST_OK</name>
+     <description>M31_PHY_BIST_OK</description>
+     <addressOffset>0x434</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DATA_OE</name>
+     <description>M31_PHY_DATA_OE</description>
+     <addressOffset>0x438</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_OSCOUTEN</name>
+     <description>M31_PHY_OSCOUTEN</description>
+     <addressOffset>0x43C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_LPM_ALIVE</name>
+     <description>M31_PHY_LPM_ALIVE</description>
+     <addressOffset>0x440</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_HS_BIST_MODE</name>
+     <description>M31_PHY_HS_BIST_MODE</description>
+     <addressOffset>0x444</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_CORECLKIN</name>
+     <description>M31_PHY_CORECLKIN</description>
+     <addressOffset>0x448</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XTLSEL</name>
+     <description>M31_PHY_XTLSEL</description>
+     <addressOffset>0x44C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_LS_EN</name>
+     <description>M31_PHY_LS_EN</description>
+     <addressOffset>0x450</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DEBUG_SEL</name>
+     <description>M31_PHY_DEBUG_SEL</description>
+     <addressOffset>0x454</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_DEBUG_OUT</name>
+     <description>M31_PHY_DEBUG_OUT</description>
+     <addressOffset>0x458</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_OUTCLKSEL</name>
+     <description>M31_PHY_OUTCLKSEL</description>
+     <addressOffset>0x45C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_31_0</name>
+     <description>M31_PHY_XCFGI_31_0</description>
+     <addressOffset>0x460</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_63_32</name>
+     <description>M31_PHY_XCFGI_63_32</description>
+     <addressOffset>0x464</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_95_64</name>
+     <description>M31_PHY_XCFGI_95_64</description>
+     <addressOffset>0x468</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_127_96</name>
+     <description>M31_PHY_XCFGI_127_96</description>
+     <addressOffset>0x46C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_137_128</name>
+     <description>M31_PHY_XCFGI_137_128</description>
+     <addressOffset>0x470</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_HS_COARSE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_HS_COARSE_TUNE_NUM</description>
+     <addressOffset>0x474</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_HS_FINE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_HS_FINE_TUNE_NUM</description>
+     <addressOffset>0x478</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_FS_COARSE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_FS_COARSE_TUNE_NUM</description>
+     <addressOffset>0x47C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_FS_FINE_TUNE_NUM</name>
+     <description>M31_PHY_XCFG_FS_FINE_TUNE_NUM</description>
+     <addressOffset>0x480</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_LOCK_RANGE_MAX</name>
+     <description>M31_PHY_XCFG_LOCK_RANGE_MAX</description>
+     <addressOffset>0x484</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGI_LOCK_RANGE_MIN</name>
+     <description>M31_PHY_XCFGI_LOCK_RANGE_MIN</description>
+     <addressOffset>0x488</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_OB_RSEL</name>
+     <description>M31_PHY_XCFG_OB_RSEL</description>
+     <addressOffset>0x48C</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFG_OC_RSEL</name>
+     <description>M31_PHY_XCFG_OC_RSEL</description>
+     <addressOffset>0x490</addressOffset>
+    </register>
+    <register>
+     <name>M31_PHY_XCFGO</name>
+     <description>M31_PHY_XCFGO</description>
+     <addressOffset>0x494</addressOffset>
+    </register>
+    <register>
+     <name>MXM_INT</name>
+     <description>USB Added Maxim Interrupt Flag Register.</description>
+     <addressOffset>0x498</addressOffset>
+     <fields>
+      <field>
+       <name>VBUS</name>
+       <description>VBUS</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOVBUS</name>
+       <description>NOVBUS</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_INT_EN</name>
+     <description>USB Added Maxim Interrupt Enable Register.</description>
+     <addressOffset>0x49C</addressOffset>
+     <fields>
+      <field>
+       <name>VBUS</name>
+       <description>VBUS</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>NOVBUS</name>
+       <description>NOVBUS</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_SUSPEND</name>
+     <description>USB Added Maxim Suspend Register.</description>
+     <addressOffset>0x4A0</addressOffset>
+     <fields>
+      <field>
+       <name>SEL</name>
+       <description>Suspend register</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>MXM_REG_A4</name>
+     <description>USB Added Maxim Power Status Register</description>
+     <addressOffset>0x4A4</addressOffset>
+     <fields>
+      <field>
+       <name>VRST_VDDB_N_A</name>
+       <description>VRST_VDDB_N_A</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--USBHS USB 2.0 High-speed Controller.-->
+  <peripheral>
+   <name>WDT</name>
+   <description>Windowed Watchdog Timer</description>
+   <baseAddress>0x40003000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WWDT</name>
+    <value>1</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CTRL</name>
+     <description>Watchdog Timer Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INT_LATE_VAL</name>
+       <description>Windowed Watchdog Interrupt Upper Limit. Sets the number of WDTCLK cycles until a windowed watchdog timer interrupt is generated (if enabled) if the CPU does not write the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE_VAL</name>
+       <description>Windowed Watchdog Reset Upper Limit. Sets the number of WDTCLK cycles until a system reset occurs (if enabled) if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>EN</name>
+       <description>Windowed Watchdog Timer Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_LATE</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Late.</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_INT_EN</name>
+       <description>Windowed Watchdog Timer Interrupt Enable.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>WDT_RST_EN</name>
+       <description>Windowed Watchdog Timer Reset Enable.</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Disable.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Enable.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Soon.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY_VAL</name>
+       <description>Windowed Watchdog Interrupt Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A windowed watchdog timer interrupt is generated (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY_VAL</name>
+       <description>Windowed Watchdog Reset Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A system reset occurs (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKRDY_IE</name>
+       <description>Switch Ready Interrupt Enable. Fires an interrupt when it is safe to swithc the clock.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY</name>
+       <description>Clock Status.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WIN_EN</name>
+       <description>Enables the Windowed Watchdog Function.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Windowed Mode Disabled (i.e. Compatibility Mode).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Windowed Mode Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Soon.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Late.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RST</name>
+     <description>Windowed Watchdog Timer Reset Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>RESET</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD_UPPER_LIMIT then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD_UPPER_LIMIT then a watchdog reset will occur, if enabled.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>seq0</name>
+         <description>The first value to be written to reset the WDT.</description>
+         <value>0x000000A5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>seq1</name>
+         <description>The second value to be written to reset the WDT.</description>
+         <value>0x0000005A</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CLKSEL</name>
+     <description>Windowed Watchdog Timer Clock Select Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SOURCE</name>
+       <description>WWDT Clock Selection Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CNT</name>
+     <description>Windowed Watchdog Timer Count Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Current Value of the Windowed Watchdog Timer Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WDT Windowed Watchdog Timer-->
+  <peripheral derivedFrom="WDT">
+   <name>WDT1</name>
+   <description>Windowed Watchdog Timer 1</description>
+   <baseAddress>0x40080800</baseAddress>
+   <interrupt>
+    <name>WDT1</name>
+    <description>WDT1 IRQ</description>
+    <value>57</value>
+   </interrupt>
+  </peripheral>
+<!--WDT1 Windowed Watchdog Timer 1-->
+  <peripheral>
+   <name>WUT</name>
+   <description>Wake Up Timer</description>
+   <baseAddress>0x40006400</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x0400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>WUT</name>
+    <value>53</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CNT</name>
+     <description>Wakeup Timer Count Register</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Timer Count Value. </description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CMP</name>
+     <description>Wakeup Timer Compare Register</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>COMPARE</name>
+       <description>Timer Compare Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INTFL</name>
+     <description>Wakeup Timer Interrupt Register</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>IRQ_CLR</name>
+       <description>Timer Interrupt.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Wakeup Timer Control Register</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>TMODE</name>
+       <description>Timer Mode Select.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>oneShot</name>
+         <description>One Shot Mode.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>continuous</name>
+         <description>Continuous Mode.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>counter</name>
+         <description>Counter Mode.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pwm</name>
+         <description>PWM Mode.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>capture</name>
+         <description>Capture Mode.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>compare</name>
+         <description>Compare Mode.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>gated</name>
+         <description>Gated Mode.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>captureCompare</name>
+         <description>Capture/Compare Mode.</description>
+         <value>7</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES</name>
+       <description>Timer Prescaler Select.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>3</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>DIV1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV2</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV8</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV16</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV32</name>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV64</name>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV128</name>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV256</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV512</name>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV1024</name>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV2048</name>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>DIV4096</name>
+         <value>5</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>TPOL</name>
+       <description>Timer pOLARITY.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TEN</name>
+       <description>Timer Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>timer_dis</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>timer_en</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>PRES3</name>
+       <description>Timer Prescaler Select.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>pres3_1</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_2</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_4</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_8</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_16</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_32</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_64</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_128</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_256</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_512</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_1024</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_2048</name>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pres3_4096</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>NOLCMP</name>
+     <description>Non Overlaping Compare Register</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>NOLLCMP</name>
+       <description>Non Overlaping Low Compare.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>NOLHCMP</name>
+       <description>Non Overlaping High Compare.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PRESET</name>
+     <description>Preset register.</description>
+     <addressOffset>0x0018</addressOffset>
+     <fields>
+      <field>
+       <name>PRESET</name>
+       <description>Preset Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RELOAD</name>
+     <description>Reload register.</description>
+     <addressOffset>0x001C</addressOffset>
+     <fields>
+      <field>
+       <name>RELOAD</name>
+       <description>Reload Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SNAPSHOT</name>
+     <description>Snapshot register.</description>
+     <addressOffset>0x0020</addressOffset>
+     <fields>
+      <field>
+       <name>SNAPSHOT</name>
+       <description>Snapshot Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--WUT Wake Up Timer-->
+ </peripherals>
+</device>


### PR DESCRIPTION
The CMSIS SoC .svd files are needed, so manually update the current export to catch it up with MSDK version of those files.

Script update that will do this automatically from now on lives at https://github.com/analogdevicesinc/msdk/pull/1447