### PR TITLE
fix(MAX32660): Fixing error with SPI source file name

### DIFF
--- a/MAX/Source/MAX32660/CMakeLists.txt
+++ b/MAX/Source/MAX32660/CMakeLists.txt
@@ -80,7 +80,7 @@ zephyr_library_sources(
     ${MSDK_PERIPH_SRC_DIR}/SPI/spi_me11.c
     ${MSDK_PERIPH_SRC_DIR}/SPI/spi_reva1.c
     ${MSDK_PERIPH_SRC_DIR}/SPIMSS/spimss_me11.c
-    ${MSDK_PERIPH_SRC_DIR}/SPIMSS/spimss_reva1.c
+    ${MSDK_PERIPH_SRC_DIR}/SPIMSS/spimss_reva.c
 )
 endif()
 


### PR DESCRIPTION
When trying to build an application for the MAX32660 that uses the SPI peripheral, the build fails because it tries to add a nonexistent `spimss_reva1.c` as a source file. Changing the file to the existing `spimss_reva.c` fixes the issue